### PR TITLE
Update glibc on AT Next

### DIFF
--- a/configs/next/packages/glibc/sources
+++ b/configs/next/packages/glibc/sources
@@ -21,7 +21,7 @@
 
 ATSRC_PACKAGE_NAME="GNU C Library"
 ATSRC_PACKAGE_VER=2.26
-ATSRC_PACKAGE_REV=5f3b183d198b
+ATSRC_PACKAGE_REV=c5c4a626098e
 ATSRC_PACKAGE_LICENSE="LGPL 2.1"
 ATSRC_PACKAGE_DOCLINK="http://www.gnu.org/software/libc/manual/html_node/index.html"
 ATSRC_PACKAGE_RELFIXES=
@@ -52,24 +52,6 @@ atsrc_get_patches ()
 		https://raw.githubusercontent.com/powertechpreview/powertechpreview/26747dc0bfb0f8f30de9ebad78847a96d3191ba5/GLIBC%20PowerPC%20Backport/2.22/0001-powerpc-Conditionally-enable-TLE.patch \
 		801c05ea780220e8b4cf931af8c86946 || return ${?}
 
-	# Fixes for gcc enabling -mfloat128 by default
-	at_get_patch \
-		https://patchwork.sourceware.org/patch/22817/mbox/ \
-		4a569f5e746b197fed3d1610e5e9760c \
-		mfloat128-1.patch || return ${?}
-	at_get_patch \
-		https://patchwork.sourceware.org/patch/22818/mbox/ \
-		b3af16d8fca7fe567038ed494a34200c \
-		mfloat128-2.patch || return ${?}
-	at_get_patch \
-		https://patchwork.sourceware.org/patch/22820/mbox/ \
-		d4d3b74471e5b3dc98317be499b987a4 \
-		mfloat128-3.patch || return ${?}
-	at_get_patch \
-		https://patchwork.sourceware.org/patch/22821/mbox/ \
-		5380f208dbf7838475124b1729b01a0c \
-		mfloat128-4.patch || return ${?}
-
 }
 
 atsrc_apply_patches ()
@@ -77,11 +59,6 @@ atsrc_apply_patches ()
 	patch -p1 < 0001-Remove-assert-if-DT_RUNPATH-and-DT_RPATH-flags-are-f.patch || return ${?}
 
 	patch -p1 < 0001-powerpc-Conditionally-enable-TLE.patch || return ${?}
-
-	patch -p1 < mfloat128-1.patch || return ${?}
-	patch -p1 < mfloat128-2.patch || return ${?}
-	patch -p1 < mfloat128-3.patch || return ${?}
-	patch -p1 < mfloat128-4.patch || return ${?}
 
 	return 0
 }


### PR DESCRIPTION
This PR removes the patches for -mfloat128 from AT Next.
Tested on Ubuntu 16.04.
