### PR TITLE
Clone OpenSSL using HTTPS

### DIFF
--- a/configs/11.0/packages/openssl/sources
+++ b/configs/11.0/packages/openssl/sources
@@ -27,7 +27,7 @@ ATSRC_PACKAGE_DOCLINK="http://www.openssl.org/docs/"
 ATSRC_PACKAGE_RELFIXES=
 ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}"
 ATSRC_PACKAGE_PRE="test -d openssl-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
-ATSRC_PACKAGE_CO=([0]="git clone git://git.openssl.org/openssl.git openssl")
+ATSRC_PACKAGE_CO=([0]="git clone https://github.com/openssl/openssl.git openssl")
 ATSRC_PACKAGE_GIT="git checkout -b openssl-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV} ${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_POST="mv openssl openssl-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_SRC="${AT_BASE}/sources/openssl-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"

--- a/configs/9.0/packages/openssl/sources
+++ b/configs/9.0/packages/openssl/sources
@@ -27,7 +27,7 @@ ATSRC_PACKAGE_DOCLINK="http://www.openssl.org/docs/"
 ATSRC_PACKAGE_RELFIXES=
 ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}"
 ATSRC_PACKAGE_PRE="test -d openssl-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
-ATSRC_PACKAGE_CO=([0]="git clone git://git.openssl.org/openssl.git openssl")
+ATSRC_PACKAGE_CO=([0]="git clone https://github.com/openssl/openssl.git openssl")
 ATSRC_PACKAGE_GIT="git checkout -b openssl-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV} ${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_POST="mv openssl openssl-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_SRC="${AT_BASE}/sources/openssl-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"

--- a/configs/next/packages/openssl/sources
+++ b/configs/next/packages/openssl/sources
@@ -27,7 +27,7 @@ ATSRC_PACKAGE_DOCLINK="http://www.openssl.org/docs/"
 ATSRC_PACKAGE_RELFIXES=
 ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}"
 ATSRC_PACKAGE_PRE="test -d openssl-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
-ATSRC_PACKAGE_CO=([0]="git clone git://git.openssl.org/openssl.git openssl")
+ATSRC_PACKAGE_CO=([0]="git clone https://github.com/openssl/openssl.git openssl")
 ATSRC_PACKAGE_GIT="git checkout -b openssl-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV} ${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_POST="mv openssl openssl-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
 ATSRC_PACKAGE_SRC="${AT_BASE}/sources/openssl-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"


### PR DESCRIPTION
Replace the git protocol with the HTTPS provided by the Github mirror
provided by the OpenSSL community.
This is expected to help reduce network errors.