### PR TITLE
Update glibc for AT 11.0

### DIFF
--- a/configs/11.0/packages/glibc/sources
+++ b/configs/11.0/packages/glibc/sources
@@ -21,7 +21,7 @@
 
 ATSRC_PACKAGE_NAME="GNU C Library"
 ATSRC_PACKAGE_VER=2.26
-ATSRC_PACKAGE_REV=63efe9a47f4c
+ATSRC_PACKAGE_REV=c9df582f3a4e
 ATSRC_PACKAGE_LICENSE="LGPL 2.1"
 ATSRC_PACKAGE_DOCLINK="http://www.gnu.org/software/libc/manual/html_node/index.html"
 ATSRC_PACKAGE_RELFIXES=
@@ -47,19 +47,11 @@ atsrc_get_patches ()
 		https://raw.githubusercontent.com/powertechpreview/powertechpreview/26747dc0bfb0f8f30de9ebad78847a96d3191ba5/GLIBC%20PowerPC%20Backport/2.22/0001-powerpc-Conditionally-enable-TLE.patch \
 		801c05ea780220e8b4cf931af8c86946 || return ${?}
 
-	# TODO: Remove this patch when the following patch gets merged.
-	# https://patchwork.sourceware.org/patch/21557/
-	at_get_patch_and_trim \
-		https://patchwork.sourceware.org/patch/21557/mbox/ \
-		fastbin.patch 0 \
-		e743ef9329de65631742831c886bf121 || return ${?}
-
 }
 
 atsrc_apply_patches ()
 {
 	patch -p1 < 0001-powerpc-Conditionally-enable-TLE.patch || return ${?}
 
-	patch -p1 < fastbin.patch || return ${?}
 	return 0
 }


### PR DESCRIPTION
This commit updates glibc for AT 11.0.  Since the upstream branch has
integrated (commit ID c55ad6452e2d) the fix for the malloc warning with
GCC 7 and -O3, this commit also drops the patch from the sources file.

Signed-off-by: Gabriel F. T. Gomes <gftg@linux.vnet.ibm.com>