### PR TITLE
Fix environment modules symlinking

### DIFF
--- a/configs/11.0/specs/monolithic.spec
+++ b/configs/11.0/specs/monolithic.spec
@@ -262,11 +262,11 @@ if [[ ! ( -d /usr/share/modules/modulefiles || \
 	mkdir -p /usr/share/Modules/modulefiles
 fi
 if [[ -w /usr/share/modules/modulefiles/. ]]; then
-	ln -sf ${RPM_INSTALL_PREFIX}/%{datadir_r}/modules/modulefiles/%{at_dir_name} \
+	ln -sf %{_datadir}/modules/modulefiles/%{at_dir_name} \
 		/usr/share/modules/modulefiles/.
 fi
 if [[ -w /usr/share/Modules/modulefiles/. ]]; then
-	ln -sf ${RPM_INSTALL_PREFIX}/%{datadir_r}/modules/modulefiles/%{at_dir_name} \
+	ln -sf %{_datadir}/modules/modulefiles/%{at_dir_name} \
 		/usr/share/Modules/modulefiles/.
 fi
 

--- a/configs/11.0/specs/monolithic_cross.spec
+++ b/configs/11.0/specs/monolithic_cross.spec
@@ -112,12 +112,13 @@ gzip -9nvf ${RPM_BUILD_ROOT}%{_tgtinfodir}/*.info*
 for INFO in $(ls ${RPM_INSTALL_PREFIX}/%{tgtinfodir_r}/*.info.gz); do
 	install-info ${INFO} ${RPM_INSTALL_PREFIX}/%{tgtinfodir_r}/dir
 done
+datadir="${RPM_INSTALL_PREFIX}/%{datadir_r}"
 if [[ -w /usr/share/modules/modulefiles/. ]]; then
-	ln -sf %{_datadir}/modules/modulefiles/%{at_dir_name}-%{target} \
+	ln -sf ${datadir}/modules/modulefiles/%{at_dir_name}-%{target} \
 		/usr/share/modules/modulefiles/.
 fi
 if [[ -w /usr/share/Modules/modulefiles/. ]]; then
-	ln -sf %{_datadir}/modules/modulefiles/%{at_dir_name}-%{target} \
+	ln -sf ${datadir}/modules/modulefiles/%{at_dir_name}-%{target} \
 		/usr/share/Modules/modulefiles/.
 fi
 ################################################
@@ -136,12 +137,13 @@ if [[ ! ( -d /usr/share/modules/modulefiles || \
 	# for Red Hat family
 	mkdir -p /usr/share/Modules/modulefiles
 fi
+datadir="${RPM_INSTALL_PREFIX}/%{datadir_r}"
 if [[ -w /usr/share/modules/modulefiles/. ]]; then
-	ln -s %{_datadir}/modules/modulefiles/%{at_dir_name} \
+	ln -s ${datadir}/modules/modulefiles/%{at_dir_name} \
 		/usr/share/modules/modulefiles/.
 fi
 if [[ -w /usr/share/Modules/modulefiles/. ]]; then
-	ln -s %{_datadir}/modules/modulefiles/%{at_dir_name} \
+	ln -s ${datadir}/modules/modulefiles/%{at_dir_name} \
 		/usr/share/Modules/modulefiles/.
 fi
 ################################################


### PR DESCRIPTION
Environment modules are shipped in both cross and non-cross packages, then symlinked in to the system environment modules directory for easy use.  The cross packages were not correctly allowing for installation relocation (via "rpm --prefix"), and the non-cross packages were unnecessarily using RPM_INSTALL_PREFIX (even though they are not relocatable.

Fixes #318 

Signed-off-by:  Paul A. Clarke <pc@us.ibm.com>