### PR TITLE
Update Expat on AT 9.0.

### DIFF
--- a/configs/10.0/packages/expat/stage_1
+++ b/configs/10.0/packages/expat/stage_1
@@ -1,1 +1,1 @@
-../../../9.0/packages/expat/stage_1
+../../../8.0/packages/expat/stage_1

--- a/configs/9.0/packages/expat/sources
+++ b/configs/9.0/packages/expat/sources
@@ -20,15 +20,17 @@
 #
 
 ATSRC_PACKAGE_NAME="Expat XML Parser"
-ATSRC_PACKAGE_VER=2.1.0
-ATSRC_PACKAGE_DOCLINK="http://www.xml.com/pub/a/1999/09/expat/index.html"
+ATSRC_PACKAGE_VER=2.1.1
+ATSRC_PACKAGE_REV=ee0adc0d9d245
+ATSRC_PACKAGE_DOCLINK="https://libexpat.github.io/doc/"
 ATSRC_PACKAGE_RELFIXES=
-ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}"
+ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
+ATSRC_PACKAGE_VERID="${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
 ATSRC_PACKAGE_LICENSE="MIT License"
-ATSRC_PACKAGE_PRE="test -d expat-${ATSRC_PACKAGE_VER}"
-ATSRC_PACKAGE_CO=([0]="wget -N https://downloads.sourceforge.net/project/expat/expat/${ATSRC_PACKAGE_VER}/expat-${ATSRC_PACKAGE_VER}.tar.gz")
-ATSRC_PACKAGE_POST="tar -xzf expat-${ATSRC_PACKAGE_VER}.tar.gz"
-ATSRC_PACKAGE_SRC=${AT_BASE}/sources/expat-${ATSRC_PACKAGE_VER}
+ATSRC_PACKAGE_PRE="test -d expat-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
+ATSRC_PACKAGE_CO=([0]="wget -O expat-${ATSRC_PACKAGE_VERID}.tar.gz https://github.com/libexpat/libexpat/archive/${ATSRC_PACKAGE_REV}.tar.gz")
+ATSRC_PACKAGE_POST="tar xzf expat-${ATSRC_PACKAGE_VERID}.tar.gz --wildcards --strip=2 libexpat-${ATSRC_PACKAGE_REV}[^\\/]*/expat --transform=s:libexpat-${ATSRC_PACKAGE_REV}[^\\/]*/expat:libexpat-${ATSRC_PACKAGE_REV}[^\\/]*/expat-${ATSRC_PACKAGE_VERID}:"
+ATSRC_PACKAGE_SRC=${AT_BASE}/sources/expat-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}
 ATSRC_PACKAGE_WORK=${AT_WORK_PATH}/expat
 ATSRC_PACKAGE_MLS=
 ATSRC_PACKAGE_PATCHES=
@@ -40,12 +42,45 @@ ATSRC_PACKAGE_BUNDLE=main_toolchain
 
 atsrc_get_patches ()
 {
-        at_get_patch \
-	https://hg.mozilla.org/releases/mozilla-esr31/raw-diff/2f3e78643f5c/parser/expat/lib/xmlparse.c \
-	978566c4144504d170869619661fbd7d || return ${?}
+	# Delete Makefile that generates man
+	at_get_patch \
+		https://github.com/racardoso/libexpat/commit/a6bb3358ddae.patch \
+		bc61e4806ae531941b652bb56abb3249 || return ${?}
+
+	# Added man pages
+	at_get_patch \
+		https://github.com/racardoso/libexpat/commit/f1a8200593de.patch \
+		0c71eb2bb1b6750a96c3c5181f67de3e || return ${?}
+
+	#Fix CVE-2012-6702 and CVE-2016-5300
+	at_get_patch \
+		https://github.com/racardoso/libexpat/commit/95dbdf173f19.patch \
+		ea1a061d504d47aa726d09dc639db1fa || return ${?}
+
+	#Fix CVE-2016-4472
+	at_get_patch \
+		https://github.com/racardoso/libexpat/commit/ca78e04e3e67.patch \
+		413e2b92eb8b6b35b8e22a1f56a2421e || return ${?}
+
+	#Fix CVE-2016-0718
+	at_get_patch \
+		https://github.com/racardoso/libexpat/commit/be940daed613.patch \
+		1bd7c8c0414bd0a6f13acae171118adf || return ${?}
+
+	#Fix CVE-2016-9063 and CVE-2017-9233
+	at_get_patch \
+		https://github.com/racardoso/libexpat/commit/a39744e4ec1e.patch \
+		50c236fd76f8868a48468faff968fc9f || return ${?}
 }
 
 atsrc_apply_patches ()
 {
-	patch -p3 < xmlparse.c || return ${?}
+	patch -p2 < a6bb3358ddae.patch || return ${?}
+	patch -p2 < f1a8200593de.patch || return ${?}
+	patch -p2 < 95dbdf173f19.patch || return ${?}
+	patch -p2 < ca78e04e3e67.patch || return ${?}
+	patch -p2 < be940daed613.patch || return ${?}
+	patch -p2 < a39744e4ec1e.patch || return ${?}
+
+	return 0
 }

--- a/configs/9.0/packages/expat/sources
+++ b/configs/9.0/packages/expat/sources
@@ -44,43 +44,43 @@ atsrc_get_patches ()
 {
 	# Delete Makefile that generates man
 	at_get_patch \
-		https://github.com/racardoso/libexpat/commit/a6bb3358ddae.patch \
+		https://raw.githubusercontent.com/powertechpreview/powertechpreview/68e9163b4022/Expat%20Patches/Delete-makefile-for-at9.0.patch \
 		bc61e4806ae531941b652bb56abb3249 || return ${?}
 
 	# Added man pages
 	at_get_patch \
-		https://github.com/racardoso/libexpat/commit/f1a8200593de.patch \
+		https://raw.githubusercontent.com/powertechpreview/powertechpreview/68e9163b4022/Expat%20Patches/Manualy-add-man-on-at9.0.patch \
 		0c71eb2bb1b6750a96c3c5181f67de3e || return ${?}
 
 	#Fix CVE-2012-6702 and CVE-2016-5300
 	at_get_patch \
-		https://github.com/racardoso/libexpat/commit/95dbdf173f19.patch \
+		https://raw.githubusercontent.com/powertechpreview/powertechpreview/68e9163b4022/Expat%20Patches/Fix-CVE-2012-6702-CVE-2016-5300-Expat-2.1.1.patch \
 		ea1a061d504d47aa726d09dc639db1fa || return ${?}
 
 	#Fix CVE-2016-4472
 	at_get_patch \
-		https://github.com/racardoso/libexpat/commit/ca78e04e3e67.patch \
+		https://raw.githubusercontent.com/powertechpreview/powertechpreview/68e9163b4022/Expat%20Patches/Fix-CVE-2016-4472-Expat-2.1.1.patch \
 		413e2b92eb8b6b35b8e22a1f56a2421e || return ${?}
 
 	#Fix CVE-2016-0718
 	at_get_patch \
-		https://github.com/racardoso/libexpat/commit/be940daed613.patch \
+		https://raw.githubusercontent.com/powertechpreview/powertechpreview/68e9163b4022/Expat%20Patches/Fix-CVE-2016-0718-Expat.2.1.1.patch \
 		1bd7c8c0414bd0a6f13acae171118adf || return ${?}
 
 	#Fix CVE-2016-9063 and CVE-2017-9233
 	at_get_patch \
-		https://github.com/racardoso/libexpat/commit/a39744e4ec1e.patch \
+		https://raw.githubusercontent.com/powertechpreview/powertechpreview/68e9163b4022/Expat%20Patches/Fix-CVE-2016-9063-CVE-2017-9233-Expat-2.1.1.patch \
 		50c236fd76f8868a48468faff968fc9f || return ${?}
 }
 
 atsrc_apply_patches ()
 {
-	patch -p2 < a6bb3358ddae.patch || return ${?}
-	patch -p2 < f1a8200593de.patch || return ${?}
-	patch -p2 < 95dbdf173f19.patch || return ${?}
-	patch -p2 < ca78e04e3e67.patch || return ${?}
-	patch -p2 < be940daed613.patch || return ${?}
-	patch -p2 < a39744e4ec1e.patch || return ${?}
+	patch -p2 < Delete-makefile-for-at9.0.patch || return ${?}
+	patch -p2 < Manualy-add-man-on-at9.0.patch || return ${?}
+	patch -p2 < Fix-CVE-2012-6702-CVE-2016-5300-Expat-2.1.1.patch || return ${?}
+	patch -p2 < Fix-CVE-2016-4472-Expat-2.1.1.patch || return ${?}
+	patch -p2 < Fix-CVE-2016-0718-Expat.2.1.1.patch || return ${?}
+	patch -p2 < Fix-CVE-2016-9063-CVE-2017-9233-Expat-2.1.1.patch || return ${?}
 
 	return 0
 }

--- a/configs/9.0/packages/expat/stage_1
+++ b/configs/9.0/packages/expat/stage_1
@@ -1,1 +1,98 @@
-../../../8.0/packages/expat/stage_1
+#!/usr/bin/env bash
+#
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Expat build parameters for stage 1
+# =========================================
+#
+
+ATCFG_HOLD_TEMP_INSTALL='no'
+ATCFG_HOLD_TEMP_BUILD='no'
+# Build in a new directory.
+ATCFG_BUILD_STAGE_T='link'
+# Don't fail if stage final install place doesn't exist
+if [[ "${cross_build}" == "yes" ]]; then
+	ATCFG_INSTALL_PEDANTIC="no"
+fi
+
+atcfg_pre_configure() {
+	# Completely clean the build prior any build.
+	if [[ -e "Makefile" ]]; then
+		make extraclean
+	fi
+
+	# Reconfigure the build with the buildconf.
+	if [[ -e ./buildconf.sh ]]; then
+		sh ./buildconf.sh || exit 1
+	else
+		aclocal
+		automake --add-missing 2>/dev/null || true
+		autoreconf -fvi
+		# Toss this; it gets created by autoconf on some systems
+		rm -rf autom4te*.cache
+	fi
+}
+
+atcfg_configure() {
+	# Expat is built for the same architecture GDB is built to.
+	# Which means that in a cross compiler build it's build for the host
+	# architecture (i.e. i686) instead of the target arch (i.e. ppc64).
+
+	if [[ "${cross_build}" == "no" ]]; then
+		# Default values for native builds.
+		cc_path="${at_dest}/bin/gcc -m${compiler}"
+		libdir="${at_dest}/lib${compiler##32}"
+		prefix=${at_dest}
+	else
+		# Cross compiler settings.
+		cc_path=${system_cc}
+		libdir="${tmp_dir}/lib"
+		prefix=${tmp_dir}
+	fi
+
+	PATH=${at_dest}/bin:${PATH} \
+	CC="${cc_path}" \
+	CFLAGS="-g -O3" CXXFLAGS="-g -O3" \
+
+	./configure \
+		--build=${host} \
+		--host=${host} \
+		--prefix=${prefix} \
+		--exec-prefix=${prefix} \
+		--libdir="${libdir}" \
+		--bindir="${prefix}/bin" \
+		--mandir="${prefix}/share/man" \
+		--disable-shared
+}
+
+
+atcfg_make() {
+	PATH=${at_dest}/bin:${PATH} ${SUB_MAKE}
+}
+
+
+atcfg_install() {
+	if [[ "${cross_build}" == "no" ]]; then
+		PATH=${at_dest}/bin:${PATH} \
+		${SUB_MAKE} install DESTDIR=${install_place}
+	else
+		# In order to install the package at $prefix, we need to force
+		# DESTDIR value. Because if AT was built using DESTDIR, the
+		# value will be stored in MFLAGS.
+		PATH=${at_dest}/bin:${PATH} \
+		${SUB_MAKE} install DESTDIR=""
+	fi
+}


### PR DESCRIPTION
Update Expat to version 2.1.1 on AT 9.0 (Issues #148 and #84).
CVE fixes backported:

CVE-2012-6702
CVE-2016-5300
CVE-2016-4472
CVE-2016-0718
CVE-2016-9063
CVE-2017-9233

Signed-off-by: Rogerio Alves Cardoso <rcardoso@linux.vnet.ibm.com>