### PR TITLE
package upgrade will remove new environment modulefiles

### DIFF
--- a/configs/11.0/specs/monolithic.spec
+++ b/configs/11.0/specs/monolithic.spec
@@ -347,9 +347,6 @@ done
 
 ####################################################
 %preun devel
-# Remove the global link to the environment module.
-rm -f /usr/share/modules/modulefiles/%{at_dir_name} 
-rm -f /usr/share/Modules/modulefiles/%{at_dir_name} 
 # Update the info directory entries
 if [ "$1" = 0 ]; then
     for INFO in $(ls %{_infodir}/*.info.gz); do
@@ -383,6 +380,11 @@ systemctl try-restart %{at_ver_alternative}-cachemanager.service >/dev/null \
 
 #---------------------------------------------------
 %postun devel
+if [ "$1" = 0 ]; then
+	# Remove the global link to the environment module.
+	rm -f /usr/share/modules/modulefiles/%{at_dir_name} 
+	rm -f /usr/share/Modules/modulefiles/%{at_dir_name} 
+fi
 # Update the loader cache after uninstall
 # We never know the order rpm is going to remove/update AT's packages.
 # So we only need to update the ldconf cache when ldconfig is still available

--- a/configs/11.0/specs/monolithic_cross.spec
+++ b/configs/11.0/specs/monolithic_cross.spec
@@ -176,9 +176,6 @@ fi
 ################################################
 
 %preun
-# Remove the global link to the environment modules.
-rm -f /usr/share/modules/modulefiles/%{at_dir_name}-%{target}
-rm -f /usr/share/Modules/modulefiles/%{at_dir_name}-%{target}
 # Update the info directory entries
 if [ "$1" = 0 ]; then
 	for INFO in $(ls ${RPM_INSTALL_PREFIX}/%{tgtinfodir_r}/*.info.gz); do
@@ -190,11 +187,11 @@ fi
 
 #################### common ####################
 %preun -n advance-toolchain-%{at_major}__CROSS__-common
-# Remove the global link to the environment modules.
-rm -f /usr/share/modules/modulefiles/%{at_dir_name}
-rm -f /usr/share/Modules/modulefiles/%{at_dir_name}
 # Update the info directory entries
 if [ "$1" = 0 ]; then
+	# Remove the global link to the environment modules.
+	rm -f /usr/share/modules/modulefiles/%{at_dir_name}
+	rm -f /usr/share/Modules/modulefiles/%{at_dir_name}
 	for INFO in $(ls ${RPM_INSTALL_PREFIX}/%{infodir_r}/*.info.gz); do
 		install-info --delete ${INFO} \
 			     ${RPM_INSTALL_PREFIX}/%{infodir_r}/dir
@@ -215,6 +212,9 @@ fi
 %postun
 if [[ ${1} -eq 0 ]]; then
 	find ${RPM_INSTALL_PREFIX} -type d -empty -delete
+	# Remove the global link to the environment modules.
+	rm -f /usr/share/modules/modulefiles/%{at_dir_name}-%{target}
+	rm -f /usr/share/Modules/modulefiles/%{at_dir_name}-%{target}
 fi
 ################################################
 


### PR DESCRIPTION
The final step in a package upgrade is %postun.  This is after
%post for the installation of the new version of the package.
The current %postun will unconditionally remove the files/symlinks
from the system modulefiles directory, thus removing the newly
installed environment modulefiles.  The fix is to move the removal
inside the conditional in %postun, which checks to see if the
current uninstall operation is still leaving an installed
instance of the package on the system.

Fixes #365

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>