### PR TITLE
Update golang to 1.10 on AT >= 12.0

### DIFF
--- a/configs/12.0/packages/golang/sources
+++ b/configs/12.0/packages/golang/sources
@@ -1,1 +1,49 @@
-../../../11.0/packages/golang/sources
+#!/usr/bin/env bash
+#
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Golang source package and build info
+# ======================================
+#
+
+ATSRC_PACKAGE_NAME="Golang"
+ATSRC_PACKAGE_VER=1.10
+ATSRC_PACKAGE_REV=3d5958383663
+ATSRC_PACKAGE_LICENSE="BSD License"
+ATSRC_PACKAGE_DOCLINK="http://golang.org/doc/"
+ATSRC_PACKAGE_RELFIXES=
+ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
+ATSRC_PACKAGE_PRE="test -d golang-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
+ATSRC_PACKAGE_CO=([0]="git clone https://github.com/powertechpreview/go.git golang")
+ATSRC_PACKAGE_GIT="git checkout -b golang-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}} ${ATSRC_PACKAGE_REV}"
+ATSRC_PACKAGE_POST="mv golang golang-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
+ATSRC_PACKAGE_SRC="${AT_BASE}/sources/golang-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
+ATSRC_PACKAGE_WORK=${AT_WORK_PATH}/golang
+ATSRC_PACKAGE_MLS=
+ATSRC_PACKAGE_ALOC=
+ATSRC_PACKAGE_PATCHES=
+ATSRC_PACKAGE_TARS=
+ATSRC_PACKAGE_DISTRIB=no
+ATSRC_PACKAGE_BUNDLE=golang
+
+atsrc_get_patches ()
+{
+	# Reuse the build from the community in order to bootstrap our own
+	# build.
+	at_get_patch \
+		https://storage.googleapis.com/golang/go1.8.1.linux-ppc64le.tar.gz \
+		8c74ee3647048c3e18802a901821e270 || return ${?}
+}


### PR DESCRIPTION
Get revision 3d5958383663.

Closes #572.