### PR TITLE
fvtr: fix package-check execution on cross

### DIFF
--- a/fvtr/package-check/package-check.exp
+++ b/fvtr/package-check/package-check.exp
@@ -126,8 +126,13 @@ proc get_pkg_flavor { package_name } {
 	# Cross compiled packages have different name patterns so that flavor
 	# should be parsed a bit different than native packages.
 	if { [regexp ".*cross.*" ${package_name}] } {
-		if { [regexp ".*-cross-common-.*" ${package_name}] } {
+		if { [regexp ".*-cross-common.*" ${package_name}] } {
 			return "cross_common"
+		}
+
+		if { [regexp ".*-cross-ppc.*\[-_\]${ver_rev}" \
+			     ${package_name}] } {
+			return "cross"
 		}
 
 		if { [regexp ".*-cross-ppc.*-(\\w\+(-\\w\+)?)\[-_\]${ver_rev}" \


### PR DESCRIPTION
Fix 2 issues:
 - The separator between the package name and version in a deb package
   is '_' instead of '-'.  Make the cross-common distro-agnostic.
 - There is a package whose flavor doesn't have a second, i.e. just
   'cross'.  This package needs its own regular expression.

Fixes issue #134.