### PR TITLE
Update TBB on AT 11.0.

### DIFF
--- a/configs/11.0/packages/tbb/sources
+++ b/configs/11.0/packages/tbb/sources
@@ -1,1 +1,71 @@
-../../../10.0/packages/tbb/sources
+#!/usr/bin/env bash
+#
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# TBB source package and build info
+# =======================================
+#
+
+ATSRC_PACKAGE_NAME="Thread Building Blocks"
+ATSRC_PACKAGE_VER=2017_U7
+ATSRC_PACKAGE_REV=eb6336ad2945
+ATSRC_PACKAGE_LICENSE="GPL 2.0"
+ATSRC_PACKAGE_DOCLINK="https://www.threadingbuildingblocks.org/documentation"
+ATSRC_PACKAGE_RELFIXES=
+ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
+ATSRC_PACKAGE_VERID="${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
+ATSRC_PACKAGE_PRE="test -d tbb${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
+ATSRC_PACKAGE_CO=([0]="wget -O tbb-${ATSRC_PACKAGE_VERID}.tar.gz https://github.com/01org/tbb/archive/${ATSRC_PACKAGE_VER}.tar.gz")
+ATSRC_PACKAGE_GIT=""
+ATSRC_PACKAGE_POST="tar xzf tbb-${ATSRC_PACKAGE_VERID}.tar.gz --transform=s/tbb-${ATSRC_PACKAGE_VER}[^\\/]*/tbb-${ATSRC_PACKAGE_VERID}/"
+ATSRC_PACKAGE_SRC=${AT_BASE}/sources/tbb-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}
+ATSRC_PACKAGE_WORK=${AT_WORK_PATH}/tbb
+ATSRC_PACKAGE_MLS=""
+ATSRC_PACKAGE_ALOC=""
+ATSRC_PACKAGE_PATCHES=""
+ATSRC_PACKAGE_TARS=""
+# Disable make check testing due to failures
+ATSRC_PACKAGE_MAKE_CHECK=none
+ATSRC_PACKAGE_DISTRIB=yes
+ATSRC_PACKAGE_BUNDLE=mcore-libs
+
+# This is a package function to verify the make_check log.
+# In some cases 'make check' will return 0 even though the log shows that
+# there some failures did occur.  Define this function for
+# packages where that has happened.  Due to differences in the implementations
+# of 'make check' or 'make test' the strings that indicate failure could
+# be different.
+
+atsrc_package_verify_make_check_log ()
+{
+	if [[ -n "${1}" ]]; then
+		grep -i "error[: ]" "${1}" > /dev/null
+		return ${?}
+	fi
+}
+
+atsrc_get_patches ()
+{
+	at_get_patch \
+		https://github.com/powertechpreview/powertechpreview/raw/42cfbcf3d4a2fb7f9216069397df0dff9fc0f651/TBB%20PowerPC%20Patches/4.3/ppc64-tbb-4.3-fix.tgz \
+		11708da1a42542608a345c8f0b71dfc6 || return ${?}
+}
+
+atsrc_apply_patches ()
+{
+	tar xzf ppc64-tbb-4.3-fix.tgz || return ${?}
+	patch -p1 < inteltbb_set_compiler.patch || return ${?}
+}


### PR DESCRIPTION
Update TBB to version 2017 Update 6 on AT 11.0 (Task #77). TBB 2017
updates was moved to github. There's no new source packages on the
old link anymore. The old packages 4.3 (2016) are still avaliable.

Signed-off-by: Rogerio Alves Cardoso <rcardoso@linux.vnet.ibm.com>