### PR TITLE
Build GCC libraries with debug information on AT >= 11.0

### DIFF
--- a/configs/11.0/packages/gcc/stage_4
+++ b/configs/11.0/packages/gcc/stage_4
@@ -40,8 +40,8 @@ atcfg_configure() {
 		CC="${at_dest}/bin/gcc" \
 		CFLAGS="-O2" \
 		CXXFLAGS="-O2" \
-		CFLAGS_FOR_TARGET="-O3" \
-		CXXFLAGS_FOR_TARGET="-O3" \
+		CFLAGS_FOR_TARGET="-O3 -g" \
+		CXXFLAGS_FOR_TARGET="-O3 -g" \
 		AS="${at_dest}/bin/as" \
 		LD="${at_dest}/bin/ld" \
 		LDFLAGS="-L${at_dest}/lib64" \


### PR DESCRIPTION
GCC libraries were missing debug information, particularly libgo.