### PR TITLE
Fix locale generation

### DIFF
--- a/configs/9.0/packages/glibc/stage_1
+++ b/configs/9.0/packages/glibc/stage_1
@@ -88,10 +88,19 @@ EOF
 		# Remove the locale-archive, because localedef does not read
 		# empty files.  This was a dummy file created during the
 		rm -f "${libdir}/locale/locale-archive"
+
+		# Locale generation can require a lot of RAM per job.  Limit
+		# the number of jobs on the amount of RAM.
+		# The largest RAM usage noticed was ~300 MB / job.  However,
+		# we pick 800 MB as a safer limit.
+		memory=$(free -m | awk '/Mem/ {print $2}')
+		max_jobs=$((${memory}/800))
+
 		# Temporarily save the current build directory
 		local build_stage_work="$(pwd)"
 		pushd ${build_stage_work}/localedata > /dev/null
-		${SUB_MAKE} -C "${ATSRC_PACKAGE_WORK}/localedata" \
+		${SUB_MAKE} -j ${max_jobs} \
+			    -C "${ATSRC_PACKAGE_WORK}/localedata" \
 			    objdir="${build_stage_work}" \
 			    install_root="/" \
 			    subdir=localedata \

--- a/configs/9.0/packages/glibc/stage_1
+++ b/configs/9.0/packages/glibc/stage_1
@@ -84,6 +84,7 @@ EOF
 
 	if [[ "${cross_build}" == "no" ]]; then
 
+		set -e
 		# Generate the required locales
 		# Remove the locale-archive, because localedef does not read
 		# empty files.  This was a dummy file created during the
@@ -106,6 +107,7 @@ EOF
 			    subdir=localedata \
 			    install-locales
 		popd > /dev/null
+		set +e
 	fi
 }
 


### PR DESCRIPTION
The first patch limits the number of jobs running in parallel when generating locales.

The second patch guarantees a build failure in case the locale generation fails.