### PR TITLE
Harden path normalization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -632,6 +632,8 @@ endef
 # Define the installation path
 # DESTDIR, is optional and should be externally defined.
 DESTDIR ?= /opt
+# Canonicalize DESTDIR path
+DESTDIR = $(shell readlink -m "${DESTDIR}")
 
 ifneq ($(AT_INTERNAL),none)
     AT_MAJOR_INTERNAL := $(AT_MAJOR)-$(AT_INTERNAL)

--- a/fvtr/ck_ldds/ck_ldds.exp
+++ b/fvtr/ck_ldds/ck_ldds.exp
@@ -35,11 +35,20 @@ if { $env(AT_CROSS_BUILD) == "yes" } {
 	exit $ENOSYS
 }
 
-proc has_broken_dynlink {file} {
+proc is_dynlink {file} {
 	set file_info [ exec file $file ]
-	set ret 0
 
 	if { [regexp "dynamically linked" $file_info] } {
+		return 1
+	} else {
+		return 0
+	}
+}
+
+proc has_broken_dynlink {file} {
+	set ret 0
+
+	if { [is_dynlink ${file}] } {
 		if {[check_lib_dependencies $file]} {
 			set ret 1
 		}
@@ -47,6 +56,21 @@ proc has_broken_dynlink {file} {
 	return ${ret}
 }
 
+# Verify if the executables' interpreters have canonical path.
+set executables [ exec find $at_dir -type f -perm /111 ]
+foreach exe $executables {
+	if { [is_dynlink ${exe}] } {
+		set interp_info [exec readelf -l ${exe}]
+		if { [regexp -line "interpreter: (.*)\]$" ${interp_info} match \
+			  interpreter]} {
+			set interpreter2 [file normalize ${interpreter}]
+			if { ${interpreter} != ${interpreter2} } {
+				fvtr_error "The interpreter of ${exe} is not \
+canonical: ${interpreter}"
+			}
+		}
+	}
+}
 
 set files [ exec find $at_dir -type f -perm /111 | \
 		grep -Ev "$at_dir/(old/|compat/)?lib(64)?/ld\-" | \

--- a/remote-build.exp
+++ b/remote-build.exp
@@ -159,9 +159,9 @@ puts "Servers: $servers"
 # desired paths.
 
 # Directory used by the script to save its files.
-set tray_dir $trayprefix/$atdir
+set tray_dir [file normalize $trayprefix/$atdir]
 # Directory where AT will be installed (aka DESTDIR).
-set destdir $destprefix/$atdir
+set destdir [file normalize $destprefix/$atdir]
 set timeout $default_timeout
 
 spawn make pack


### PR DESCRIPTION
Fix issue #92.

Canonicalize DESTDIR in Makefile, and tray_dir and destdir in
remote-build.exp in order to avoid unnecessary characters, e.g. multiple
slashes or relative paths.