### PR TITLE
Use find -mindepth instead of explicitly excluding "."

### DIFF
--- a/scripts/utilities/pkg_build_monolithic.sh
+++ b/scripts/utilities/pkg_build_monolithic.sh
@@ -41,7 +41,7 @@ source "${utilities}/pkg_build_filefilters.sh"
 function monolithic_filelists()
 {
 	local GROUP PACK
-	local groups=$(find "${dynamic_spec}"/. -type d ! -path "${dynamic_spec}"/. -printf '%f ')
+	local groups=$(find "${dynamic_spec}"/. -mindepth 1 -type d -printf '%f ')
 
 	# Clean up final lists (from previous build)
 	for GROUP in ${groups}; do


### PR DESCRIPTION
I think this is a common use-case for mindepth, so let's use it.

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>