### PR TITLE
Fix for remake when just building .debs

### DIFF
--- a/scripts/utilities/pkg_build_deb.sh
+++ b/scripts/utilities/pkg_build_deb.sh
@@ -35,6 +35,8 @@ remove_compat ()
 	mv ${deb_d}/control.tmp ${deb_d}/control
 }
 
+# Clean the debhelper tree
+rm -rf "${deb_d}"
 mkdir -p ${deb_d}
 
 at_version=$(echo ${at_full_ver} | cut -d"." -f 1)


### PR DESCRIPTION
remake.sh was tripping over existing content in the debhelper
directory.  Clearing that directory before populating it allows
remake to succeed.

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>