### PR TITLE
Remove git.linux.ibm.com mirrors

### DIFF
--- a/configs/10.0/packages/binutils/sources
+++ b/configs/10.0/packages/binutils/sources
@@ -27,9 +27,7 @@ ATSRC_PACKAGE_DOCLINK="http://sourceware.org/binutils/docs/"
 ATSRC_PACKAGE_RELFIXES=
 ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_PRE="test -d binutils-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
-# git.linux.ibm.com is a mirror of sourceware.org.
-ATSRC_PACKAGE_CO=([0]="git clone git://git.linux.ibm.com/binutils-gdb/binutils-gdb.git binutils" \
-		  [1]="git clone git://sourceware.org/git/binutils-gdb.git binutils")
+ATSRC_PACKAGE_CO=([0]="git clone git://sourceware.org/git/binutils-gdb.git binutils")
 ATSRC_PACKAGE_GIT="git checkout -b binutils-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}} ${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_POST="mv binutils binutils-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
 ATSRC_PACKAGE_SRC=${AT_BASE}/sources/binutils-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}

--- a/configs/10.0/packages/gdb/sources
+++ b/configs/10.0/packages/gdb/sources
@@ -26,9 +26,7 @@ ATSRC_PACKAGE_DOCLINK="http://sourceware.org/gdb/current/onlinedocs/gdb/"
 ATSRC_PACKAGE_RELFIXES=
 ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
 ATSRC_PACKAGE_PRE="test -d gdb-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
-# git.linux.ibm.com is a mirror of sourceware.org.
-ATSRC_PACKAGE_CO=([0]="git clone git://git.linux.ibm.com/binutils-gdb/binutils-gdb.git gdb" \
-		  [1]="git clone git://sourceware.org/git/binutils-gdb.git gdb")
+ATSRC_PACKAGE_CO=([0]="git clone git://sourceware.org/git/binutils-gdb.git gdb")
 ATSRC_PACKAGE_GIT="git checkout -b gdb-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}} ${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_POST="mv gdb gdb-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
 ATSRC_PACKAGE_SRC="${AT_BASE}/sources/gdb-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"

--- a/configs/10.0/packages/glibc/sources
+++ b/configs/10.0/packages/glibc/sources
@@ -27,9 +27,7 @@ ATSRC_PACKAGE_DOCLINK="http://www.gnu.org/software/libc/manual/html_node/index.h
 ATSRC_PACKAGE_RELFIXES=
 ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}-ibm"
 ATSRC_PACKAGE_PRE="test -d glibc-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
-# git://git.linux.ibm.com/toolchain-mirrors/glibc.git is a mirror of the https://sourceware.org/git/glibc.git
-ATSRC_PACKAGE_CO=([0]="git clone git://git.linux.ibm.com/toolchain-mirrors/glibc.git" \
-		  [1]="git clone git://sourceware.org/git/glibc.git")
+ATSRC_PACKAGE_CO=([0]="git clone git://sourceware.org/git/glibc.git")
 ATSRC_PACKAGE_GIT="git checkout -b glibc-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}} ${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_POST="mv glibc glibc-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
 ATSRC_PACKAGE_SRC=${AT_BASE}/sources/glibc-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}

--- a/configs/11.0/packages/binutils/sources
+++ b/configs/11.0/packages/binutils/sources
@@ -27,9 +27,7 @@ ATSRC_PACKAGE_DOCLINK="http://sourceware.org/binutils/docs/"
 ATSRC_PACKAGE_RELFIXES=
 ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_PRE="test -d binutils-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
-# git.linux.ibm.com is a mirror of sourceware.org.
-ATSRC_PACKAGE_CO=([0]="git clone git://git.linux.ibm.com/binutils-gdb/binutils-gdb.git binutils" \
-		  [1]="git clone git://sourceware.org/git/binutils-gdb.git binutils")
+ATSRC_PACKAGE_CO=([0]="git clone git://sourceware.org/git/binutils-gdb.git binutils")
 ATSRC_PACKAGE_GIT="git checkout -b binutils-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}} ${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_POST="mv binutils binutils-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
 ATSRC_PACKAGE_SRC=${AT_BASE}/sources/binutils-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}

--- a/configs/6.0/packages/glibc/sources
+++ b/configs/6.0/packages/glibc/sources
@@ -25,9 +25,7 @@ ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}-ibm"
 ATSRC_PACKAGE_LICENSE="LGPL 2.1"
 ATSRC_PACKAGE_DOCLINK="http://www.gnu.org/software/libc/manual/html_node/index.html"
 ATSRC_PACKAGE_PRE="test -d glibc-${ATSRC_PACKAGE_VER}"
-# git://git.linux.ibm.com/toolchain-mirrors/glibc.git is a mirror of the https://sourceware.org/git/glibc.git
-ATSRC_PACKAGE_CO=([0]="git clone git://git.linux.ibm.com/toolchain-mirrors/glibc.git" \
-                  [1]="git clone git://sourceware.org/git/glibc.git")
+ATSRC_PACKAGE_CO=([0]="git clone git://sourceware.org/git/glibc.git")
 ATSRC_PACKAGE_GIT="git checkout -b glibc-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}} origin/ibm/${ATSRC_PACKAGE_VER}/master"
 ATSRC_PACKAGE_POST="mv glibc glibc-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
 ATSRC_PACKAGE_SRC=${AT_BASE}/sources/glibc-${ATSRC_PACKAGE_VER}

--- a/configs/7.0/packages/glibc/sources
+++ b/configs/7.0/packages/glibc/sources
@@ -27,9 +27,7 @@ ATSRC_PACKAGE_DOCLINK="http://www.gnu.org/software/libc/manual/html_node/index.h
 ATSRC_PACKAGE_RELFIXES=
 ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}-ibm"
 ATSRC_PACKAGE_PRE="test -d glibc-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
-# git://git.linux.ibm.com/toolchain-mirrors/glibc.git is a mirror of the https://sourceware.org/git/glibc.git
-ATSRC_PACKAGE_CO=([0]="git clone git://git.linux.ibm.com/toolchain-mirrors/glibc.git" \
-                  [1]="git clone git://sourceware.org/git/glibc.git")
+ATSRC_PACKAGE_CO=([0]="git clone git://sourceware.org/git/glibc.git")
 ATSRC_PACKAGE_GIT="git checkout -b glibc-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}} ${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_POST="mv glibc glibc-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
 ATSRC_PACKAGE_SRC=${AT_BASE}/sources/glibc-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}

--- a/configs/7.1/packages/binutils/sources
+++ b/configs/7.1/packages/binutils/sources
@@ -27,9 +27,7 @@ ATSRC_PACKAGE_DOCLINK="http://sourceware.org/binutils/docs/"
 ATSRC_PACKAGE_RELFIXES=
 ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_PRE="test -d binutils-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
-# git.linux.ibm.com is a mirror of sourceware.org.
-ATSRC_PACKAGE_CO=([0]="git clone git://git.linux.ibm.com/binutils-gdb/binutils-gdb.git binutils" \
-		  [1]="git clone git://sourceware.org/git/binutils-gdb.git binutils")
+ATSRC_PACKAGE_CO=([0]="git clone git://sourceware.org/git/binutils-gdb.git binutils")
 ATSRC_PACKAGE_GIT="git checkout -b binutils-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}} ${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_POST="mv binutils binutils-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
 ATSRC_PACKAGE_SRC=${AT_BASE}/sources/binutils-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}

--- a/configs/7.1/packages/gdb/sources
+++ b/configs/7.1/packages/gdb/sources
@@ -26,9 +26,7 @@ ATSRC_PACKAGE_DOCLINK="http://sourceware.org/gdb/current/onlinedocs/gdb/"
 ATSRC_PACKAGE_RELFIXES=
 ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
 ATSRC_PACKAGE_PRE="test -d gdb-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
-# git.linux.ibm.com is a mirror of sourceware.org.
-ATSRC_PACKAGE_CO=([0]="git clone git://git.linux.ibm.com/binutils-gdb/binutils-gdb.git gdb" \
-		  [1]="git clone git://sourceware.org/git/binutils-gdb.git gdb")
+ATSRC_PACKAGE_CO=([0]="git clone git://sourceware.org/git/binutils-gdb.git gdb")
 ATSRC_PACKAGE_GIT="git checkout -b gdb-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}} ${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_POST="mv gdb gdb-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
 ATSRC_PACKAGE_SRC="${AT_BASE}/sources/gdb-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"

--- a/configs/7.1/packages/glibc/sources
+++ b/configs/7.1/packages/glibc/sources
@@ -27,9 +27,7 @@ ATSRC_PACKAGE_DOCLINK="http://www.gnu.org/software/libc/manual/html_node/index.h
 ATSRC_PACKAGE_RELFIXES=
 ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}-ibm"
 ATSRC_PACKAGE_PRE="test -d glibc-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
-# git://git.linux.ibm.com/toolchain-mirrors/glibc.git is a mirror of the https://sourceware.org/git/glibc.git
-ATSRC_PACKAGE_CO=([0]="git clone git://git.linux.ibm.com/toolchain-mirrors/glibc.git" \
-                  [1]="git clone git://sourceware.org/git/glibc.git")
+ATSRC_PACKAGE_CO=([0]="git clone git://sourceware.org/git/glibc.git")
 ATSRC_PACKAGE_GIT="git checkout -b glibc-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}} ${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_POST="mv glibc glibc-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
 ATSRC_PACKAGE_SRC=${AT_BASE}/sources/glibc-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}

--- a/configs/8.0/packages/binutils/sources
+++ b/configs/8.0/packages/binutils/sources
@@ -27,9 +27,7 @@ ATSRC_PACKAGE_DOCLINK="http://sourceware.org/binutils/docs/"
 ATSRC_PACKAGE_RELFIXES=
 ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_PRE="test -d binutils-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
-# git.linux.ibm.com is a mirror of sourceware.org.
-ATSRC_PACKAGE_CO=([0]="git clone git://git.linux.ibm.com/binutils-gdb/binutils-gdb.git binutils" \
-		  [1]="git clone git://sourceware.org/git/binutils-gdb.git binutils")
+ATSRC_PACKAGE_CO=([0]="git clone git://sourceware.org/git/binutils-gdb.git binutils")
 ATSRC_PACKAGE_GIT="git checkout -b binutils-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}} ${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_POST="mv binutils binutils-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
 ATSRC_PACKAGE_SRC=${AT_BASE}/sources/binutils-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}

--- a/configs/8.0/packages/gdb/sources
+++ b/configs/8.0/packages/gdb/sources
@@ -26,9 +26,7 @@ ATSRC_PACKAGE_DOCLINK="http://sourceware.org/gdb/current/onlinedocs/gdb/"
 ATSRC_PACKAGE_RELFIXES=
 ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
 ATSRC_PACKAGE_PRE="test -d gdb-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
-# git.linux.ibm.com is a mirror of sourceware.org.
-ATSRC_PACKAGE_CO=([0]="git clone git://git.linux.ibm.com/binutils-gdb/binutils-gdb.git gdb" \
-		  [1]="git clone git://sourceware.org/git/binutils-gdb.git gdb")
+ATSRC_PACKAGE_CO=([0]="git clone git://sourceware.org/git/binutils-gdb.git gdb")
 ATSRC_PACKAGE_GIT="git checkout -b gdb-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}} ${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_POST="mv gdb gdb-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
 ATSRC_PACKAGE_SRC="${AT_BASE}/sources/gdb-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"

--- a/configs/8.0/packages/glibc/sources
+++ b/configs/8.0/packages/glibc/sources
@@ -27,9 +27,7 @@ ATSRC_PACKAGE_DOCLINK="http://www.gnu.org/software/libc/manual/html_node/index.h
 ATSRC_PACKAGE_RELFIXES=
 ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}-ibm"
 ATSRC_PACKAGE_PRE="test -d glibc-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
-# git://git.linux.ibm.com/toolchain-mirrors/glibc.git is a mirror of the https://sourceware.org/git/glibc.git
-ATSRC_PACKAGE_CO=([0]="git clone git://git.linux.ibm.com/toolchain-mirrors/glibc.git" \
-                  [1]="git clone git://sourceware.org/git/glibc.git")
+ATSRC_PACKAGE_CO=([0]="git clone git://sourceware.org/git/glibc.git")
 ATSRC_PACKAGE_GIT="git checkout -b glibc-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}} ${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_POST="mv glibc glibc-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
 ATSRC_PACKAGE_SRC=${AT_BASE}/sources/glibc-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}

--- a/configs/9.0/packages/binutils/sources
+++ b/configs/9.0/packages/binutils/sources
@@ -27,9 +27,7 @@ ATSRC_PACKAGE_DOCLINK="http://sourceware.org/binutils/docs/"
 ATSRC_PACKAGE_RELFIXES=
 ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_PRE="test -d binutils-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
-# git.linux.ibm.com is a mirror of sourceware.org.
-ATSRC_PACKAGE_CO=([0]="git clone git://git.linux.ibm.com/binutils-gdb/binutils-gdb.git binutils" \
-		  [1]="git clone git://sourceware.org/git/binutils-gdb.git binutils")
+ATSRC_PACKAGE_CO=([0]="git clone git://sourceware.org/git/binutils-gdb.git binutils")
 ATSRC_PACKAGE_GIT="git checkout -b binutils-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}} ${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_POST="mv binutils binutils-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
 ATSRC_PACKAGE_SRC=${AT_BASE}/sources/binutils-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}

--- a/configs/9.0/packages/gdb/sources
+++ b/configs/9.0/packages/gdb/sources
@@ -26,9 +26,7 @@ ATSRC_PACKAGE_DOCLINK="http://sourceware.org/gdb/current/onlinedocs/gdb/"
 ATSRC_PACKAGE_RELFIXES=
 ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
 ATSRC_PACKAGE_PRE="test -d gdb-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
-# git.linux.ibm.com is a mirror of sourceware.org.
-ATSRC_PACKAGE_CO=([0]="git clone git://git.linux.ibm.com/binutils-gdb/binutils-gdb.git gdb" \
-		  [1]="git clone git://sourceware.org/git/binutils-gdb.git gdb")
+ATSRC_PACKAGE_CO=([0]="git clone git://sourceware.org/git/binutils-gdb.git gdb")
 ATSRC_PACKAGE_GIT="git checkout -b gdb-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}} ${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_POST="mv gdb gdb-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
 ATSRC_PACKAGE_SRC="${AT_BASE}/sources/gdb-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"

--- a/configs/9.0/packages/glibc/sources
+++ b/configs/9.0/packages/glibc/sources
@@ -27,9 +27,7 @@ ATSRC_PACKAGE_DOCLINK="http://www.gnu.org/software/libc/manual/html_node/index.h
 ATSRC_PACKAGE_RELFIXES=
 ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}-ibm"
 ATSRC_PACKAGE_PRE="test -d glibc-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
-# git://git.linux.ibm.com/toolchain-mirrors/glibc.git is a mirror of the https://sourceware.org/git/glibc.git
-ATSRC_PACKAGE_CO=([0]="git clone git://git.linux.ibm.com/toolchain-mirrors/glibc.git" \
-		  [1]="git clone git://sourceware.org/git/glibc.git")
+ATSRC_PACKAGE_CO=([0]="git clone git://sourceware.org/git/glibc.git")
 ATSRC_PACKAGE_GIT="git checkout -b glibc-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}} ${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_POST="mv glibc glibc-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
 ATSRC_PACKAGE_SRC=${AT_BASE}/sources/glibc-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}

--- a/configs/next/packages/binutils/sources
+++ b/configs/next/packages/binutils/sources
@@ -27,9 +27,7 @@ ATSRC_PACKAGE_DOCLINK="http://sourceware.org/binutils/docs/"
 ATSRC_PACKAGE_RELFIXES=
 ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_PRE="test -d binutils-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
-# git.linux.ibm.com is a mirror of sourceware.org.
-ATSRC_PACKAGE_CO=([0]="git clone git://git.linux.ibm.com/binutils-gdb/binutils-gdb.git binutils" \
-		  [1]="git clone git://sourceware.org/git/binutils-gdb.git binutils")
+ATSRC_PACKAGE_CO=([0]="git clone git://sourceware.org/git/binutils-gdb.git binutils")
 ATSRC_PACKAGE_GIT="git checkout -b binutils-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}} ${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_POST="mv binutils binutils-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
 ATSRC_PACKAGE_SRC=${AT_BASE}/sources/binutils-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}

--- a/configs/next/packages/gcc/sources
+++ b/configs/next/packages/gcc/sources
@@ -32,8 +32,7 @@ ATSRC_PACKAGE_RELFIXES=
 ATSRC_PACKAGE_NAMESUFFIX="[C, C++ (g++), fortran, Go]"
 ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}-ibm-r${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_PRE="test -d gcc-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
-ATSRC_PACKAGE_CO=([0]="git clone git://git.linux.ibm.com/gcc/gcc.git" \
-                  [1]="git clone git://gcc.gnu.org/git/gcc.git")
+ATSRC_PACKAGE_CO=([0]="git clone git://gcc.gnu.org/git/gcc.git")
 ATSRC_PACKAGE_GIT="git checkout -b gcc-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV} ${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_POST="mv gcc gcc-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_SRC=${AT_BASE}/sources/gcc-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}

--- a/configs/next/packages/gdb/sources
+++ b/configs/next/packages/gdb/sources
@@ -26,9 +26,7 @@ ATSRC_PACKAGE_DOCLINK="http://sourceware.org/gdb/current/onlinedocs/gdb/"
 ATSRC_PACKAGE_RELFIXES=
 ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
 ATSRC_PACKAGE_PRE="test -d gdb-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
-# git.linux.ibm.com is a mirror of sourceware.org.
-ATSRC_PACKAGE_CO=([0]="git clone git://git.linux.ibm.com/binutils-gdb/binutils-gdb.git gdb" \
-		  [1]="git clone git://sourceware.org/git/binutils-gdb.git gdb")
+ATSRC_PACKAGE_CO=([0]="git clone git://sourceware.org/git/binutils-gdb.git gdb")
 ATSRC_PACKAGE_GIT="git checkout -b gdb-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}} ${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_POST="mv gdb gdb-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
 ATSRC_PACKAGE_SRC="${AT_BASE}/sources/gdb-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"

--- a/configs/next/packages/glibc/sources
+++ b/configs/next/packages/glibc/sources
@@ -27,9 +27,7 @@ ATSRC_PACKAGE_DOCLINK="http://www.gnu.org/software/libc/manual/html_node/index.h
 ATSRC_PACKAGE_RELFIXES=
 ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}-ibm"
 ATSRC_PACKAGE_PRE="test -d glibc-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
-# git://git.linux.ibm.com/toolchain-mirrors/glibc.git is a mirror of the https://sourceware.org/git/glibc.git
-ATSRC_PACKAGE_CO=([0]="git clone git://git.linux.ibm.com/toolchain-mirrors/glibc.git" \
-		  [1]="git clone git://sourceware.org/git/glibc.git")
+ATSRC_PACKAGE_CO=([0]="git clone git://sourceware.org/git/glibc.git")
 ATSRC_PACKAGE_GIT="git checkout -b glibc-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}} ${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_POST="mv glibc glibc-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
 ATSRC_PACKAGE_SRC=${AT_BASE}/sources/glibc-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}


### PR DESCRIPTION
Git repositories on git.linux.ibm.com don't work anymore, this patch
remove all references to that mirrors.