### PR TITLE
fvtr: check golang directory exists.

### DIFF
--- a/fvtr/golang/golang.exp
+++ b/fvtr/golang/golang.exp
@@ -41,6 +41,10 @@ if { $env(AT_BUILD_ARCH) != "ppc64le" } {
 	printit "Golang is only supported on ppc64le.\t\[SUCCESS\]"
 	exit $ENOSYS
 }
+if { ![file isdirectory $go_root] } {
+	printit "Error: go directory $go_root is missing."
+	exit 1
+}
 
 set go $go_root/bin/go
 


### PR DESCRIPTION
Golang tests fail miserably if its root directory
does not exist.

Added a check for the directory existence, otherwise
return with error nicely.

Signed-off-by: Wainer dos Santos Moschetta <wainersm@linux.vnet.ibm.com>