### PR TITLE
Remove local patch from expat on AT Next

### DIFF
--- a/configs/next/packages/expat/sources
+++ b/configs/next/packages/expat/sources
@@ -21,7 +21,7 @@
 
 ATSRC_PACKAGE_NAME="Expat XML Parser"
 ATSRC_PACKAGE_VER="2.2.5"
-ATSRC_PACKAGE_REV=025edea25270
+ATSRC_PACKAGE_REV=86cbbb2e748f
 ATSRC_PACKAGE_DOCLINK="https://libexpat.github.io/doc/"
 ATSRC_PACKAGE_RELFIXES=
 ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
@@ -40,18 +40,3 @@ ATSRC_PACKAGE_TARS=
 ATSRC_PACKAGE_MAKE_CHECK=
 ATSRC_PACKAGE_DISTRIB=no
 ATSRC_PACKAGE_BUNDLE=main_toolchain
-
-atsrc_get_patches ()
-{
-	# Fix Makefile to try different command for docbook2x-man.
-	at_get_patch \
-		https://raw.githubusercontent.com/powertechpreview/powertechpreview/c26de312a9d003d5bb817f1c8a177d7aeddc4f11/Expat%20Patches/Fix-docMakefile-for-multiple-distros.patch \
-		64657051a6a04ea465cfecd4f6d7cc6a || return ${?}
-}
-
-atsrc_apply_patches ()
-{
-	patch -p2 < Fix-docMakefile-for-multiple-distros.patch || return ${?}
-
-	return 0
-}


### PR DESCRIPTION
Commit ID https://github.com/libexpat/libexpat/commit/cb7d430d22c0 on libexpat fixed the dependency check for docbook, which renders obsolete the local patch on AT Next.  This commit removes the local patch and updates libexpat.