### PR TITLE
Remove libgo_cv_lib_setcontext_clobbers_tls=no from GCC build

### DIFF
--- a/configs/11.0/packages/gcc/stage_4
+++ b/configs/11.0/packages/gcc/stage_4
@@ -156,14 +156,10 @@ atcfg_pre_make() {
 atcfg_make() {
 	if [[ "${cross_build}" == "no" ]]; then
 		# Make build command
-		# libgo_cv_lib_setcontext_clobbers=no must be set for
-		# 32 bit go builds to work correctly.  Once
-		# RH BZ 1018072 is fixed then setting the variable is
-		# no longer needed and the build will work.
-		PATH=${at_dest}/bin:${PATH}  libgo_cv_lib_setcontext_clobbers_tls=no \
+		PATH=${at_dest}/bin:${PATH} \
 			${SUB_MAKE} STAGE1_CFLAGS="-g -O" profiledbootstrap
 	else
-		PATH=${at_dest}/bin:${PATH} libgo_cv_lib_setcontext_clobbers_tls=no \
+		PATH=${at_dest}/bin:${PATH} \
 			${SUB_MAKE} STAGE1_CFLAGS="-g -O"
 	fi
 }

--- a/configs/11.0/packages/gcc/stage_optimized
+++ b/configs/11.0/packages/gcc/stage_optimized
@@ -82,11 +82,6 @@ atcfg_configure() {
 
 
 atcfg_make() {
-	# libgo_cv_lib_setcontext_clobbers=no must be set for
-	# 32 bit go builds to work correctly.  Once
-	# RH BZ 1018072 is fixed then setting the variable is
-	# no longer needed and the build will work.
-	#
 	# gcc_cv_have_tls=yes is required to avoid configure scripts testing if
 	# TLS is available.  These tests try to execute programs compiled with
 	# a -mcpu that is superior of the base value, which can cause a silent
@@ -98,7 +93,6 @@ atcfg_make() {
 	# of the base value, which can cause a silent illegal instruction
 	# error, forcing the script to assume that vsnprintf is not usable.
 	PATH=${at_dest}/bin:${PATH} \
-	libgo_cv_lib_setcontext_clobbers_tls=no \
 		${SUB_MAKE} all \
 			    gcc_cv_have_tls=yes \
 			    ssp_have_usable_vsnprintf=define


### PR DESCRIPTION
The RH BZ #1018072 was fixed and libgo_cv_lib_setcontext_clobbers_tls=no
doesn't need to be set anymore, this patch removes it from the build.