### PR TITLE
Update Userspace RCU on AT 11.0

### DIFF
--- a/configs/11.0/packages/liburcu/sources
+++ b/configs/11.0/packages/liburcu/sources
@@ -1,1 +1,35 @@
-../../../10.0/packages/liburcu/sources
+#!/usr/bin/env bash
+#
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# URCU source package and build info
+# ==================================
+#
+
+ATSRC_PACKAGE_NAME="Userspace RCU"
+ATSRC_PACKAGE_VER=0.10.0
+ATSRC_PACKAGE_LICENSE="Lesser GPL 2.1"
+ATSRC_PACKAGE_DOCLINK="http://lttng.org/urcu"
+ATSRC_PACKAGE_RELFIXES=
+ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}"
+ATSRC_PACKAGE_PRE="test -d userspace-rcu-${ATSRC_PACKAGE_VER}"
+ATSRC_PACKAGE_CO=([0]="wget -N https://lttng.org/files/urcu/userspace-rcu-${ATSRC_PACKAGE_VER}.tar.bz2")
+ATSRC_PACKAGE_POST="tar -xjf userspace-rcu-${ATSRC_PACKAGE_VER}.tar.bz2"
+ATSRC_PACKAGE_SRC="${AT_BASE}/sources/userspace-rcu-${ATSRC_PACKAGE_VER}"
+ATSRC_PACKAGE_WORK=${AT_WORK_PATH}/userspace-rcu
+ATSRC_PACKAGE_MAKE_CHECK=""
+ATSRC_PACKAGE_DISTRIB=yes
+ATSRC_PACKAGE_BUNDLE=mcore-libs


### PR DESCRIPTION
Update Userspace RCU to version 0.9.3 on AT 11.0 (Task #78).

Signed-off-by: Rogerio Alves Cardoso <rcardoso@linux.vnet.ibm.com>