### PR TITLE
Do not check the interpreter of debug files in ck_ldds

### DIFF
--- a/fvtr/ck_ldds/ck_ldds.exp
+++ b/fvtr/ck_ldds/ck_ldds.exp
@@ -57,7 +57,9 @@ proc has_broken_dynlink {file} {
 }
 
 # Verify if the executables' interpreters have canonical path.
-set executables [ exec find $at_dir -type f -perm /111 ]
+# Ignore debug info files as they may not have an interpreter.
+set executables [ exec find $at_dir -type f -perm /111 | \
+			grep -Ev "\.debug$" ]
 foreach exe $executables {
 	if { [is_dynlink ${exe}] } {
 		set interp_info [exec ${at_dir}/bin/readelf -l ${exe}]


### PR DESCRIPTION
Debug files may not have information about the interpreter and can be
safely ignored when validating the interpreter.

Fixes issue #573.