### PR TITLE
Add support for sqlite on AT version of Python

### DIFF
--- a/configs/10.0/distros/centos-6.mk
+++ b/configs/10.0/distros/centos-6.mk
@@ -72,7 +72,7 @@ ifndef AT_DISTRO_REQ_PKGS
     AT_CROSS_PKGS_REQ :=
     AT_NATIVE_PKGS_REQ := \(ibm-java2-ppc64-sdk-5.0\|java-1.5.0-ibm-devel\) \
                           libxslt popt-devel qt-devel readline \
-                          readline-devel
+                          readline-devel sqlite-devel
     AT_COMMON_PKGS_REQ := zlib-devel ncurses-devel flex bison texinfo \
                           createrepo glibc-devel subversion cvs gawk autoconf \
                           rsync curl bc automake imake

--- a/configs/10.0/distros/centos-7.mk
+++ b/configs/10.0/distros/centos-7.mk
@@ -86,7 +86,7 @@ endef
 ifndef AT_DISTRO_REQ_PKGS
     AT_CROSS_PKGS_REQ :=
     AT_NATIVE_PKGS_REQ := libxslt docbook-style-xsl qt-devel \
-                          autogen-libopts
+                          autogen-libopts sqlite-devel
     AT_COMMON_PKGS_REQ := zlib-devel ncurses-devel flex bison texinfo \
                           createrepo glibc-devel subversion cvs gawk \
                           rsync curl bc automake libstdc\\+\\+-static \

--- a/configs/10.0/distros/ubuntu-16.mk
+++ b/configs/10.0/distros/ubuntu-16.mk
@@ -65,7 +65,8 @@ endef
 ifndef AT_DISTRO_REQ_PKGS
     AT_CROSS_PKGS_REQ :=
     AT_NATIVE_PKGS_REQ := libxslt libpopt-dev libqt4-dev \
-                          libc6-dev libbz2-dev xsltproc docbook-xsl
+                          libc6-dev libbz2-dev xsltproc docbook-xsl \
+                          libsqlite3-dev
     AT_COMMON_PKGS_REQ := zlib1g-dev libncurses5-dev ncurses-term flex bison \
                           texinfo subversion cvs gawk fakeroot debhelper \
                           autoconf rsync curl bc libxml2-utils automake \

--- a/configs/8.0/packages/python/stage_1
+++ b/configs/8.0/packages/python/stage_1
@@ -44,7 +44,8 @@ atcfg_configure() {
 		--prefix=${at_dest} \
 		--exec-prefix=${at_dest} \
 		--libdir="${at_dest}/lib${compiler##32}" \
-		--enable-shared
+		--enable-shared \
+		--enable-loadable-sqlite-extensions
 }
 
 atcfg_make() {

--- a/configs/9.0/distros/fedora-22.mk
+++ b/configs/9.0/distros/fedora-22.mk
@@ -77,7 +77,7 @@ endef
 ifndef AT_DISTRO_REQ_PKGS
     AT_CROSS_PKGS_REQ :=
     AT_NATIVE_PKGS_REQ := libxslt docbook-style-xsl qt-devel \
-                          autogen-libopts
+                          autogen-libopts sqlite-devel
     AT_COMMON_PKGS_REQ := zlib-devel ncurses-devel flex bison texinfo \
                           createrepo glibc-devel subversion cvs gawk \
                           rsync curl bc automake libstdc\\+\\+-static \

--- a/configs/9.0/distros/redhat-6.mk
+++ b/configs/9.0/distros/redhat-6.mk
@@ -72,7 +72,7 @@ ifndef AT_DISTRO_REQ_PKGS
     AT_CROSS_PKGS_REQ :=
     AT_NATIVE_PKGS_REQ := \(ibm-java2-ppc64-sdk-5.0\|java-1.5.0-ibm-devel\) \
                           libxslt popt-devel qt-devel readline \
-                          readline-devel
+                          readline-devel sqlite-devel
     AT_COMMON_PKGS_REQ := zlib-devel ncurses-devel flex bison texinfo \
                           createrepo glibc-devel subversion cvs gawk autoconf \
                           rsync curl bc automake imake

--- a/configs/9.0/distros/redhat-7.mk
+++ b/configs/9.0/distros/redhat-7.mk
@@ -86,7 +86,7 @@ endef
 ifndef AT_DISTRO_REQ_PKGS
     AT_CROSS_PKGS_REQ :=
     AT_NATIVE_PKGS_REQ := libxslt docbook-style-xsl qt-devel \
-                          autogen-libopts
+                          autogen-libopts sqlite-devel
     AT_COMMON_PKGS_REQ := zlib-devel ncurses-devel flex bison texinfo \
                           createrepo glibc-devel subversion cvs gawk \
                           rsync curl bc automake libstdc\\+\\+-static \

--- a/configs/9.0/distros/suse-12.mk
+++ b/configs/9.0/distros/suse-12.mk
@@ -71,7 +71,7 @@ endef
 ifndef AT_DISTRO_REQ_PKGS
     AT_CROSS_PKGS_REQ :=
     AT_NATIVE_PKGS_REQ := libxslt popt-devel docbook-xsl-stylesheets \
-                          java-1_7_1-ibm-devel libbz2-devel
+                          java-1_7_1-ibm-devel libbz2-devel sqlite3-devel
     AT_COMMON_PKGS_REQ := zlib-devel ncurses-devel flex bison texinfo \
                           createrepo subversion cvs gawk autoconf rsync curl \
                           bc automake rpm-build gcc-c++ xorg-x11-util-devel

--- a/configs/9.0/distros/ubuntu-14.mk
+++ b/configs/9.0/distros/ubuntu-14.mk
@@ -65,7 +65,8 @@ endef
 ifndef AT_DISTRO_REQ_PKGS
     AT_CROSS_PKGS_REQ :=
     AT_NATIVE_PKGS_REQ := libxslt libpopt-dev libqt4-dev \
-                          libc6-dev libtool libbz2-dev xsltproc docbook-xsl
+                          libc6-dev libtool libbz2-dev xsltproc docbook-xsl \
+                          libsqlite3-dev
     AT_COMMON_PKGS_REQ := zlib1g-dev libncurses5-dev ncurses-term flex bison \
                           texinfo subversion cvs gawk fakeroot debhelper \
                           autoconf rsync curl bc libxml2-utils automake \

--- a/fvtr/python/python.exp
+++ b/fvtr/python/python.exp
@@ -91,7 +91,9 @@ if { "$pyver" == "2.6" } {
 	# Python unit tests are "embarrassingly parallel", at least up to 6 cores
 	# it seems
 	set CORES [expr min(6, [exec grep -c "processor" /proc/cpuinfo ])]
-
+        # Test for the issue #45
+        printit "Executing sqlite3 importing test."
+        exec $env(AT_DEST)/bin/python3 -c "import sqlite3"
 	# The following tests fail for python when run using FVTR so exclude
 	# them.
 	set spawn_cmd "spawn $env(AT_DEST)/bin/python3 $test_script \


### PR DESCRIPTION
	This commit fixes the issue #45 which is
	related to the missing of sqlite3 in the
	python version built by AT. It adds the
	option --enable-loadable-sqlite-extensions
	during the confuration steps and includes
	the correct dependency of the devel package
	of sqlite for AT8.0 to AT Next.

Signed-off-by: Rafael Peria de Sene <rpsene@br.ibm.com>