### PR TITLE
fix "failed to create symbolic link" upgrading common package

### DIFF
--- a/configs/11.0/deb/monolithic/devel.postinst
+++ b/configs/11.0/deb/monolithic/devel.postinst
@@ -32,7 +32,7 @@ if [[ "${1}" == configure ]]; then
 		mkdir -p /usr/share/modules/modulefiles
 	fi
 	if [[ -w /usr/share/modules/modulefiles/. ]]; then
-		ln -s __AT_DEST__/share/modules/modulefiles/__AT_DIR_NAME__ \
+		ln -sf __AT_DEST__/share/modules/modulefiles/__AT_DIR_NAME__ \
 			/usr/share/modules/modulefiles/.
 	fi
 fi

--- a/configs/11.0/deb/monolithic_cross/cross-common.postinst
+++ b/configs/11.0/deb/monolithic_cross/cross-common.postinst
@@ -27,7 +27,7 @@ if [[ "${1}" == configure ]]; then
 		mkdir -p /usr/share/modules/modulefiles
 	fi
 	if [[ -w /usr/share/modules/modulefiles/. ]]; then
-		ln -s __AT_DEST__/share/modules/modulefiles/__AT_DIR_NAME__ \
+		ln -sf __AT_DEST__/share/modules/modulefiles/__AT_DIR_NAME__ \
 			/usr/share/modules/modulefiles/.
 	fi
 fi


### PR DESCRIPTION
Upgrading common package will fail:
```
Setting up advance-toolchain-at11.0-cross-common (11.0-3) ...
ln: failed to create symbolic link '/usr/share/modules/modulefiles/./at11.0': File exists
dpkg: error processing package advance-toolchain-at11.0-cross-common (--configure):
 subprocess installed post-installation script returned error exit status 1
```
Upgrades will call the package's "prerm" script with "upgrade" as the
parameter. Only if the parameter is "remove" will the symlink be removed
which will later be created by the new version's "postinst" script.  Thus,
"ln -s" will fail, as seen here.

Solution is to use "ln -sf" instead.

Fixes #382

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>