### PR TITLE
Update boost version on AT 11.0

### DIFF
--- a/configs/11.0/packages/boost/sources
+++ b/configs/11.0/packages/boost/sources
@@ -1,1 +1,39 @@
-../../../10.0/packages/boost/sources
+#!/usr/bin/env bash
+#
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Boost source package and build info
+# ==================================
+#
+ATSRC_PACKAGE_NAME="Boost"
+ATSRC_PACKAGE_VER=1.64.0
+ATSRC_PACKAGE_VERID="${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
+ATSRC_PACKAGE_DOCLINK="http://www.boost.org/doc/libs/${ATSRC_PACKAGE_VER//./_}/"
+ATSRC_PACKAGE_RELFIXES=
+ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}"
+ATSRC_PACKAGE_LICENSE="Boost Software License 1.0"
+ATSRC_PACKAGE_PRE="test -d boost_${ATSRC_PACKAGE_VER//./_}"
+ATSRC_PACKAGE_CO=([0]="wget -N http://sourceforge.net/projects/boost/files/boost/${ATSRC_PACKAGE_VER}/boost_${ATSRC_PACKAGE_VER//./_}.tar.bz2")
+ATSRC_PACKAGE_POST="tar jxf boost_${ATSRC_PACKAGE_VER//./_}.tar.bz2"
+ATSRC_PACKAGE_SRC="${AT_BASE}/sources/boost_${ATSRC_PACKAGE_VER//./_}"
+ATSRC_PACKAGE_WORK=${AT_WORK_PATH}/boost
+ATSRC_PACKAGE_MLS=""
+ATSRC_PACKAGE_ALOC=""
+ATSRC_PACKAGE_PATCHES=""
+ATSRC_PACKAGE_TARS=""
+ATSRC_PACKAGE_MAKE_CHECK=""
+ATSRC_PACKAGE_DISTRIB=no
+ATSRC_PACKAGE_BUNDLE=mcore-libs


### PR DESCRIPTION
	This patch updates the version of boost to
	1.64.0. It removes the symlink that was
	poiting to the file used by AT 10 and adds
	a new file called source with the specific
	boost configuration for AT 11.0.

Signed-off-by: Rafael Peria de Sene <rpsene@br.ibm.com>