### PR TITLE
Fixes to the cache manager mechanism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1125,7 +1125,7 @@ $(RCPTS)/monitor.rcpt: $(RCPTS)/toolchain.rcpt
 		systemd_preset=$$( pkg-config --variable=systemdsystempresetdir systemd ); \
 	        echo "$${systemd_unit}/$${at_ver_rev_internal//./}-cachemanager.service" \
 	             >> $(DYNAMIC_SPEC)/$${group}/ldconfig.filelist; \
-	        echo "$${systemd_preset}/90-at$${at_ver_rev_internal//./}cachemanager.preset" \
+	        echo "$${systemd_preset}/90-$${at_ver_rev_internal//./}cachemanager.preset" \
 	             >> $(DYNAMIC_SPEC)/$${group}/ldconfig.filelist; \
 	    else \
 		echo "/etc/cron.d/$${at_ver_rev_internal//./}_ldconfig" \

--- a/configs/10.0/deb/monolithic/rules
+++ b/configs/10.0/deb/monolithic/rules
@@ -63,6 +63,7 @@ binary-cp: build
 	mkdir -p debian/tmp/etc/cron.d/
 	echo "@reboot root __AT_DEST__/bin/watch_ldconfig &" \
 	      > debian/tmp/etc/cron.d/__AT_VER_ALTERNATIVE___ldconfig
+	chmod 644 debian/tmp/etc/cron.d/__AT_VER_ALTERNATIVE___ldconfig
 	gzip -9nvf debian/tmp/__AT_DEST__/share/info/*.info*
 	# Prepare the area for golang
 	mkdir -p debian/tmp/__GO_DEST__

--- a/configs/11.0/deb/monolithic/rules
+++ b/configs/11.0/deb/monolithic/rules
@@ -70,14 +70,15 @@ ifeq (__USE_SYSTEMD__, yes)
 	mkdir -p debian/tmp/__SYSTEMD_UNIT__/
 	mv debian/cachemanager.service debian/tmp/__SYSTEMD_UNIT__/__AT_VER_ALTERNATIVE__-cachemanager.service
 	mkdir -p debian/tmp/__SYSTEMD_PRESET__/
-	echo "enable at*cachemanager.service" \
-		> debian/tmp/__SYSTEMD_PRESET__/90-at__AT_VER_ALTERNATIVE__cachemanager.preset
+	echo "enable __AT_VER_ALTERNATIVE__-cachemanager.service" \
+		> debian/tmp/__SYSTEMD_PRESET__/90-__AT_VER_ALTERNATIVE__cachemanager.preset
 else
 	# Set a cronjob to run AT's ldconfig when the system's ldconfig is
 	# executed.
 	mkdir -p debian/tmp/etc/cron.d/
 	echo "@reboot root __AT_DEST__/bin/watch_ldconfig &" \
 	      > debian/tmp/etc/cron.d/__AT_VER_ALTERNATIVE___ldconfig
+	chmod 644 debian/tmp/etc/cron.d/__AT_VER_ALTERNATIVE___ldconfig
 endif
 	gzip -9nvf debian/tmp/__AT_DEST__/share/info/*.info*
 	# Prepare the area for golang

--- a/configs/11.0/deb/monolithic/runtime.postinst
+++ b/configs/11.0/deb/monolithic/runtime.postinst
@@ -27,5 +27,10 @@ fi
 if [[ "__USE_SYSTEMD__" == "yes" ]]; then
 	systemctl --no-reload preset __AT_VER_ALTERNATIVE__-cachemanager.service \
 	    > /dev/null 2>&1 || :
-	systemctl restart __AT_VER_ALTERNATIVE__-cachemanager.service
+	systemctl restart __AT_VER_ALTERNATIVE__-cachemanager.service || \
+	    echo -e " Failed to start __AT_VER_ALTERNATIVE__-cachemanager.service.\n \
+AT's linker cache file is not automatically updated when a package is \
+installed or modified.\n \
+Please run __AT_DEST__/bin/watch_ldconfig if you want it to be."
+
 fi

--- a/configs/11.0/specs/monolithic.spec
+++ b/configs/11.0/specs/monolithic.spec
@@ -193,8 +193,8 @@ sed -e s:__AT_VER_REV_INTERNAL__:%{at_ver_rev_internal}: \
     -e s:__AT_DEST__:%{_prefix}: %{_rpmdir}/cachemanager.service \
     > ${RPM_BUILD_ROOT}/${systemd_unit}/%{at_ver_alternative}-cachemanager.service
 mkdir -p ${RPM_BUILD_ROOT}/${systemd_preset}/
-echo "enable at*cachemanager.service" \
-    > ${RPM_BUILD_ROOT}/${systemd_preset}/90-at%{at_ver_alternative}cachemanager.preset
+echo "enable %{at_ver_alternative}-cachemanager.service" \
+    > ${RPM_BUILD_ROOT}/${systemd_preset}/90-%{at_ver_alternative}cachemanager.preset
 
 ####################################################
 %pre runtime

--- a/configs/6.0/specs/monolithic.spec
+++ b/configs/6.0/specs/monolithic.spec
@@ -134,6 +134,7 @@ gzip -9nvf ${RPM_BUILD_ROOT}%{_infodir}/*.info*
 mkdir -p ${RPM_BUILD_ROOT}/etc/cron.d/
 echo "@reboot root %{_bindir}/watch_ldconfig &" \
       > ${RPM_BUILD_ROOT}/etc/cron.d/%{at_ver_alternative}_ldconfig
+chmod 644 ${RPM_BUILD_ROOT}/etc/cron.d/%{at_ver_alternative}_ldconfig
 
 ####################################################
 %pre runtime

--- a/configs/7.1/deb/monolithic/rules
+++ b/configs/7.1/deb/monolithic/rules
@@ -57,6 +57,7 @@ binary-cp: build
 	mkdir -p debian/tmp/etc/cron.d/
 	echo "@reboot root __AT_DEST__/bin/watch_ldconfig &" \
 	      > debian/tmp/etc/cron.d/__AT_VER_ALTERNATIVE___ldconfig
+	chmod 644 debian/tmp/etc/cron.d/__AT_VER_ALTERNATIVE___ldconfig
 	gzip -9nvf debian/tmp/__AT_DEST__/share/info/*.info*
 
 binary: binary-indep binary-arch

--- a/configs/8.0/specs/monolithic.spec
+++ b/configs/8.0/specs/monolithic.spec
@@ -120,6 +120,7 @@ gzip -9nvf ${RPM_BUILD_ROOT}%{_infodir}/*.info*
 mkdir -p ${RPM_BUILD_ROOT}/etc/cron.d/
 echo "@reboot root %{_bindir}/watch_ldconfig &" \
       > ${RPM_BUILD_ROOT}/etc/cron.d/%{at_ver_alternative}_ldconfig
+chmod 644 ${RPM_BUILD_ROOT}/etc/cron.d/%{at_ver_alternative}_ldconfig
 
 ####################################################
 %pre runtime

--- a/configs/9.0/deb/monolithic/rules
+++ b/configs/9.0/deb/monolithic/rules
@@ -63,6 +63,7 @@ binary-cp: build
 	mkdir -p debian/tmp/etc/cron.d/
 	echo "@reboot root __AT_DEST__/bin/watch_ldconfig &" \
 	      > debian/tmp/etc/cron.d/__AT_VER_ALTERNATIVE___ldconfig
+	chmod 644 debian/tmp/etc/cron.d/__AT_VER_ALTERNATIVE___ldconfig
 	gzip -9nvf debian/tmp/__AT_DEST__/share/info/*.info*
 	# Prepare the area for golang
 	mkdir -p debian/tmp/__GO_DEST__

--- a/configs/9.0/specs/monolithic.spec
+++ b/configs/9.0/specs/monolithic.spec
@@ -193,8 +193,8 @@ sed -e s:__AT_VER_REV_INTERNAL__:%{at_ver_rev_internal}: \
     -e s:__AT_DEST__:%{_prefix}: %{_rpmdir}/cachemanager.service \
     > ${RPM_BUILD_ROOT}/${systemd_unit}/%{at_ver_alternative}-cachemanager.service
 mkdir -p ${RPM_BUILD_ROOT}/${systemd_preset}/
-echo "enable at*cachemanager.service" \
-    > ${RPM_BUILD_ROOT}/${systemd_preset}/90-at%{at_ver_alternative}cachemanager.preset
+echo "enable %{at_ver_alternative}-cachemanager.service" \
+    > ${RPM_BUILD_ROOT}/${systemd_preset}/90-%{at_ver_alternative}cachemanager.preset
 
 ####################################################
 %pre runtime


### PR DESCRIPTION
This patch changes to 644 the mode of the cron file because in some
systems the script doesn't run with 664 permissions.
It also removes the redundancy of the systemd preset file name and
specify the version that the file enables.
Lastly, now the ubuntu packages don't fail in the post install if
the systemd service doesn't start by an unexpected behaviour like
what happens on docker.
This fixes #145 and #132.

Signed-off-by: Raphael Moreira Zinsly <rzinsly@linux.vnet.ibm.com>