### PR TITLE
Re-enable libsanitizer on AT >= 11.0

### DIFF
--- a/configs/11.0/packages/gcc/stage_2
+++ b/configs/11.0/packages/gcc/stage_2
@@ -68,7 +68,6 @@ atcfg_pre_configure() {
 atcfg_configure() {
 	if [[ "${cross_build}" == "no" ]]; then
 		# Configure command for native builds
-		# TODO: Re-enable libsanitizer when GCC bug #81066 is fixed.
 		CC="${cc_64}" \
 		CXX="${cxx_64}" \
 		CFLAGS="-O2" \
@@ -97,7 +96,6 @@ atcfg_configure() {
 			--disable-lto \
 			--disable-libgomp \
 			--disable-plugin \
-			--disable-libsanitizer \
 			--without-ppl \
 			--without-cloog \
 			--with-gmp-include="${at_dest}/include" \

--- a/configs/11.0/packages/gcc/stage_3
+++ b/configs/11.0/packages/gcc/stage_3
@@ -85,7 +85,6 @@ atcfg_pre_configure() {
 # Conditional configure command for builds
 atcfg_configure() {
 	if [[ "${cross_build}" == "no" ]]; then
-		# TODO: Re-enable libsanitizer when GCC bug #81066 is fixed.
 		CC="${cc_64}" \
 		CXX="${cxx_64}" \
 		CFLAGS="-O2 -mminimal-toc" \
@@ -114,7 +113,6 @@ atcfg_configure() {
 			--enable-gnu-indirect-function \
 			--enable-linker-build-id \
 			--disable-libgomp \
-			--disable-libsanitizer \
 			--with-gmp-include="${at_dest}/include" \
 			--with-gmp-lib=${libdir} \
 			--with-mpfr-include="${at_dest}/include" \

--- a/configs/11.0/packages/gcc/stage_4
+++ b/configs/11.0/packages/gcc/stage_4
@@ -36,7 +36,6 @@ atcfg_pre_configure() {
 atcfg_configure() {
 	if [[ "${cross_build}" == "no" ]]; then
 		# Configure command for native builds
-		# TODO: Re-enable libsanitizer when GCC bug #81066 is fixed.
 		PATH=${at_dest}/bin:${PATH} \
 		CC="${at_dest}/bin/gcc" \
 		CFLAGS="-O2" \
@@ -68,7 +67,6 @@ atcfg_configure() {
 			--enable-gnu-indirect-function \
 			--enable-initfini-array \
 			--enable-linker-build-id \
-			--disable-libsanitizer \
 			--with-system-zlib \
 			--with-gmp-include="${at_dest}/include" \
 			--with-gmp-lib="${at_dest}/lib64" \
@@ -84,7 +82,6 @@ atcfg_configure() {
 			--with-tune=${build_optimization}
 	else
 		# Configure command for cross builds
-		# TODO: Re-enable libsanitizer when GCC bug #81066 is fixed.
 		CC="${system_cc}" \
 		CXX="${system_cxx}" \
 		LD_FOR_TARGET="${at_dest}/bin/${target}-ld" \
@@ -113,7 +110,6 @@ atcfg_configure() {
 			--enable-cross \
 			--enable-initfini-array \
 			--enable-linker-build-id \
-			--disable-libsanitizer \
 			--disable-gotools \
 			--disable-libcc1 \
 			--disable-bootstrap \

--- a/configs/11.0/packages/gcc/stage_optimized
+++ b/configs/11.0/packages/gcc/stage_optimized
@@ -36,7 +36,6 @@ atcfg_pre_configure() {
 
 
 atcfg_configure() {
-	# TODO: Re-enable libsanitizer when GCC bug #81066 is fixed.
 	PATH=${at_dest}/bin:${PATH} \
 	CC="${at_dest}/bin/gcc" \
 	CFLAGS="-O2" \
@@ -66,7 +65,6 @@ atcfg_configure() {
 		--enable-lto \
 		--enable-linker-build-id \
 		--disable-bootstrap \
-		--disable-libsanitizer \
 		--with-gmp-include="${at_dest}/include" \
 		--with-gmp-lib="${at_dest}/lib64" \
 		--with-mpfr-include="${at_dest}/include" \


### PR DESCRIPTION
   Fix for #114    

    This commit re-enables libsanitizer on both versions
    of AT (native and cross) for versions greater then
    11.0. It affects the stages 2, 3, 4 and optimized of
    GCC build.

Signed-off-by: Rafael Peria de Sene <rpsene@br.ibm.com>