### PR TITLE
remote-build: improve error check when cleaning files

### DIFF
--- a/remote-build.exp
+++ b/remote-build.exp
@@ -228,24 +228,15 @@ foreach server $servers {
 	}
 
 	# Remove files from old builds
-	send "test -x remake.sh; echo $?\n"
+	send "test -x remake.sh && ./remake.sh clean\n"
 	expect {
-		"1" { }
-		"0" {
-			flush_expect
-
-			send "./remake.sh clean\n"
-			expect {
-				-re $prompt { }
-				# Some servers are very slow and require a lot
-				# of time to clean a previous build.
-				-timeout 600 default {
-					send_user "Failed to clean a previous build.\n"
-					exit 1
-				}
-			}
+		-re $prompt { }
+		# Some servers are very slow and require a lot
+		# of time to clean a previous build.
+		-timeout 600 default {
+			send_user "Failed to clean a previous build.\n"
+			exit 1
 		}
-		-re ${prompt} { }
 	}
 
 	flush_expect


### PR DESCRIPTION
On some distros, the check for the availability of remake.sh was
returning false even if the file was there, causing unexpected build
behavior.

This patch uses the shell from the remote system to validate if
remake.sh is available and run remake.sh clean without requiring extra
expect code.

Signed-off-by: Tulio Magno Quites Machado Filho <tuliom@linux.vnet.ibm.com>