### PR TITLE
Systemd fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1123,9 +1123,9 @@ $(RCPTS)/monitor.rcpt: $(RCPTS)/toolchain.rcpt
 	    if [[ $(USE_SYSTEMD) == "yes" ]]; then \
 		systemd_unit=$$( pkg-config --variable=systemdsystemunitdir systemd ); \
 		systemd_preset=$$( pkg-config --variable=systemdsystempresetdir systemd ); \
-	        echo "$${systemd_unit}/$(AT_VER_REV_INTERNAL)-cachemanager.service" \
+	        echo "$${systemd_unit}/$${at_ver_rev_internal//./}-cachemanager.service" \
 	             >> $(DYNAMIC_SPEC)/$${group}/ldconfig.filelist; \
-	        echo "$${systemd_preset}/90-atcachemanager.preset" \
+	        echo "$${systemd_preset}/90-at$${at_ver_rev_internal//./}cachemanager.preset" \
 	             >> $(DYNAMIC_SPEC)/$${group}/ldconfig.filelist; \
 	    else \
 		echo "/etc/cron.d/$${at_ver_rev_internal//./}_ldconfig" \

--- a/configs/11.0/deb/monolithic/rules
+++ b/configs/11.0/deb/monolithic/rules
@@ -68,10 +68,10 @@ ifeq (__USE_SYSTEMD__, yes)
 	# Set a systemd service to run AT's ldconfig when the system's \
 	# ldconfig is executed.
 	mkdir -p debian/tmp/__SYSTEMD_UNIT__/
-	mv debian/cachemanager.service debian/tmp/__SYSTEMD_UNIT__/__AT_VER_REV_INTERNAL__-cachemanager.service
+	mv debian/cachemanager.service debian/tmp/__SYSTEMD_UNIT__/__AT_VER_ALTERNATIVE__-cachemanager.service
 	mkdir -p debian/tmp/__SYSTEMD_PRESET__/
 	echo "enable at*cachemanager.service" \
-		> debian/tmp/__SYSTEMD_PRESET__/90-atcachemanager.preset
+		> debian/tmp/__SYSTEMD_PRESET__/90-at__AT_VER_ALTERNATIVE__cachemanager.preset
 else
 	# Set a cronjob to run AT's ldconfig when the system's ldconfig is
 	# executed.

--- a/configs/11.0/deb/monolithic/runtime.postinst
+++ b/configs/11.0/deb/monolithic/runtime.postinst
@@ -25,7 +25,7 @@ if [[ "${1}" == configure ]]; then
 fi
 
 if [[ "__USE_SYSTEMD__" == "yes" ]]; then
-	systemctl --no-reload preset __AT_VER_REV_INTERNAL__-cachemanager.service \
+	systemctl --no-reload preset __AT_VER_ALTERNATIVE__-cachemanager.service \
 	    > /dev/null 2>&1 || :
-	systemctl restart __AT_VER_REV_INTERNAL__-cachemanager.service
+	systemctl restart __AT_VER_ALTERNATIVE__-cachemanager.service
 fi

--- a/configs/11.0/specs/monolithic.spec
+++ b/configs/11.0/specs/monolithic.spec
@@ -191,10 +191,10 @@ systemd_preset=$(pkg-config --variable=systemdsystempresetdir systemd)
 mkdir -p ${RPM_BUILD_ROOT}/${systemd_unit}/
 sed -e s:__AT_VER_REV_INTERNAL__:%{at_ver_rev_internal}: \
     -e s:__AT_DEST__:%{_prefix}: %{_rpmdir}/cachemanager.service \
-    > ${RPM_BUILD_ROOT}/${systemd_unit}/%{at_ver_rev_internal}-cachemanager.service
+    > ${RPM_BUILD_ROOT}/${systemd_unit}/%{at_ver_alternative}-cachemanager.service
 mkdir -p ${RPM_BUILD_ROOT}/${systemd_preset}/
 echo "enable at*cachemanager.service" \
-    > ${RPM_BUILD_ROOT}/${systemd_preset}/90-atcachemanager.preset
+    > ${RPM_BUILD_ROOT}/${systemd_preset}/90-at%{at_ver_alternative}cachemanager.preset
 
 ####################################################
 %pre runtime
@@ -232,9 +232,9 @@ ln -s /etc/localtime %{_prefix}/etc/localtime
 if [[ -f %{_sbindir}/ldconfig ]]; then
     %{_sbindir}/ldconfig
 fi
-systemctl --no-reload preset %{at_ver_rev_internal}-cachemanager.service \
+systemctl --no-reload preset %{at_ver_alternative}-cachemanager.service \
     > /dev/null 2>&1 || :
-systemctl restart %{at_ver_rev_internal}-cachemanager.service
+systemctl restart %{at_ver_alternative}-cachemanager.service
 
 #---------------------------------------------------
 %post devel
@@ -354,7 +354,7 @@ fi
 ####################################################
 %preun runtime
 systemctl --no-reload disable --now \
-    %{at_ver_rev_internal}-cachemanager.service > /dev/null 2>&1 || :
+    %{at_ver_alternative}-cachemanager.service > /dev/null 2>&1 || :
 
 ####################################################
 %postun runtime
@@ -372,7 +372,7 @@ if file /usr/sbin/ldconfig | grep "bash script" > /dev/null; then
         rm -f /usr/sbin/ldconfig
     fi
 fi
-systemctl try-restart %{at_ver_rev_internal}-cachemanager.service >/dev/null \
+systemctl try-restart %{at_ver_alternative}-cachemanager.service >/dev/null \
     2>&1 || :
 
 #---------------------------------------------------

--- a/configs/9.0/specs/monolithic.spec
+++ b/configs/9.0/specs/monolithic.spec
@@ -191,10 +191,10 @@ systemd_preset=$(pkg-config --variable=systemdsystempresetdir systemd)
 mkdir -p ${RPM_BUILD_ROOT}/${systemd_unit}/
 sed -e s:__AT_VER_REV_INTERNAL__:%{at_ver_rev_internal}: \
     -e s:__AT_DEST__:%{_prefix}: %{_rpmdir}/cachemanager.service \
-    > ${RPM_BUILD_ROOT}/${systemd_unit}/%{at_ver_rev_internal}-cachemanager.service
+    > ${RPM_BUILD_ROOT}/${systemd_unit}/%{at_ver_alternative}-cachemanager.service
 mkdir -p ${RPM_BUILD_ROOT}/${systemd_preset}/
 echo "enable at*cachemanager.service" \
-    > ${RPM_BUILD_ROOT}/${systemd_preset}/90-atcachemanager.preset
+    > ${RPM_BUILD_ROOT}/${systemd_preset}/90-at%{at_ver_alternative}cachemanager.preset
 
 ####################################################
 %pre runtime
@@ -232,9 +232,9 @@ ln -s /etc/localtime %{_prefix}/etc/localtime
 if [[ -f %{_sbindir}/ldconfig ]]; then
     %{_sbindir}/ldconfig
 fi
-systemctl --no-reload preset %{at_ver_rev_internal}-cachemanager.service \
+systemctl --no-reload preset %{at_ver_alternative}-cachemanager.service \
     > /dev/null 2>&1 || :
-systemctl restart %{at_ver_rev_internal}-cachemanager.service
+systemctl restart %{at_ver_alternative}-cachemanager.service
 
 #---------------------------------------------------
 %post devel
@@ -338,7 +338,7 @@ fi
 ####################################################
 %preun runtime
 systemctl --no-reload disable --now \
-    %{at_ver_rev_internal}-cachemanager.service > /dev/null 2>&1 || :
+    %{at_ver_alternative}-cachemanager.service > /dev/null 2>&1 || :
 
 ####################################################
 %postun runtime
@@ -356,7 +356,7 @@ if file /usr/sbin/ldconfig | grep "bash script" > /dev/null; then
         rm -f /usr/sbin/ldconfig
     fi
 fi
-systemctl try-restart %{at_ver_rev_internal}-cachemanager.service >/dev/null \
+systemctl try-restart %{at_ver_alternative}-cachemanager.service >/dev/null \
     2>&1 || :
 
 #---------------------------------------------------


### PR DESCRIPTION
This patch changes the names of the systemd files to avoid name clash
and work in all environments.

This PR depends on PR #133.
