### PR TITLE
Use systemd in our cache manager system for DEB based distros

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1118,15 +1118,15 @@ $(RCPTS)/monitor.rcpt: $(RCPTS)/toolchain.rcpt
 	    group=$$( ls $(DYNAMIC_SPEC)/ | grep "toolchain\$$" ); \
 	    echo "$(AT_DEST)/bin/watch_ldconfig" \
 	          >> $(DYNAMIC_SPEC)/$${group}/ldconfig.filelist; \
-	    if [[ "$(pack-sys)" == "deb" || $${at_major_version%.*} -lt  9 ]]; then \
+	    if [[ $${at_major_version%.*} -lt  9 ]] || [[ "$(pack-sys)" == "deb" && $${at_major_version%.*} -lt 11 ]]; then \
 	        echo "/etc/cron.d/$${at_ver_rev_internal//./}_ldconfig" \
 	             >> $(DYNAMIC_SPEC)/$${group}/ldconfig.filelist; \
 	    else \
 		systemd_unit=$$( pkg-config --variable=systemdsystemunitdir systemd ); \
 		systemd_preset=$$( pkg-config --variable=systemdsystempresetdir systemd ); \
-	        echo "${RPM_BUILD_ROOT}/$${systemd_unit}/$(AT_VER_REV_INTERNAL)-cachemanager.service" \
+	        echo "$${systemd_unit}/$(AT_VER_REV_INTERNAL)-cachemanager.service" \
 	             >> $(DYNAMIC_SPEC)/$${group}/ldconfig.filelist; \
-	        echo "${RPM_BUILD_ROOT}/$${systemd_preset}/90-atcachemanager.preset" \
+	        echo "$${systemd_preset}/90-atcachemanager.preset" \
 	             >> $(DYNAMIC_SPEC)/$${group}/ldconfig.filelist; \
 	    fi; \
 	    echo "All done."; \

--- a/configs/10.0/deb/monolithic/rules
+++ b/configs/10.0/deb/monolithic/rules
@@ -62,7 +62,7 @@ binary-cp: build
 	# executed.
 	mkdir -p debian/tmp/etc/cron.d/
 	echo "@reboot root __AT_DEST__/bin/watch_ldconfig &" \
-	      > debian/tmp/etc/cron.d/__AT_VER_REV_INTERNAL___ldconfig
+	      > debian/tmp/etc/cron.d/__AT_VER_ALTERNATIVE___ldconfig
 	gzip -9nvf debian/tmp/__AT_DEST__/share/info/*.info*
 	# Prepare the area for golang
 	mkdir -p debian/tmp/__GO_DEST__

--- a/configs/11.0/deb/monolithic/control
+++ b/configs/11.0/deb/monolithic/control
@@ -1,1 +1,158 @@
-../../../10.0/deb/monolithic/control
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+Source: advance-toolchain-__AT_MAJOR_INTERNAL__
+Section: devel
+Priority: extra
+Maintainer: Advance Toolchain
+
+Package: advance-toolchain-runtime
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__)
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime
+Architecture: ppc64el
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+
+Package: advance-toolchain-runtime-dbg
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime-dbg (= __AT_FULL_VER__)
+Description: Advance Toolchain
+ The advance toolchain debugging information.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime-dbg
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__)
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain debugging information.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime-compat
+Architecture: ppc64el
+Conflicts: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime
+Depends: ${shlibs:Depends}
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+
+Package: advance-toolchain-devel
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-devel (= __AT_FULL_VER__)
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ This package provides the packages necessary to build applications that use the
+ features provided by the Advance Toolchain.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-devel
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__)
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ This package provides the packages necessary to build applications that use the
+ features provided by the Advance Toolchain.
+
+Package: advance-toolchain-devel-dbg
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-devel-dbg (= __AT_FULL_VER__)
+Description: Advance Toolchain
+ The advance toolchain debugging information.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-devel-dbg
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-devel (= __AT_FULL_VER__)
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain debugging information.
+
+Package: advance-toolchain-mcore-libs
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-mcore-libs (= __AT_FULL_VER__)
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ This package provides the necessary libraries to build multi-threaded
+ applications.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-mcore-libs
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__)
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ This package provides the necessary libraries to build multi-threaded
+ applications.
+
+Package: advance-toolchain-mcore-libs-dbg
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-mcore-libs-dbg (= __AT_FULL_VER__)
+Description: Advance Toolchain
+ The advance toolchain debugging information.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-mcore-libs-dbg
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-mcore-libs (= __AT_FULL_VER__)
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain debugging information.
+
+Package: advance-toolchain-perf
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-perf (= __AT_FULL_VER__)
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ This package contains the performance library install targets for Valgrind
+ and OProfile.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-perf
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__)
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ This package contains the performance library install targets for Valgrind
+ and OProfile.
+
+Package: advance-toolchain-perf-dbg
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-perf-dbg (= __AT_FULL_VER__)
+Description: Advance Toolchain
+ The advance toolchain debugging information.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-perf-dbg
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-perf (= __AT_FULL_VER__)
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain debugging information.
+
+Package: advance-toolchain-golang-at
+Architecture: ppc64el
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ This package provides the Golang binaries for ppc64el.

--- a/configs/11.0/deb/monolithic/control
+++ b/configs/11.0/deb/monolithic/control
@@ -26,6 +26,7 @@ Description: Advance Toolchain
 
 Package: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime
 Architecture: ppc64el
+Build-Depends: dh-systemd
 Depends: ${shlibs:Depends} ${misc:Depends}
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview

--- a/configs/11.0/deb/monolithic/rules
+++ b/configs/11.0/deb/monolithic/rules
@@ -33,9 +33,11 @@ binary-arch: build binary-cp
 	dh_installdirs
 	dh_installdocs
 	dh_installchangelogs
+	dh_systemd_enable
 
 # Copy the packages' files.
 	dh_install --fail-missing
+	dh_systemd_start
 
 # Strip binaries
 	perl debian/dh_strip --dest=__AT_DEST__ --exclude=getconf --exclude=libgo. --exclude=ld- --dbg-package=advance-toolchain-__AT_MAJOR_INTERNAL__-runtime-dbg -p advance-toolchain-__AT_MAJOR_INTERNAL__-runtime
@@ -58,11 +60,13 @@ binary-cp: build
 	      --exclude=compat/include \
 	      --exclude=share/info/dir \
 	      __AT_DEST__ debian/tmp/__AT_DEST__/../
-	# Set a cronjob to run AT's ldconfig when the system's ldconfig is
-	# executed.
-	mkdir -p debian/tmp/etc/cron.d/
-	echo "@reboot root __AT_DEST__/bin/watch_ldconfig &" \
-	      > debian/tmp/etc/cron.d/__AT_VER_REV_INTERNAL___ldconfig
+	# Set a systemd service to run AT's ldconfig when the system's \
+	# ldconfig is executed.
+	mkdir -p debian/tmp/__SYSTEMD_UNIT__/
+	mv debian/cachemanager.service debian/tmp/__SYSTEMD_UNIT__/__AT_VER_REV_INTERNAL__-cachemanager.service
+	mkdir -p debian/tmp/__SYSTEMD_PRESET__/
+	echo "enable at*cachemanager.service" \
+		> debian/tmp/__SYSTEMD_PRESET__/90-atcachemanager.preset
 	gzip -9nvf debian/tmp/__AT_DEST__/share/info/*.info*
 	# Prepare the area for golang
 	mkdir -p debian/tmp/__GO_DEST__

--- a/configs/11.0/deb/monolithic/rules
+++ b/configs/11.0/deb/monolithic/rules
@@ -1,1 +1,72 @@
-../../../10.0/deb/monolithic/rules
+#!/usr/bin/make -f
+#
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+PACKAGES=$(shell dh_listpackages)
+
+build:
+	dh_testdir
+	dh_testroot
+	dh_prep
+
+clean:
+	dh_testdir
+	dh_testroot
+	dh_clean -d
+
+binary-indep: build
+
+binary-arch: build binary-cp
+	dh_installdirs
+	dh_installdocs
+	dh_installchangelogs
+
+# Copy the packages' files.
+	dh_install --fail-missing
+
+# Strip binaries
+	perl debian/dh_strip --dest=__AT_DEST__ --exclude=getconf --exclude=libgo. --exclude=ld- --dbg-package=advance-toolchain-__AT_MAJOR_INTERNAL__-runtime-dbg -p advance-toolchain-__AT_MAJOR_INTERNAL__-runtime
+	perl debian/dh_strip --dest=__AT_DEST__ --dbg-package=advance-toolchain-__AT_MAJOR_INTERNAL__-mcore-libs-dbg -p advance-toolchain-__AT_MAJOR_INTERNAL__-mcore-libs
+	perl debian/dh_strip --dest=__AT_DEST__ --exclude=getconf --dbg-package=advance-toolchain-__AT_MAJOR_INTERNAL__-devel-dbg -p advance-toolchain-__AT_MAJOR_INTERNAL__-devel
+	perl debian/dh_strip --dest=__AT_DEST__ --dbg-package=advance-toolchain-__AT_MAJOR_INTERNAL__-perf-dbg -p advance-toolchain-__AT_MAJOR_INTERNAL__-perf
+
+	dh_compress
+	dh_makeshlibs --version-info
+	dh_installdeb
+	dh_shlibdeps --exclude=typedef --exclude=testdata
+	dh_gencontrol
+	dh_md5sums
+	dh_builddeb
+
+binary-cp: build
+	mkdir -p debian/tmp/__AT_DEST__
+	rsync -a --delete --delete-excluded \
+	      --exclude=etc/ld.so.cache \
+	      --exclude=compat/include \
+	      --exclude=share/info/dir \
+	      __AT_DEST__ debian/tmp/__AT_DEST__/../
+	# Set a cronjob to run AT's ldconfig when the system's ldconfig is
+	# executed.
+	mkdir -p debian/tmp/etc/cron.d/
+	echo "@reboot root __AT_DEST__/bin/watch_ldconfig &" \
+	      > debian/tmp/etc/cron.d/__AT_VER_REV_INTERNAL___ldconfig
+	gzip -9nvf debian/tmp/__AT_DEST__/share/info/*.info*
+	# Prepare the area for golang
+	mkdir -p debian/tmp/__GO_DEST__
+	rsync -a --delete __TMP_DIR__/golang_1/__GO_DEST__ debian/tmp/__GO_DEST__/../
+
+binary: binary-indep binary-arch
+.PHONY: build clean binary-indep binary-arch binary

--- a/configs/11.0/deb/monolithic/runtime.postinst
+++ b/configs/11.0/deb/monolithic/runtime.postinst
@@ -24,7 +24,6 @@ if [[ "${1}" == configure ]]; then
 	[[ -f __AT_DEST__/sbin/ldconfig ]] && __AT_DEST__/sbin/ldconfig
 fi
 
-echo "AT's linker cache file is not automatically updated when a package is \
-installed or modified."
-echo "Please run __AT_DEST__/bin/watch_ldconfig or reboot your system if you \
-want it to be."
+systemctl --no-reload preset __AT_VER_REV_INTERNAL__-cachemanager.service \
+    > /dev/null 2>&1 || :
+systemctl restart __AT_VER_REV_INTERNAL__-cachemanager.service

--- a/configs/11.0/deb/monolithic/runtime.postinst
+++ b/configs/11.0/deb/monolithic/runtime.postinst
@@ -1,1 +1,30 @@
-../../../10.0/deb/monolithic/runtime.postinst
+#!/bin/bash
+#
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if [[ "${1}" == configure ]]; then
+	# Automatically set the timezone
+	rm -f "__AT_DEST__/etc/localtime"
+	ln -s /etc/localtime "__AT_DEST__/etc/localtime"
+
+	# Update ld.so.cache
+	[[ -f __AT_DEST__/sbin/ldconfig ]] && __AT_DEST__/sbin/ldconfig
+fi
+
+echo "AT's linker cache file is not automatically updated when a package is \
+installed or modified."
+echo "Please run __AT_DEST__/bin/watch_ldconfig or reboot your system if you \
+want it to be."

--- a/configs/7.1/deb/monolithic/rules
+++ b/configs/7.1/deb/monolithic/rules
@@ -56,7 +56,7 @@ binary-cp: build
 	# executed.
 	mkdir -p debian/tmp/etc/cron.d/
 	echo "@reboot root __AT_DEST__/bin/watch_ldconfig &" \
-	      > debian/tmp/etc/cron.d/__AT_VER_REV_INTERNAL___ldconfig
+	      > debian/tmp/etc/cron.d/__AT_VER_ALTERNATIVE___ldconfig
 	gzip -9nvf debian/tmp/__AT_DEST__/share/info/*.info*
 
 binary: binary-indep binary-arch

--- a/configs/9.0/deb/monolithic/rules
+++ b/configs/9.0/deb/monolithic/rules
@@ -62,7 +62,7 @@ binary-cp: build
 	# executed.
 	mkdir -p debian/tmp/etc/cron.d/
 	echo "@reboot root __AT_DEST__/bin/watch_ldconfig &" \
-	      > debian/tmp/etc/cron.d/__AT_VER_REV_INTERNAL___ldconfig
+	      > debian/tmp/etc/cron.d/__AT_VER_ALTERNATIVE___ldconfig
 	gzip -9nvf debian/tmp/__AT_DEST__/share/info/*.info*
 	# Prepare the area for golang
 	mkdir -p debian/tmp/__GO_DEST__


### PR DESCRIPTION
On RPM based distros we use a  a systemd service instead of a cronjob to start our mechanism to automatic update AT's loader cache, these patches does the same for DEB based distros on AT >= 11.0.