### PR TITLE
Use systemd to run watch_ldconfig on RPM based distros

### DIFF
--- a/scripts/utilities/cachemanager.service
+++ b/scripts/utilities/cachemanager.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Advance Toolchain __AT_VER_REV_INTERNAL__ ld.so.cache manager
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+ProtectSystem=full
+PrivateDevices=true
+
+ExecStart=__AT_DEST__/bin/watch_ldconfig
+KillSignal=SIGKILL

--- a/scripts/utilities/pkg_build_rpm.sh
+++ b/scripts/utilities/pkg_build_rpm.sh
@@ -89,6 +89,8 @@ function pkg_build_rpms()
 		rev_number=${at_revision_number}
 	fi
 
+	cp "${utilities}/cachemanager.service" "${rpmdir}"
+
 	# Copy find-debuginfo.sh from the system and patch it to support
 	# debuginfo under /opt.
 	#


### PR DESCRIPTION
To be able to start watch_ldconfig after the runtime package is installed, this patch sets a systemd service for RPM based distros.