### PR TITLE
Print the name of the log when collecting it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -544,8 +544,10 @@ define set_provides_arch
 endef
 
 define collect_logs
-    @echo -en "Collecting log information... ";
-    @+{ unset commit_info; \
+    @dt=$$(date -u +"%Y-%m-%d_%H.%M.%S"); \
+    fname=collected_logs-$(AT_VER_REV_INTERNAL).$(BUILD_ID)_$${dt}.tar.gz; \
+    echo -en "Collecting log information to $${fname}... "; \
+    { unset commit_info; \
         if [[ -f commit.info ]]; then \
             cp -p commit.info $(AT_WD); \
             commit_info="./commit.info"; \
@@ -555,7 +557,7 @@ define collect_logs
             ./logs/* ./dynamic $${commit_info} \
             $$(find ./builds -name 'config.[hlms]*' \
                     -print); \
-        mv -f $(AT_WD)/collected_logs.tar.gz $(AT_BASE)/collected_logs-$(AT_VER_REV_INTERNAL).$(BUILD_ID)_$$(date --rfc-3339=seconds | tr ' ' '_' | tr ':' '.' | cut -c -19).tar.gz; \
+        mv -f $(AT_WD)/collected_logs.tar.gz $(AT_BASE)/$${fname}; \
         unset commit_info; \
     } > /dev/null 2>&1
     @echo 'done!'


### PR DESCRIPTION
Printing the file name of the collected logs helps to identify which
collected logs are related to each build.

This feature is particularly useful in build slaves, where builds run
sequentially and collected logs can pile up in a single directory.

Signed-off-by: Tulio Magno Quites Machado Filho <tuliom@linux.vnet.ibm.com>