### PR TITLE
Remove Python test files from runtime package

### DIFF
--- a/configs/11.0/packages/groups
+++ b/configs/11.0/packages/groups
@@ -43,7 +43,8 @@ runtime_exclude=('/^.*\.a$/d' \
                  '/^.*\.o$/d' \
                  '/^.*\.la$/d' \
                  '/^.*\.spec$/d' \
-                 '/^.*\.gox$/d')
+                 '/^.*\.gox$/d' \
+                 '/^.*\/lib64\/python[0-9].[0-9]\/test\/.*$/d')
 
 # Filters to use on runtime package file inclusion (grep ERE)
 runtime_include=
@@ -62,4 +63,5 @@ devel_include=('^.*\.a$' \
                '^.*\.o$' \
                '^.*\.la$' \
                '^.*\.spec$' \
-               '^.*\.gox$')
+               '^.*\.gox$' \
+               '^.*\/lib64\/python[0-9].[0-9]\/test\/.*$')


### PR DESCRIPTION
    This patch provides a fix for the issue #79
    by removing the Python test files from runtime
    and including them into devel packages.

Signed-off-by: Rafael Peria de Sene <rpsene@br.ibm.com>