### PR TITLE
Update Python on AT next

### DIFF
--- a/configs/next/packages/python/sources
+++ b/configs/next/packages/python/sources
@@ -21,7 +21,7 @@
 
 ATSRC_PACKAGE_NAME="Python"
 ATSRC_PACKAGE_VER=3.7
-ATSRC_PACKAGE_REV=657e3f9a2c0d
+ATSRC_PACKAGE_REV=9a3ffc0492d1
 ATSRC_PACKAGE_LICENSE="Python Software Foundation License 2"
 ATSRC_PACKAGE_DOCLINK="https://docs.python.org/3.6/"
 ATSRC_PACKAGE_RELFIXES=
@@ -43,8 +43,8 @@ ATSRC_PACKAGE_BUNDLE=toolchain_extra
 atsrc_get_patches ()
 {
 	at_get_patch \
-		https://raw.githubusercontent.com/powertechpreview/powertechpreview/226be61c2b761170553ce90f9e48ce9d21b3c850/Python%20Fixes/python-3.7-getlib64s1.patch \
-		92a14e9c5a7b58af1a65f25070683e21 || return ${?}
+		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/master/Python%20Fixes/python-3.7-getlib64s2.patch' \
+		fdbf84e9eedfcfb2ef86c7807967f5a1 || return ${?}
 
 	# Disable test_random_fork (test_ssl).
 	# See https://github.com/advancetoolchain/advance-toolchain/issues/201
@@ -62,7 +62,7 @@ atsrc_get_patches ()
 
 atsrc_apply_patches ()
 {
-	patch -p1 < python-3.7-getlib64s1.patch || return ${?}
+	patch -p1 < python-3.7-getlib64s2.patch || return ${?}
 	patch -p1 < python-3.7-disable-zlib-version-check.patch || return ${?}
 	patch -p1 < python-3.6.3-skip_test_random_fork.patch || return ${?}
 }


### PR DESCRIPTION
Bump revision to 9a3ffc0492d1.
Update the getlib64 patch in order to continue working.

This patch fixes the issue with Python's test_email found in PR #779 .