### PR TITLE
Update Expat on AT >= 11.0.

### DIFF
--- a/configs/11.0/distros/centos-6.mk
+++ b/configs/11.0/distros/centos-6.mk
@@ -1,1 +1,91 @@
-../../10.0/distros/centos-6.mk
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Distro dependent basic definitions for RedHat Enterprise Server 6
+# =================================================================
+# This Makefile include contains the definitions for the distro being used
+# for the build process. It contains kernel version infos and distro specific
+# sanity checks.
+
+# Informs the distro supported power archs
+AT_SUPPORTED_ARCHS := ppc64
+
+# You may force the BUILD_IGNORE_AT_COMPAT general condition by distro
+#BUILD_IGNORE_AT_COMPAT := yes
+
+# Kernel version to build toolchain against
+# - As this distro only supports one arch variation (ppc64), there is no
+#   need to conditionally define these versions based on arch.
+AT_KERNEL := 2.6.32     # Current distro kernel version for runtime.
+AT_OLD_KERNEL := 2.6.18 # Previous distro kernel version for runtime-compat.
+
+# Inform the mainly supported distros
+AT_SUPPORTED_DISTROS := "RHEL6 RHEL7"
+
+# Inform the compatibility supported distros
+AT_COMPAT_DISTROS := RHEL5
+
+# Sign the repository and packages
+AT_SIGN_PKGS := yes
+AT_SIGN_REPO := yes
+AT_SIGN_PKGS_CROSS := no
+AT_SIGN_REPO_CROSS := yes
+
+# ID of GNUPG key used to sign our packages (main/compat)
+AT_GPG_KEYID  := 6976A827
+AT_GPG_KEYIDC := 3052930D
+AT_GPG_KEYIDL := 6976A827
+# ID of GNUPG key used to sign our repositories (main/compat)
+AT_GPG_REPO_KEYID  := 3052930D
+AT_GPG_REPO_KEYIDC := 3052930D
+AT_GPG_REPO_KEYIDL := 6976A827
+
+# Options required by the command to update the repository metadata
+AT_REPOCMD_OPTS := -p -s sha1 --simple-md-filenames --no-database
+
+# Moved here from build.mk since the value for this variable
+# depends on the distro.
+# For a cross build the executables in the toolchain (gcc, ld, etc.)
+# should be built as 32 bit.
+BUILD_CROSS_32 := yes
+
+# As some distros have special requirements for configuration upon final
+# AT installation, put in this macro, the final configurations required
+# after the main build and prior to the rpm build
+define distro_final_config
+    echo "nothing to do."
+endef
+
+# Inform the list of packages to check
+ifndef AT_DISTRO_REQ_PKGS
+    AT_CROSS_PKGS_REQ :=
+    AT_NATIVE_PKGS_REQ := \(ibm-java2-ppc64-sdk-5.0\|java-1.5.0-ibm-devel\) \
+                          libxslt popt-devel qt-devel readline \
+                          readline-devel sqlite-devel
+    AT_COMMON_PKGS_REQ := zlib-devel ncurses-devel flex bison texinfo \
+                          createrepo glibc-devel subversion cvs gawk autoconf \
+                          rsync curl bc automake imake wget docbook2X
+    AT_CROSS_PGMS_REQ :=
+    AT_NATIVE_PGMS_REQ :=
+    AT_COMMON_PGMS_REQ := git_1.7
+    AT_JAVA_VERSIONS := 5
+endif
+
+# If needed, define the necessary distro related sanity checks.
+define distro_sanity
+    echo "nothing to test here"
+endef
+
+# Inform if the systemd service to monitor the loader cache should be used.
+USE_SYSTEMD := no

--- a/configs/11.0/distros/centos-7.mk
+++ b/configs/11.0/distros/centos-7.mk
@@ -1,1 +1,119 @@
-../../10.0/distros/centos-7.mk
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Distro dependent basic definitions for RedHat Enterprise Server 7
+# =================================================================
+# This Makefile include contains the definitions for the distro being used
+# for the build process. It contains kernel version infos and distro specific
+# sanity checks.
+
+# Informs the distro supported power archs
+AT_SUPPORTED_ARCHS := ppc64 ppc64le
+
+# You may force the BUILD_IGNORE_AT_COMPAT general condition by distro
+#BUILD_IGNORE_AT_COMPAT := yes
+
+# Kernel version to build toolchain against
+# - As this distro may support any arch variation combination (ppc64le/ppc64),
+#   there is a need to conditionally define these versions based on arch.
+ifeq ($(BUILD_ARCH),ppc64le)
+    # Current distro kernel version for runtime.
+    AT_KERNEL := 3.10
+    # Previous distro kernel version for runtime-compat.
+    AT_OLD_KERNEL :=
+else
+    # Current distro kernel version for runtime.
+    AT_KERNEL := 3.10
+    # Previous distro kernel version for runtime-compat.
+    AT_OLD_KERNEL := 2.6.32
+endif
+
+# Inform the mainly supported distros
+AT_SUPPORTED_DISTROS := RHEL7
+
+# Inform the compatibility supported distros
+AT_COMPAT_DISTROS := RHEL6
+
+# Sign the repository and packages
+AT_SIGN_PKGS := yes
+AT_SIGN_REPO := yes
+AT_SIGN_PKGS_CROSS := no
+AT_SIGN_REPO_CROSS := yes
+
+# ID of GNUPG key used to sign our packages (main/compat)
+AT_GPG_KEYID  := 6976A827
+AT_GPG_KEYIDC := 6976A827
+AT_GPG_KEYIDL := 6976A827
+# ID of GNUPG key used to sign our repositories (main/compat)
+AT_GPG_REPO_KEYID  := 6976A827
+AT_GPG_REPO_KEYIDC := 3052930D
+AT_GPG_REPO_KEYIDL := 6976A827
+
+# Options required by the command to update the repository metadata
+AT_REPOCMD_OPTS := -p -s sha1 --simple-md-filenames --no-database
+
+# Moved here from build.mk since the value for this variable
+# depends on the distro.
+# For a cross build the executables in the toolchain (gcc, ld, etc.)
+# should be built as 32 bit.
+BUILD_CROSS_32 := no
+
+# As some distros have special requirements for configuration upon final
+# AT installation, put in this macro, the final configurations required
+# after the main build and prior to the rpm build
+define distro_final_config
+    echo "nothing to do."
+endef
+
+# Due to a problem found on RHEL 7.0 GA there is a package that doesn't fall
+# into the default dependencies and should be added manually for checking here
+# libstdc++-static (in this case, either i686 and x86_64) must be available for
+# the build to proceed. If RedHat fixes its internal dependencies later on,
+# this check could be safely removed.
+
+# Inform the list of packages to check
+ifndef AT_DISTRO_REQ_PKGS
+    AT_CROSS_PKGS_REQ :=
+    AT_NATIVE_PKGS_REQ := libxslt docbook-style-xsl qt-devel \
+                          autogen-libopts sqlite-devel
+    AT_COMMON_PKGS_REQ := zlib-devel ncurses-devel flex bison texinfo \
+                          createrepo glibc-devel subversion cvs gawk \
+                          rsync curl bc automake libstdc\\+\\+-static \
+                          redhat-lsb-core autoconf bzip2-[0-9] libtool-[0-9] \
+                          gzip rpm-build-[0-9] rpm-sign gcc-c++ imake wget \
+                          docbook2X
+    AT_CROSS_PGMS_REQ :=
+    AT_NATIVE_PGMS_REQ :=
+    AT_COMMON_PGMS_REQ := git_1.7
+    AT_JAVA_VERSIONS := 7
+endif
+
+# Complete the list of packages to check that are based on arch being build
+ifeq ($(BUILD_ARCH),ppc64le)
+    AT_NATIVE_PKGS_REQ += \(ibm-java2-ppc64le-sdk-7.1\|java-1.7.1-ibm-devel\)
+    AT_NATIVE_PKGS_REQ += glibc-devel bzip2-devel popt-devel
+else
+    AT_NATIVE_PKGS_REQ += \(ibm-java2-ppc64-sdk-7.0\|java-1.7.1-ibm-devel\) \
+                          glibc-devel-.*\.ppc$$ glibc-devel-.*\.ppc64$$ \
+                          bzip2-devel-.*\.ppc$$ bzip2-devel-.*\.ppc64$$ \
+                          popt-devel-.*\.ppc$$ popt-devel-.*\.ppc64$$
+endif
+
+# If needed, define the necessary distro related sanity checks.
+define distro_sanity
+    echo "nothing to test here"
+endef
+
+# Inform if the systemd service to monitor the loader cache should be used.
+USE_SYSTEMD := no

--- a/configs/11.0/distros/redhat-7.mk
+++ b/configs/11.0/distros/redhat-7.mk
@@ -1,1 +1,118 @@
-../../10.0/distros/redhat-7.mk
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Distro dependent basic definitions for RedHat Enterprise Server 7
+# =================================================================
+# This Makefile include contains the definitions for the distro being used
+# for the build process. It contains kernel version infos and distro specific
+# sanity checks.
+
+# Informs the distro supported power archs
+AT_SUPPORTED_ARCHS := ppc64 ppc64le
+
+# You may force the BUILD_IGNORE_AT_COMPAT general condition by distro
+#BUILD_IGNORE_AT_COMPAT := yes
+
+# Kernel version to build toolchain against
+# - As this distro may support any arch variation combination (ppc64le/ppc64),
+#   there is a need to conditionally define these versions based on arch.
+ifeq ($(BUILD_ARCH),ppc64le)
+    # Current distro kernel version for runtime.
+    AT_KERNEL := 3.10
+    # Previous distro kernel version for runtime-compat.
+    AT_OLD_KERNEL :=
+else
+    # Current distro kernel version for runtime.
+    AT_KERNEL := 3.10
+    # Previous distro kernel version for runtime-compat.
+    AT_OLD_KERNEL := 2.6.32
+endif
+
+# Inform the mainly supported distros
+AT_SUPPORTED_DISTROS := RHEL7
+
+# Inform the compatibility supported distros
+AT_COMPAT_DISTROS := RHEL6
+
+# Sign the repository and packages
+AT_SIGN_PKGS := yes
+AT_SIGN_REPO := yes
+AT_SIGN_PKGS_CROSS := no
+AT_SIGN_REPO_CROSS := yes
+
+# ID of GNUPG key used to sign our packages (main/compat)
+AT_GPG_KEYID  := 6976A827
+AT_GPG_KEYIDC := 6976A827
+AT_GPG_KEYIDL := 6976A827
+# ID of GNUPG key used to sign our repositories (main/compat)
+AT_GPG_REPO_KEYID  := 6976A827
+AT_GPG_REPO_KEYIDC := 3052930D
+AT_GPG_REPO_KEYIDL := 6976A827
+
+# Options required by the command to update the repository metadata
+AT_REPOCMD_OPTS := -p -s sha1 --simple-md-filenames --no-database
+
+# Moved here from build.mk since the value for this variable
+# depends on the distro.
+# For a cross build the executables in the toolchain (gcc, ld, etc.)
+# should be built as 32 bit.
+BUILD_CROSS_32 := no
+
+# As some distros have special requirements for configuration upon final
+# AT installation, put in this macro, the final configurations required
+# after the main build and prior to the rpm build
+define distro_final_config
+    echo "nothing to do."
+endef
+
+# Due to a problem found on RHEL 7.0 GA there is a package that doesn't fall
+# into the default dependencies and should be added manually for checking here
+# libstdc++-static (in this case, either i686 and x86_64) must be available for
+# the build to proceed. If RedHat fixes its internal dependencies later on,
+# this check could be safely removed.
+
+# Inform the list of packages to check
+ifndef AT_DISTRO_REQ_PKGS
+    AT_CROSS_PKGS_REQ :=
+    AT_NATIVE_PKGS_REQ := libxslt docbook-style-xsl qt-devel \
+                          autogen-libopts sqlite-devel
+    AT_COMMON_PKGS_REQ := zlib-devel ncurses-devel flex bison texinfo \
+                          createrepo glibc-devel subversion cvs gawk \
+                          rsync curl bc automake libstdc\\+\\+-static \
+                          redhat-lsb-core autoconf bzip2-[0-9] libtool-[0-9] \
+                          gzip rpm-build-[0-9] rpm-sign gcc-c++ imake wget \
+                          docbook2X
+    AT_CROSS_PGMS_REQ :=
+    AT_NATIVE_PGMS_REQ :=
+    AT_COMMON_PGMS_REQ := git_1.7
+    AT_JAVA_VERSIONS := 7
+endif
+
+# Complete the list of packages to check that are based on arch being build
+ifeq ($(BUILD_ARCH),ppc64le)
+    AT_NATIVE_PKGS_REQ += \(ibm-java2-ppc64le-sdk-7.1\|java-1.7.1-ibm-devel\)
+    AT_NATIVE_PKGS_REQ += glibc-devel bzip2-devel popt-devel
+else
+    AT_NATIVE_PKGS_REQ += \(ibm-java2-ppc64-sdk-7.0\|java-1.7.1-ibm-devel\) \
+                          glibc-devel-.*\.ppc$$ glibc-devel-.*\.ppc64$$ \
+                          bzip2-devel-.*\.ppc$$ bzip2-devel-.*\.ppc64$$ \
+                          popt-devel-.*\.ppc$$ popt-devel-.*\.ppc64$$
+endif
+
+# If needed, define the necessary distro related sanity checks.
+define distro_sanity
+    echo "nothing to test here"
+endef
+# Inform if the systemd service to monitor the loader cache should be used.
+USE_SYSTEMD := yes

--- a/configs/11.0/distros/suse-12.mk
+++ b/configs/11.0/distros/suse-12.mk
@@ -1,1 +1,91 @@
-../../10.0/distros/suse-12.mk
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Distro dependent basic definitions for SuSE Enterprise Server 12
+# ================================================================
+# This Makefile include contains the definitions for the distro being used
+# for the build process. It contains kernel version infos and distro specific
+# sanity checks.
+
+# Informs the distro supported power archs
+AT_SUPPORTED_ARCHS := ppc64le
+
+# You may force the BUILD_IGNORE_AT_COMPAT general condition by distro
+#BUILD_IGNORE_AT_COMPAT := yes
+
+# Kernel version to build toolchain against
+# - As this distro only supports one arch variation (ppc64le), there is no
+#   need to conditionally define these versions based on arch.
+AT_KERNEL := 3.12.12     # Current distro kernel version for runtime.
+AT_OLD_KERNEL :=         # Previous distro kernel version for runtime-compat.
+
+# Inform the mainly supported distros
+AT_SUPPORTED_DISTROS := SLES_12
+
+# Inform the compatibility supported distros
+AT_COMPAT_DISTROS :=
+
+# Sign the repository and packages
+AT_SIGN_PKGS := yes
+AT_SIGN_REPO := yes
+AT_SIGN_PKGS_CROSS := no
+AT_SIGN_REPO_CROSS := yes
+
+# ID of GNUPG key used to sign our packages (main/compat)
+AT_GPG_KEYID  := 6976A827
+AT_GPG_KEYIDC := 6976A827
+AT_GPG_KEYIDL := 6976A827
+# ID of GNUPG key used to sign our repositories (main/compat)
+AT_GPG_REPO_KEYID  := 6976A827
+AT_GPG_REPO_KEYIDC := 6976A827
+AT_GPG_REPO_KEYIDL := 6976A827
+
+# Options required by the command to update the repository metadata
+AT_REPOCMD_OPTS := -p
+
+# Moved here from build.mk since the value for this variable
+# depends on the distro.
+# For a cross build the executables in the toolchain (gcc, ld, etc.)
+# should be built as 64 bit.
+BUILD_CROSS_32 := no
+
+# As some distros have special requirements for configuration upon final
+# AT installation, put in this macro, the final configurations required
+# after the main build and prior to the rpm build
+define distro_final_config
+    echo "nothing to do."
+endef
+
+# Inform the list of packages to check
+ifndef AT_DISTRO_REQ_PKGS
+    AT_CROSS_PKGS_REQ :=
+    AT_NATIVE_PKGS_REQ := libxslt popt-devel docbook-xsl-stylesheets \
+                          java-1_7_1-ibm-devel libbz2-devel sqlite3-devel
+    AT_COMMON_PKGS_REQ := zlib-devel ncurses-devel flex bison texinfo \
+                          createrepo subversion cvs gawk autoconf rsync curl \
+                          bc automake rpm-build gcc-c++ xorg-x11-util-devel \
+                          docbook2x wget
+    AT_CROSS_PGMS_REQ :=
+    AT_NATIVE_PGMS_REQ :=
+    AT_COMMON_PGMS_REQ := git_1.7
+    AT_JAVA_VERSIONS := 7
+endif
+
+# If needed, define the necessary distro related sanity checks.
+define distro_sanity
+    echo "nothing to test here"
+endef
+
+# Inform if the systemd service to monitor the loader cache should be used.
+USE_SYSTEMD := yes

--- a/configs/11.0/distros/ubuntu-14.mk
+++ b/configs/11.0/distros/ubuntu-14.mk
@@ -1,1 +1,86 @@
-../../10.0/distros/ubuntu-14.mk
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Distro dependent basic definitions for Ubuntu 14.04 LTS
+# =======================================================
+# This Makefile include contains the definitions for the distro being used
+# for the build process. It contains kernel version infos and distro specific
+# sanity checks.
+
+# Informs the distro supported power archs
+AT_SUPPORTED_ARCHS := ppc64le
+
+# You may force the BUILD_IGNORE_AT_COMPAT general condition by distro
+#BUILD_IGNORE_AT_COMPAT := yes
+
+# Kernel version to build toolchain against
+# - As this distro only supports one arch variation (ppc64le), there is no
+#   need to conditionally define these versions based on arch.
+AT_KERNEL := 3.13    # Current distro kernel version for runtime.
+# Ubuntu 14 doesn't support compat mode because it's the first version
+# running on ppc64le.
+#AT_OLD_KERNEL :=  # Previous distro kernel version for runtime-compat.
+
+# Inform the mainly supported distros
+AT_SUPPORTED_DISTROS := trusty
+
+# Inform the compatibility supported distros
+#AT_COMPAT_DISTROS :=
+
+# Sign the repository and packages
+#AT_SIGN_PKGS := yes
+#AT_SIGN_REPO := yes
+#AT_SIGN_PKGS_CROSS := no
+#AT_SIGN_REPO_CROSS := yes
+
+# ID of GNUPG key used to sign our packages (main/compat)
+AT_GPG_KEYID := 6976A827
+AT_GPG_KEYIDC := 3052930D
+# ID of GNUPG key used to sign our repositories (main/compat)
+AT_GPG_REPO_KEYID := 3052930D
+AT_GPG_REPO_KEYIDC := 3052930D
+
+# Options required by the command to update the repository metadata
+AT_REPOCMD_OPTS := -p -s sha1 --simple-md-filenames --no-database
+
+# As some distros have special requirements for configuration upon final
+# AT installation, put in this macro, the final configurations required
+# after the main build and prior to the rpm build
+define distro_final_config
+    echo "nothing to do."
+endef
+
+# Inform the list of packages to check
+ifndef AT_DISTRO_REQ_PKGS
+    AT_CROSS_PKGS_REQ :=
+    AT_NATIVE_PKGS_REQ := libxslt libpopt-dev libqt4-dev \
+                          libc6-dev libtool libbz2-dev xsltproc docbook-xsl \
+                          libsqlite3-dev
+    AT_COMMON_PKGS_REQ := zlib1g-dev libncurses5-dev ncurses-term flex bison \
+                          texinfo subversion cvs gawk fakeroot debhelper \
+                          autoconf rsync curl bc libxml2-utils automake \
+                          docbook2x dpkg-sig xutils-dev wget
+    AT_CROSS_PGMS_REQ :=
+    AT_NATIVE_PGMS_REQ := pkg-config /opt/ibm/java-ppc64le-71/bin/java
+    AT_COMMON_PGMS_REQ := git_1.7
+    AT_JAVA_VERSIONS := 7
+endif
+
+# If needed, define the necessary distro related sanity checks.
+define distro_sanity
+    echo "nothing to test here"
+endef
+
+# Inform if the systemd service to monitor the loader cache should be used.
+USE_SYSTEMD := no

--- a/configs/11.0/distros/ubuntu-16.mk
+++ b/configs/11.0/distros/ubuntu-16.mk
@@ -71,7 +71,7 @@ ifndef AT_DISTRO_REQ_PKGS
                           texinfo subversion cvs gawk fakeroot debhelper \
                           autoconf rsync curl bc libxml2-utils automake \
                           dpkg-sig xutils-dev libtool wget dh-systemd \
-                          pkg-config
+                          docbook2x pkg-config
     AT_CROSS_PGMS_REQ :=
     AT_NATIVE_PGMS_REQ := /opt/ibm/java-ppc64le-80/jre/bin/java
     AT_COMMON_PGMS_REQ := git_2.7

--- a/configs/11.0/packages/expat/sources
+++ b/configs/11.0/packages/expat/sources
@@ -1,1 +1,56 @@
-../../../10.0/packages/expat/sources
+#!/usr/bin/env bash
+#
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# GLIBC source package and build info
+# ===================================
+#
+
+ATSRC_PACKAGE_NAME="Expat XML Parser"
+ATSRC_PACKAGE_VER="2.2.3"
+ATSRC_PACKAGE_REV=97c6bd019900
+ATSRC_PACKAGE_DOCLINK="https://libexpat.github.io/doc/"
+ATSRC_PACKAGE_RELFIXES=
+ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
+ATSRC_PACKAGE_VERID="${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
+ATSRC_PACKAGE_LICENSE="MIT License"
+ATSRC_PACKAGE_PRE="test -d expat-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
+ATSRC_PACKAGE_CO=([0]="wget -O expat-${ATSRC_PACKAGE_VERID}.tar.gz https://github.com/libexpat/libexpat/archive/${ATSRC_PACKAGE_REV}.tar.gz")
+ATSRC_PACKAGE_POST="tar xzf expat-${ATSRC_PACKAGE_VERID}.tar.gz --wildcards --strip=2 libexpat-${ATSRC_PACKAGE_REV}[^\\/]*/expat --transform=s:libexpat-${ATSRC_PACKAGE_REV}[^\\/]*/expat:libexpat-${ATSRC_PACKAGE_REV}[^\\/]*/expat-${ATSRC_PACKAGE_VERID}:"
+ATSRC_PACKAGE_SRC=${AT_BASE}/sources/expat-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}
+ATSRC_PACKAGE_WORK=${AT_WORK_PATH}/expat
+ATSRC_PACKAGE_MLS=
+ATSRC_PACKAGE_PATCHES=
+ATSRC_PACKAGE_ALOC=
+ATSRC_PACKAGE_TARS=
+ATSRC_PACKAGE_MAKE_CHECK=
+ATSRC_PACKAGE_DISTRIB=no
+ATSRC_PACKAGE_BUNDLE=main_toolchain
+
+atsrc_get_patches ()
+{
+	# Fix Makefile to try different command for docbook2x-man.
+	at_get_patch \
+		https://github.com/racardoso/libexpat/commit/9a8024f1a8ec.patch \
+		5fe8379cba7a7572b987639a198d9cc7 || return ${?}
+}
+
+atsrc_apply_patches ()
+{
+	patch -p2 < 9a8024f1a8ec.patch || return ${?}
+
+	return 0
+}

--- a/configs/11.0/packages/expat/stage_1
+++ b/configs/11.0/packages/expat/stage_1
@@ -1,1 +1,98 @@
-../../../10.0/packages/expat/stage_1
+#!/usr/bin/env bash
+#
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Expat build parameters for stage 1
+# =========================================
+#
+
+ATCFG_HOLD_TEMP_INSTALL='no'
+ATCFG_HOLD_TEMP_BUILD='no'
+# Build in a new directory.
+ATCFG_BUILD_STAGE_T='link'
+# Don't fail if stage final install place doesn't exist
+if [[ "${cross_build}" == "yes" ]]; then
+	ATCFG_INSTALL_PEDANTIC="no"
+fi
+
+atcfg_pre_configure() {
+	# Completely clean the build prior any build.
+	if [[ -e "Makefile" ]]; then
+		make extraclean
+	fi
+
+	# Reconfigure the build with the buildconf.
+	if [[ -e ./buildconf.sh ]]; then
+		sh ./buildconf.sh || exit 1
+	else
+		aclocal
+		automake --add-missing 2>/dev/null || true
+		autoreconf -fvi
+		# Toss this; it gets created by autoconf on some systems
+		rm -rf autom4te*.cache
+	fi
+}
+
+atcfg_configure() {
+	# Expat is built for the same architecture GDB is built to.
+	# Which means that in a cross compiler build it's build for the host
+	# architecture (i.e. i686) instead of the target arch (i.e. ppc64).
+
+	if [[ "${cross_build}" == "no" ]]; then
+		# Default values for native builds.
+		cc_path="${at_dest}/bin/gcc -m${compiler}"
+		libdir="${at_dest}/lib${compiler##32}"
+		prefix=${at_dest}
+	else
+		# Cross compiler settings.
+		cc_path=${system_cc}
+		libdir="${tmp_dir}/lib"
+		prefix=${tmp_dir}
+	fi
+
+	PATH=${at_dest}/bin:${PATH} \
+	CC="${cc_path}" \
+	CFLAGS="-g -O3" CXXFLAGS="-g -O3" \
+
+	./configure \
+		--build=${host} \
+		--host=${host} \
+		--prefix=${prefix} \
+		--exec-prefix=${prefix} \
+		--libdir="${libdir}" \
+		--bindir="${prefix}/bin" \
+		--mandir="${prefix}/share/man" \
+		--disable-shared
+}
+
+
+atcfg_make() {
+	PATH=${at_dest}/bin:${PATH} ${SUB_MAKE}
+}
+
+
+atcfg_install() {
+	if [[ "${cross_build}" == "no" ]]; then
+		PATH=${at_dest}/bin:${PATH} \
+		${SUB_MAKE} install DESTDIR=${install_place}
+	else
+		# In order to install the package at $prefix, we need to force
+		# DESTDIR value. Because if AT was built using DESTDIR, the
+		# value will be stored in MFLAGS.
+		PATH=${at_dest}/bin:${PATH} \
+		${SUB_MAKE} install DESTDIR=""
+	fi
+}


### PR DESCRIPTION
Update Expat to version 2.2.2 on AT 10.0 and 11.0 to fix CVE-2017-9233 (task #113).

Signed-off-by: Rogerio Alves Cardoso <rcardoso@linux.vnet.ibm.com>