### PR TITLE
Update Python on AT 9.0.

### DIFF
--- a/configs/9.0/packages/python/sources
+++ b/configs/9.0/packages/python/sources
@@ -20,7 +20,7 @@
 #
 
 ATSRC_PACKAGE_NAME="Python"
-ATSRC_PACKAGE_VER=3.4.6
+ATSRC_PACKAGE_VER=3.4.7
 ATSRC_PACKAGE_LICENSE="Python Software Foundation License 2"
 ATSRC_PACKAGE_DOCLINK="http://docs.python.org/release/3.4/"
 ATSRC_PACKAGE_RELFIXES=


### PR DESCRIPTION
Update Python to version 3.4.7 on AT 9.0 (#177).

Signed-off-by: Rogerio Alves <rcardoso@linux.vnet.ibm.com>