### PR TITLE
Stop using systemd scriptlets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1106,18 +1106,19 @@ $(RCPTS)/package.rcpt: $(RCPTS)/$(pack-sys).rcpt $(RCPTS)/source_tarball.rcpt
 	@touch $@
 
 # Build and include the monitor (watch_ldconfig) utility
+# RPM distros use a systemd service and DEB distros use a cronjob.
 $(RCPTS)/monitor.rcpt: $(RCPTS)/toolchain.rcpt
-	# RPM distros use a systemd service and DEB distros use a cronjob.
 	@echo "Preparing the system's ld.so.cache monitor"
 	@+{ $(AT_DEST)/bin/gcc -O2 -DAT_LDCONFIG_PATH=$(AT_DEST)/sbin/ldconfig \
 	         $(SCRIPTS_ROOT)/utilities/watch_ldconfig.c -o $(AT_DEST)/bin/watch_ldconfig; \
 	    echo "Monitor sucesfully compiled."; \
 	    echo "Updating the SPEC files"; \
 	    at_ver_rev_internal=$$( echo $(AT_VER_REV_INTERNAL) ); \
+	    at_major_version=$$( echo $(AT_MAJOR_VERSION) ); \
 	    group=$$( ls $(DYNAMIC_SPEC)/ | grep "toolchain\$$" ); \
 	    echo "$(AT_DEST)/bin/watch_ldconfig" \
 	          >> $(DYNAMIC_SPEC)/$${group}/ldconfig.filelist; \
-	    if [[ "$(pack-sys)" == "deb" ]]; then \
+	    if [[ "$(pack-sys)" == "deb" || $${at_major_version%.*} -lt  9 ]]; then \
 	        echo "/etc/cron.d/$${at_ver_rev_internal//./}_ldconfig" \
 	             >> $(DYNAMIC_SPEC)/$${group}/ldconfig.filelist; \
 	    else \

--- a/configs/9.0/specs/monolithic.spec
+++ b/configs/9.0/specs/monolithic.spec
@@ -230,7 +230,8 @@ ln -s /etc/localtime %{_prefix}/etc/localtime
 if [[ -f %{_sbindir}/ldconfig ]]; then
     %{_sbindir}/ldconfig
 fi
-%systemd_post %{at_ver_rev_internal}-cachemanager.service
+systemctl --no-reload preset %{at_ver_rev_internal}-cachemanager.service \
+    > /dev/null 2>&1 || :
 systemctl restart %{at_ver_rev_internal}-cachemanager.service
 
 #---------------------------------------------------
@@ -334,7 +335,8 @@ fi
 
 ####################################################
 %preun runtime
-%systemd_preun %{at_ver_rev_internal}-cachemanager.service
+systemctl --no-reload disable --now \
+    %{at_ver_rev_internal}-cachemanager.service > /dev/null 2>&1 || :
 
 ####################################################
 %postun runtime
@@ -352,7 +354,8 @@ if file /usr/sbin/ldconfig | grep "bash script" > /dev/null; then
         rm -f /usr/sbin/ldconfig
     fi
 fi
-%systemd_postun_with_restart %{at_ver_rev_internal}-cachemanager.service
+systemctl try-restart %{at_ver_rev_internal}-cachemanager.service >/dev/null \
+    2>&1 || :
 
 #---------------------------------------------------
 %postun devel


### PR DESCRIPTION
In order to be able to uninstall and install the rpm packages without errors on SLES 12 we need to stop using the systemd scriptlets.
