### PR TITLE
Update tcmalloc on AT 11.0 (#29)

### DIFF
--- a/configs/11.0/packages/tcmalloc/sources
+++ b/configs/11.0/packages/tcmalloc/sources
@@ -1,1 +1,43 @@
-../../../10.0/packages/tcmalloc/sources
+#!/usr/bin/env bash
+#
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Tcmalloc source package and build info
+# ==================================
+#
+
+ATSRC_PACKAGE_NAME="TCMalloc"
+ATSRC_PACKAGE_VER=2.6
+ATSRC_PACKAGE_REV=50125d8f7000
+ATSRC_PACKAGE_LICENSE="BSD License"
+ATSRC_PACKAGE_DOCLINK="http://htmlpreview.github.io/?https://github.com/gperftools/gperftools/blob/master/doc/tcmalloc.html"
+ATSRC_PACKAGE_RELFIXES=
+ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
+ATSRC_PACKAGE_VERID="${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
+ATSRC_PACKAGE_PRE="test -d gperftools-${ATSRC_PACKAGE_VERID}"
+ATSRC_PACKAGE_CO=([0]="wget -O gperftools-${ATSRC_PACKAGE_VERID}.tar.gz https://github.com/gperftools/gperftools/archive/${ATSRC_PACKAGE_REV}.tar.gz")
+ATSRC_PACKAGE_GIT=""
+# Use --transform to give a better name to Gperftools directory.
+ATSRC_PACKAGE_POST="tar xzf gperftools-${ATSRC_PACKAGE_VERID}.tar.gz --transform=s/gperftools-${ATSRC_PACKAGE_REV}[^\\/]*/gperftools-${ATSRC_PACKAGE_VERID}/"
+ATSRC_PACKAGE_SRC="${AT_BASE}/sources/gperftools-${ATSRC_PACKAGE_VERID}"
+ATSRC_PACKAGE_WORK=${AT_WORK_PATH}/gperftools
+ATSRC_PACKAGE_MLS=""
+ATSRC_PACKAGE_ALOC=""
+ATSRC_PACKAGE_PATCHES=""
+ATSRC_PACKAGE_TARS=""
+ATSRC_PACKAGE_MAKE_CHECK=""
+ATSRC_PACKAGE_DISTRIB=no
+ATSRC_PACKAGE_BUNDLE=toolchain_extra


### PR DESCRIPTION
This patch updates tcmalloc to revision 50125d8 on AT 11.0.

Signed-off-by: Rajalakshmi Srinivasaraghavan  <raji@linux.vnet.ibm.com>