### PR TITLE
Fix SPEC CPU2006 config file for AT 12.0 (GCC 8)

### DIFF
--- a/fvtr/speccpu2006/at10.0-sniff32.cfg
+++ b/fvtr/speccpu2006/at10.0-sniff32.cfg
@@ -51,6 +51,9 @@ strict_rundir_verify=0
 CPORTABILITY   = -DSPEC_CPU_LINUX_PPC -std=gnu89
 EXTRA_CFLAGS = -fno-strict-aliasing
 
+416.gamess=default=default=default:
+FPORTABILITY = -std=legacy
+
 462.libquantum=default=default=default:
 CPORTABILITY   = -DSPEC_CPU_LINUX
 

--- a/fvtr/speccpu2006/at10.0-sniff64.cfg
+++ b/fvtr/speccpu2006/at10.0-sniff64.cfg
@@ -57,6 +57,9 @@ EXTRA_CFLAGS = -fno-strict-aliasing
 403.gcc=default=default=default:
 PORTABILITY = -DSPEC_CPU_LP64
 
+416.gamess=default=default=default:
+FPORTABILITY = -std=legacy
+
 462.libquantum=default=default=default:
 CPORTABILITY   = -DSPEC_CPU_LINUX
 


### PR DESCRIPTION
Fix #549.

(EDIT: Tested on a SLES 12 powerpc64le server)