### PR TITLE
Rely on the distro files to use the systemd service 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1120,15 +1120,15 @@ $(RCPTS)/monitor.rcpt: $(RCPTS)/toolchain.rcpt
 	    group=$$( ls $(DYNAMIC_SPEC)/ | grep "toolchain\$$" ); \
 	    echo "$(AT_DEST)/bin/watch_ldconfig" \
 	          >> $(DYNAMIC_SPEC)/$${group}/ldconfig.filelist; \
-	    if [[ $${at_major_version%.*} -lt  9 ]] || [[ "$(pack-sys)" == "deb" && $${at_major_version%.*} -lt 11 ]]; then \
-	        echo "/etc/cron.d/$${at_ver_rev_internal//./}_ldconfig" \
-	             >> $(DYNAMIC_SPEC)/$${group}/ldconfig.filelist; \
-	    else \
+	    if [[ $(USE_SYSTEMD) == "yes" ]]; then \
 		systemd_unit=$$( pkg-config --variable=systemdsystemunitdir systemd ); \
 		systemd_preset=$$( pkg-config --variable=systemdsystempresetdir systemd ); \
 	        echo "$${systemd_unit}/$(AT_VER_REV_INTERNAL)-cachemanager.service" \
 	             >> $(DYNAMIC_SPEC)/$${group}/ldconfig.filelist; \
 	        echo "$${systemd_preset}/90-atcachemanager.preset" \
+	             >> $(DYNAMIC_SPEC)/$${group}/ldconfig.filelist; \
+	    else \
+		echo "/etc/cron.d/$${at_ver_rev_internal//./}_ldconfig" \
 	             >> $(DYNAMIC_SPEC)/$${group}/ldconfig.filelist; \
 	    fi; \
 	    echo "All done."; \

--- a/configs/10.0/distros/centos-6.mk
+++ b/configs/10.0/distros/centos-6.mk
@@ -86,3 +86,6 @@ endif
 define distro_sanity
     echo "nothing to test here"
 endef
+
+# Inform if the systemd service to monitor the loader cache should be used.
+USE_SYSTEMD := no

--- a/configs/10.0/distros/centos-7.mk
+++ b/configs/10.0/distros/centos-7.mk
@@ -113,3 +113,6 @@ endif
 define distro_sanity
     echo "nothing to test here"
 endef
+
+# Inform if the systemd service to monitor the loader cache should be used.
+USE_SYSTEMD := no

--- a/configs/10.0/distros/ubuntu-16.mk
+++ b/configs/10.0/distros/ubuntu-16.mk
@@ -72,7 +72,7 @@ ifndef AT_DISTRO_REQ_PKGS
                           autoconf rsync curl bc libxml2-utils automake \
                           dpkg-sig xutils-dev libtool wget
     AT_CROSS_PGMS_REQ :=
-    AT_NATIVE_PGMS_REQ := pkg-config /opt/ibm/java-ppc64le-80/jre/bin/java
+    AT_NATIVE_PGMS_REQ := /opt/ibm/java-ppc64le-80/jre/bin/java
     AT_COMMON_PGMS_REQ := git_2.7
     AT_JAVA_VERSIONS := 8
 endif
@@ -81,3 +81,6 @@ endif
 define distro_sanity
     echo "nothing to test here"
 endef
+
+# Inform if the systemd service to monitor the loader cache should be used.
+USE_SYSTEMD := no

--- a/configs/11.0/deb/monolithic/rules
+++ b/configs/11.0/deb/monolithic/rules
@@ -33,11 +33,15 @@ binary-arch: build binary-cp
 	dh_installdirs
 	dh_installdocs
 	dh_installchangelogs
+ifeq (__USE_SYSTEMD__, yes)
 	dh_systemd_enable
+endif
 
 # Copy the packages' files.
 	dh_install --fail-missing
+ifeq (__USE_SYSTEMD__, yes)
 	dh_systemd_start
+endif
 
 # Strip binaries
 	perl debian/dh_strip --dest=__AT_DEST__ --exclude=getconf --exclude=libgo. --exclude=ld- --dbg-package=advance-toolchain-__AT_MAJOR_INTERNAL__-runtime-dbg -p advance-toolchain-__AT_MAJOR_INTERNAL__-runtime
@@ -60,6 +64,7 @@ binary-cp: build
 	      --exclude=compat/include \
 	      --exclude=share/info/dir \
 	      __AT_DEST__ debian/tmp/__AT_DEST__/../
+ifeq (__USE_SYSTEMD__, yes)
 	# Set a systemd service to run AT's ldconfig when the system's \
 	# ldconfig is executed.
 	mkdir -p debian/tmp/__SYSTEMD_UNIT__/
@@ -67,6 +72,13 @@ binary-cp: build
 	mkdir -p debian/tmp/__SYSTEMD_PRESET__/
 	echo "enable at*cachemanager.service" \
 		> debian/tmp/__SYSTEMD_PRESET__/90-atcachemanager.preset
+else
+	# Set a cronjob to run AT's ldconfig when the system's ldconfig is
+	# executed.
+	mkdir -p debian/tmp/etc/cron.d/
+	echo "@reboot root __AT_DEST__/bin/watch_ldconfig &" \
+	      > debian/tmp/etc/cron.d/__AT_VER_ALTERNATIVE___ldconfig
+endif
 	gzip -9nvf debian/tmp/__AT_DEST__/share/info/*.info*
 	# Prepare the area for golang
 	mkdir -p debian/tmp/__GO_DEST__

--- a/configs/11.0/deb/monolithic/runtime.postinst
+++ b/configs/11.0/deb/monolithic/runtime.postinst
@@ -24,6 +24,8 @@ if [[ "${1}" == configure ]]; then
 	[[ -f __AT_DEST__/sbin/ldconfig ]] && __AT_DEST__/sbin/ldconfig
 fi
 
-systemctl --no-reload preset __AT_VER_REV_INTERNAL__-cachemanager.service \
-    > /dev/null 2>&1 || :
-systemctl restart __AT_VER_REV_INTERNAL__-cachemanager.service
+if [[ "__USE_SYSTEMD__" == "yes" ]]; then
+	systemctl --no-reload preset __AT_VER_REV_INTERNAL__-cachemanager.service \
+	    > /dev/null 2>&1 || :
+	systemctl restart __AT_VER_REV_INTERNAL__-cachemanager.service
+fi

--- a/configs/11.0/distros/ubuntu-16.mk
+++ b/configs/11.0/distros/ubuntu-16.mk
@@ -70,9 +70,10 @@ ifndef AT_DISTRO_REQ_PKGS
     AT_COMMON_PKGS_REQ := zlib1g-dev libncurses5-dev ncurses-term flex bison \
                           texinfo subversion cvs gawk fakeroot debhelper \
                           autoconf rsync curl bc libxml2-utils automake \
-                          dpkg-sig xutils-dev libtool wget
+                          dpkg-sig xutils-dev libtool wget dh-systemd \
+                          pkg-config
     AT_CROSS_PGMS_REQ :=
-    AT_NATIVE_PGMS_REQ := pkg-config /opt/ibm/java-ppc64le-80/jre/bin/java
+    AT_NATIVE_PGMS_REQ := /opt/ibm/java-ppc64le-80/jre/bin/java
     AT_COMMON_PGMS_REQ := git_2.7
     AT_JAVA_VERSIONS := 8
 endif
@@ -81,3 +82,6 @@ endif
 define distro_sanity
     echo "nothing to test here"
 endef
+
+# Inform if the systemd service to monitor the loader cache should be used.
+USE_SYSTEMD := yes

--- a/configs/11.0/distros/ubuntu-16.mk
+++ b/configs/11.0/distros/ubuntu-16.mk
@@ -1,1 +1,83 @@
-../../10.0/distros/ubuntu-16.mk
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Distro dependent basic definitions for Ubuntu 16.04 LTS
+# =======================================================
+# This Makefile include contains the definitions for the distro being used
+# for the build process. It contains kernel version infos and distro specific
+# sanity checks.
+
+# Informs the distro supported power archs
+AT_SUPPORTED_ARCHS := ppc64le
+
+# You may force the BUILD_IGNORE_AT_COMPAT general condition by distro
+#BUILD_IGNORE_AT_COMPAT := yes
+
+# Kernel version to build toolchain against
+# - As this distro only supports one arch variation (ppc64le), there is no
+#   need to conditionally define these versions based on arch.
+AT_KERNEL := 4.4    # Current distro kernel version for runtime.
+# TODO: fill this when our packaging system starts supporting runtime-compat
+# on Ubuntu.
+#AT_OLD_KERNEL :=  # Previous distro kernel version for runtime-compat.
+
+# Inform the mainly supported distros
+AT_SUPPORTED_DISTROS := xenial
+
+# Inform the compatibility supported distros
+#AT_COMPAT_DISTROS :=
+
+# Sign the repository and packages
+#AT_SIGN_PKGS := yes
+#AT_SIGN_REPO := yes
+#AT_SIGN_PKGS_CROSS := no
+#AT_SIGN_REPO_CROSS := yes
+
+# ID of GNUPG key used to sign our packages (main/compat)
+AT_GPG_KEYID := 6976A827
+AT_GPG_KEYIDC := 3052930D
+# ID of GNUPG key used to sign our repositories (main/compat)
+AT_GPG_REPO_KEYID := 3052930D
+AT_GPG_REPO_KEYIDC := 3052930D
+
+# Options required by the command to update the repository metadata
+AT_REPOCMD_OPTS := -p -s sha1 --simple-md-filenames --no-database
+
+# As some distros have special requirements for configuration upon final
+# AT installation, put in this macro, the final configurations required
+# after the main build and prior to the rpm build
+define distro_final_config
+    echo "nothing to do."
+endef
+
+# Inform the list of packages to check
+ifndef AT_DISTRO_REQ_PKGS
+    AT_CROSS_PKGS_REQ :=
+    AT_NATIVE_PKGS_REQ := libxslt libpopt-dev libqt4-dev \
+                          libc6-dev libbz2-dev xsltproc docbook-xsl \
+                          libsqlite3-dev
+    AT_COMMON_PKGS_REQ := zlib1g-dev libncurses5-dev ncurses-term flex bison \
+                          texinfo subversion cvs gawk fakeroot debhelper \
+                          autoconf rsync curl bc libxml2-utils automake \
+                          dpkg-sig xutils-dev libtool wget
+    AT_CROSS_PGMS_REQ :=
+    AT_NATIVE_PGMS_REQ := pkg-config /opt/ibm/java-ppc64le-80/jre/bin/java
+    AT_COMMON_PGMS_REQ := git_2.7
+    AT_JAVA_VERSIONS := 8
+endif
+
+# If needed, define the necessary distro related sanity checks.
+define distro_sanity
+    echo "nothing to test here"
+endef

--- a/configs/6.0/distros/redhat-6.mk
+++ b/configs/6.0/distros/redhat-6.mk
@@ -80,3 +80,6 @@ endif
 define distro_sanity
     echo "nothing to test here"
 endef
+
+# Inform if the systemd service to monitor the loader cache should be used.
+USE_SYSTEMD := no

--- a/configs/6.0/distros/suse-11.mk
+++ b/configs/6.0/distros/suse-11.mk
@@ -80,3 +80,6 @@ endif
 define distro_sanity
     echo "nothing to test here"
 endef
+
+# Inform if the systemd service to monitor the loader cache should be used.
+USE_SYSTEMD := no

--- a/configs/7.0/distros/redhat-6.mk
+++ b/configs/7.0/distros/redhat-6.mk
@@ -81,3 +81,6 @@ endif
 define distro_sanity
     echo "nothing to test here"
 endef
+
+# Inform if the systemd service to monitor the loader cache should be used.
+USE_SYSTEMD := no

--- a/configs/7.0/distros/suse-11.mk
+++ b/configs/7.0/distros/suse-11.mk
@@ -82,3 +82,6 @@ endif
 define distro_sanity
     echo "nothing to test here"
 endef
+
+# Inform if the systemd service to monitor the loader cache should be used.
+USE_SYSTEMD := no

--- a/configs/7.1/distros/redhat-6.mk
+++ b/configs/7.1/distros/redhat-6.mk
@@ -86,3 +86,6 @@ endif
 define distro_sanity
     echo "nothing to test here"
 endef
+
+# Inform if the systemd service to monitor the loader cache should be used.
+USE_SYSTEMD := no

--- a/configs/7.1/distros/redhat-7.mk
+++ b/configs/7.1/distros/redhat-7.mk
@@ -113,3 +113,6 @@ endif
 define distro_sanity
     echo "nothing to test here"
 endef
+
+# Inform if the systemd service to monitor the loader cache should be used.
+USE_SYSTEMD := no

--- a/configs/7.1/distros/suse-11.mk
+++ b/configs/7.1/distros/suse-11.mk
@@ -88,3 +88,6 @@ endif
 define distro_sanity
     echo "nothing to test here"
 endef
+
+# Inform if the systemd service to monitor the loader cache should be used.
+USE_SYSTEMD := no

--- a/configs/7.1/distros/ubuntu-14.mk
+++ b/configs/7.1/distros/ubuntu-14.mk
@@ -81,3 +81,6 @@ endif
 define distro_sanity
     echo "nothing to test here"
 endef
+
+# Inform if the systemd service to monitor the loader cache should be used.
+USE_SYSTEMD := no

--- a/configs/8.0/distros/suse-12.mk
+++ b/configs/8.0/distros/suse-12.mk
@@ -86,3 +86,6 @@ endif
 define distro_sanity
     echo "nothing to test here"
 endef
+
+# Inform if the systemd service to monitor the loader cache should be used.
+USE_SYSTEMD := no

--- a/configs/9.0/distros/fedora-22.mk
+++ b/configs/9.0/distros/fedora-22.mk
@@ -104,3 +104,6 @@ endif
 define distro_sanity
     echo "nothing to test here"
 endef
+
+# Inform if the systemd service to monitor the loader cache should be used.
+USE_SYSTEMD := yes

--- a/configs/9.0/distros/redhat-6.mk
+++ b/configs/9.0/distros/redhat-6.mk
@@ -86,3 +86,6 @@ endif
 define distro_sanity
     echo "nothing to test here"
 endef
+
+# Inform if the systemd service to monitor the loader cache should be used.
+USE_SYSTEMD := no

--- a/configs/9.0/distros/redhat-7.mk
+++ b/configs/9.0/distros/redhat-7.mk
@@ -113,3 +113,6 @@ endif
 define distro_sanity
     echo "nothing to test here"
 endef
+
+# Inform if the systemd service to monitor the loader cache should be used.
+USE_SYSTEMD := yes

--- a/configs/9.0/distros/suse-12.mk
+++ b/configs/9.0/distros/suse-12.mk
@@ -86,3 +86,6 @@ endif
 define distro_sanity
     echo "nothing to test here"
 endef
+
+# Inform if the systemd service to monitor the loader cache should be used.
+USE_SYSTEMD := yes

--- a/configs/9.0/distros/ubuntu-14.mk
+++ b/configs/9.0/distros/ubuntu-14.mk
@@ -81,3 +81,6 @@ endif
 define distro_sanity
     echo "nothing to test here"
 endef
+
+# Inform if the systemd service to monitor the loader cache should be used.
+USE_SYSTEMD := no

--- a/scripts/helpers/utilities.mk
+++ b/scripts/helpers/utilities.mk
@@ -320,6 +320,8 @@ define deb_setenv
     export debh_root=$(DEBH_ROOT); \
     echo "  - Setting debs to $(DEBS)"; \
     export debs="$(DEBS)"; \
+    echo "  - Setting use_systemd to $(USE_SYSTEMD)"; \
+    export use_systemd="$(USE_SYSTEMD)"; \
     echo "* Finished deb env variables."
 endef
 

--- a/scripts/utilities/pkg_build_deb.sh
+++ b/scripts/utilities/pkg_build_deb.sh
@@ -40,7 +40,7 @@ mkdir -p ${deb_d}
 at_version=$(echo ${at_full_ver} | cut -d"." -f 1)
 
 # Set systemd cache manager directories.
-if (( ${at_version} >= 11 )) || [[ "${at_version}" == next ]]; then
+if [[ "${use_systemd}" == "yes" ]]; then
 	cp "${utilities}/cachemanager.service" ${debh_root}/monolithic/
 	systemd_unit=$(pkg-config --variable=systemdsystemunitdir systemd)
 	systemd_preset=$(pkg-config --variable=systemdsystempresetdir systemd)
@@ -80,6 +80,7 @@ for f in *; do
 	    -e "s/__GO_DEST__/${go_dest//\//\\/}/g" \
 	    -e "s/__SYSTEMD_UNIT__/${systemd_unit//\//\\/}/g" \
 	    -e "s/__SYSTEMD_PRESET__/${systemd_preset//\//\\/}/g" \
+	    -e "s/__USE_SYSTEMD__/${use_systemd}/g" \
 	    ${f} > ${deb_d}/${f}
 done
 popd > /dev/null
@@ -234,7 +235,7 @@ for pkg in $(awk '/^Package:/ { print $2 }' ${deb_d}/control | grep -v dbg); do
 				fi
 				;;
 			"runtime")
-				if (( ${at_version} < 11 )); then
+				if [[ "${use_systemd}" != "yes" ]]; then
 					echo "/etc/cron.d/${at_ver_rev_internal//./}_ldconfig"
 				fi
 				[[ ${addtlehelper} == "yes" ]] && \


### PR DESCRIPTION
This patch changes how we choose the mechanism to monitor AT's
loader cache by relying in a variable provided by the distro files.

This fixes the Ubuntu 14.04 build on AT >= 11.0.