### PR TITLE
fvtr: Ignore ck_tuned on AT <= 6.0

### DIFF
--- a/fvtr/ck_tuned/ck_tuned.exp
+++ b/fvtr/ck_tuned/ck_tuned.exp
@@ -12,6 +12,11 @@ set libs {libc.so libcrypto.so libdfp.so libgcc_s.so libz.so}
 set rc 0
 set libs2 {}
 
+if { [regexp "5\..*|6\..*" $env(AT_MAJOR_VERSION)] } {
+	printit "Tuned libraries had different settings prior to AT 7.0."
+	exit $ENOSYS
+}
+
 if { $env(AT_CROSS_BUILD) == "yes" } {
 	printit "AT doesn't distribute tuned libraries in the cross compiler."
 	exit ${ENOSYS}


### PR DESCRIPTION
AT <= 6.0 didn't use  to provide tuned libraries.

Signed-off-by: Tulio Magno Quites Machado Filho <tuliom@linux.vnet.ibm.com>