### PR TITLE
Fix python test case failures on AT next

### DIFF
--- a/configs/11.0/packages/python/sources
+++ b/configs/11.0/packages/python/sources
@@ -49,12 +49,18 @@ atsrc_get_patches ()
 	at_get_patch \
 		http://pkgs.fedoraproject.org/cgit/rpms/python3.git/plain/00273-skip-float-test.patch \
 		a1cb79875e6c2633222dc95910e59ab8 || return ${?}
+
+	# Fix for test_ssl
+	at_get_patch \
+		https://raw.githubusercontent.com/powertechpreview/powertechpreview/93548fdd0ae7740f7a6158ced0ebdbd5a125bacf/Python%20Fixes/python-3.6.3-reseed_openssl_after_fork.patch \
+		2d8bd979783852a291ad5b916f845202 || return ${?}
 }
 
 atsrc_apply_patches ()
 {
 	patch -p1 < python-3.6.0-getlib64s1.patch || return ${?}
 	patch -p1 < 00273-skip-float-test.patch || return ${?}
+	patch -p1 < python-3.6.3-reseed_openssl_after_fork.patch || return ${?}
 }
 
 atsrc_package_verify_make_log ()

--- a/configs/11.0/packages/python/sources
+++ b/configs/11.0/packages/python/sources
@@ -20,7 +20,7 @@
 #
 
 ATSRC_PACKAGE_NAME="Python"
-ATSRC_PACKAGE_VER=3.6.1
+ATSRC_PACKAGE_VER=3.6.3
 ATSRC_PACKAGE_LICENSE="Python Software Foundation License 2"
 ATSRC_PACKAGE_DOCLINK="https://docs.python.org/3.6/"
 ATSRC_PACKAGE_RELFIXES=
@@ -44,12 +44,6 @@ atsrc_get_patches ()
 		https://raw.githubusercontent.com/powertechpreview/powertechpreview/e9bebfe3c94e612fc348cbab3183a771247ad8b2/Python%20Fixes/python-3.6.0-getlib64s1.patch \
 		c46ccb4d8f043da9966bbce62ae8b9e5 || return ${?}
 
-	# Fix Python issue https://bugs.python.org/issue30714
-	at_get_patch_and_trim \
-		https://github.com/python/cpython/commit/7b40cb7293cb14e5c7c8ed123efaf9acb33edae2.patch \
-		issue30714.patch 0 \
-		0f55c13d34f14cb2645e60f8c70d3926 || return ${?}
-
 	# Skip test_float_with_comma, it is failing since glibc commit ID
 	# 70a6707.
 	at_get_patch \
@@ -60,7 +54,6 @@ atsrc_get_patches ()
 atsrc_apply_patches ()
 {
 	patch -p1 < python-3.6.0-getlib64s1.patch || return ${?}
-	patch -p1 < issue30714.patch || return ${?}
 	patch -p1 < 00273-skip-float-test.patch || return ${?}
 }
 


### PR DESCRIPTION
The test case, test_ssl, in python was failing two subtests: test_multiprocessing_forkserver and
test_random_fork.  This pull requests fixes them.

Tested for SLES 12, Ubuntu 14.04, and Ubuntu 16.04 (Should fix the CI failures).