### PR TITLE
Properly remove the cache manager services on Ubuntu

### DIFF
--- a/configs/11.0/deb/monolithic/runtime.prerm
+++ b/configs/11.0/deb/monolithic/runtime.prerm
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Copyright 2018 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if [[ "${1}" == remove ]]; then
+	# Stop and disable the cache manager service to remove symlinks.
+	if [[ "__USE_SYSTEMD__" == "yes" ]]; then
+		systemctl stop __AT_VER_ALTERNATIVE__-cachemanager.service
+		systemctl disable __AT_VER_ALTERNATIVE__-cachemanager.service
+	fi
+fi

--- a/configs/next/deb/monolithic/runtime.prerm
+++ b/configs/next/deb/monolithic/runtime.prerm
@@ -1,0 +1,1 @@
+../../../11.0/deb/monolithic/runtime.prerm


### PR DESCRIPTION
Removes the systemd symlinks for our cache manager system after uninstallation on Ubuntu (#179).