### PR TITLE
[RFC] Build AT 11.0 with multilibs

### DIFF
--- a/configs/11.0/arch/ppc64le.ppc64le.mk
+++ b/configs/11.0/arch/ppc64le.ppc64le.mk
@@ -1,1 +1,34 @@
-../../10.0/arch/ppc64le.ppc64le.mk
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Set default variables when host=ppc64le, targeting ppc64le.
+
+# Generate 64-bit binaries by default.
+COMPILER := 64
+# We only build for 64 bits on little endian, because its ABI doesn't support
+# 32-bit mode.
+BUILD_TARGET_ARCH64 := powerpc64le
+
+include $(CONFIG)/arch/default.mk
+
+TARGET := $(CTARGET_64)
+HEADER_TARGET64 := ppc64le
+DEFAULT_CPU := default64
+HOST := $(CTARGET_64)
+
+CROSS_BUILD := no
+ENV_BUILD_ARCH := 64
+
+# Don't build 32-bit libraries when targeting 64-bit only.
+DISABLE_MULTILIB := yes

--- a/configs/11.0/arch/ppc64le.ppc64le.mk
+++ b/configs/11.0/arch/ppc64le.ppc64le.mk
@@ -29,6 +29,3 @@ HOST := $(CTARGET_64)
 
 CROSS_BUILD := no
 ENV_BUILD_ARCH := 64
-
-# Don't build 32-bit libraries when targeting 64-bit only.
-DISABLE_MULTILIB := yes

--- a/configs/11.0/packages/gcc/stage_4
+++ b/configs/11.0/packages/gcc/stage_4
@@ -55,6 +55,7 @@ atcfg_configure() {
 			${with_dfp_standalone:+--enable-decimal-float} \
 			${secure_plt:+--enable-secureplt} \
 			${disable_multilib:+--disable-multilib} \
+			--with-long-double-format=ibm \
 			--with-advance-toolchain=$(basename ${at_dest}) \
 			--with-glibc-version=${glibc} \
 			--with-local-prefix=${at_dest} \
@@ -149,6 +150,14 @@ atcfg_pre_make() {
 			exit 1
 		fi
 		popd
+
+		# Setup the multilib directory
+		mkdir -p "${at_dest}/lib64/ieee128"
+		cp ${at_dest}/lib64/crt*.o ${at_dest}/lib64/ieee128/
+		if [[ ${?} -ne 0 ]]; then
+			echo "Error copying crt*.o files!"
+			exit 1
+		fi
 	fi
 }
 
@@ -257,4 +266,9 @@ atcfg_post_install() {
 		done
 		set +e
 	fi
+
+	# Include crti.o, crtn.o and crt1.o from the multilibs directory in the
+	# RPM/DEB package.
+	ls ${at_dest}/lib64/ieee128/crt*.o \
+	  >> ${dynamic_spec}/main_toolchain/${stepid}.filelist
 }


### PR DESCRIPTION
This patches enable GCC's multilibs on AT 11.0.
We need a hack to copy the crt*.o files into the multilib directory in order to work. 