### PR TITLE
Update binutils 2.28 for AT 11.0.

### DIFF
--- a/configs/11.0/packages/binutils/sources
+++ b/configs/11.0/packages/binutils/sources
@@ -21,7 +21,7 @@
 
 ATSRC_PACKAGE_NAME="GNU Binutils"
 ATSRC_PACKAGE_VER=2.28
-ATSRC_PACKAGE_REV=7fa393306ed8
+ATSRC_PACKAGE_REV=f85ae672d555
 ATSRC_PACKAGE_LICENSE="GPL 2.0"
 ATSRC_PACKAGE_DOCLINK="http://sourceware.org/binutils/docs/"
 ATSRC_PACKAGE_RELFIXES=
@@ -42,3 +42,20 @@ ATSRC_PACKAGE_PATCHES=
 ATSRC_PACKAGE_TARS=
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=main_toolchain
+
+atsrc_get_patches ()
+{
+	at_get_patch_and_trim \
+		https://sourceware.org/ml/binutils/2017-02/msg00269.html \
+		fix-incorrect-indirection.patch 14 \
+		80e3c4062604f28f186289db0167b592 || return ${?}
+}
+
+atsrc_apply_patches ()
+{
+	#Fix error: comparison between pointer and zero character constant
+	#[-Werror=pointer-compare] in stabs.c
+	patch -p1 < fix-incorrect-indirection.patch
+
+	return 0
+}

--- a/configs/11.0/packages/binutils/sources
+++ b/configs/11.0/packages/binutils/sources
@@ -55,7 +55,5 @@ atsrc_apply_patches ()
 {
 	#Fix error: comparison between pointer and zero character constant
 	#[-Werror=pointer-compare] in stabs.c
-	patch -p1 < fix-incorrect-indirection.patch
-
-	return 0
+	patch -p1 < fix-incorrect-indirection.patch || return ${?}
 }


### PR DESCRIPTION
Updates binutils 2.28 to rev f85ae672d555. This fix a binutils
build error due to dynamic relocs (issue #19). Also includes
a patch to fix a incorrect pointer dereference at stabs.c.

Signed-off-by: Rogerio Alves Cardoso <rogealve@br.ibm.com>