### PR TITLE
Remove libauxv from AT next

### DIFF
--- a/configs/next/packages/libauxv/libauxv.mk
+++ b/configs/next/packages/libauxv/libauxv.mk
@@ -1,1 +1,0 @@
-../../../11.0/packages/libauxv/libauxv.mk

--- a/configs/next/packages/libauxv/sources
+++ b/configs/next/packages/libauxv/sources
@@ -1,1 +1,0 @@
-../../../11.0/packages/libauxv/sources

--- a/configs/next/packages/libauxv/specfile
+++ b/configs/next/packages/libauxv/specfile
@@ -1,1 +1,0 @@
-../../../11.0/packages/libauxv/specfile

--- a/configs/next/packages/libauxv/stage_1
+++ b/configs/next/packages/libauxv/stage_1
@@ -1,1 +1,0 @@
-../../../11.0/packages/libauxv/stage_1


### PR DESCRIPTION
libauxv became obsolete when glibc 2.16 (AT 6.0) started to distribute
getauxval(), wich provide the same features of libauxv without requiring an
extra project.

Fixes #464.

Signed-off-by: Tulio Magno Quites Machado Filho <tuliom@linux.ibm.com>