### PR TITLE
Fix the list of packages to compare requirements with

### DIFF
--- a/scripts/helpers/utilities.mk
+++ b/scripts/helpers/utilities.mk
@@ -671,7 +671,7 @@ define check_packages
         missing_pkg="no"; \
         tmp_file=$$(mktemp); \
         if [[ ("$(DISTRO_FM)" == "ubuntu") || ("$(DISTRO_FM)" == "debian") ]]; then \
-            dpkg -l | tail -n +6 | awk '{ printf("%s\n",$$2); };' > $${tmp_file}; \
+            dpkg -l | tail -n +6 | awk '{ print $$2 "-" $$3; };' > $${tmp_file}; \
         else \
             rpm -qa > $${tmp_file}; \
         fi; \


### PR DESCRIPTION
On RedHat/SuSE, the list is made of package name+version.
However, on Ubuntu/Debian the list was made only of package name.
This meant a version requirement, like make-[4-9], made the check
failed while comparing with the list of package name only.

Fixes #570 

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>