### PR TITLE
Use string operator in string comparison

### DIFF
--- a/scripts/utilities/update_revision.sh
+++ b/scripts/utilities/update_revision.sh
@@ -463,7 +463,7 @@ update_revision ()
 	fi
 
 	# TODO: weak check - some revisions have less than 12 chars.
-	if [[ ${2} -eq ${ATSRC_PACKAGE_REV} ]]; then
+	if [[ ${2} == ${ATSRC_PACKAGE_REV} ]]; then
 		print_msg 0 "Sources at latest revision already. Nothing to be done."
 		exit 0;
 	fi


### PR DESCRIPTION
The automatic update of mpc is not working.  It fails to detect a revision change between what's in configs/next/packages/mpc/sources and what's in mpc's repository.

The failure is due to a wrong comparison operator being used in update-revision.sh