### PR TITLE
Scripts: fix ssh call

### DIFF
--- a/scripts/utilities/update_revision.sh
+++ b/scripts/utilities/update_revision.sh
@@ -291,7 +291,7 @@ send_to_github ()
 
 	# Check connection to GitHub
 	print_msg 2 "Checking GitHub SSH accessibility."
-	ssh git@github.com > /dev/null 2>&1
+	ssh git@github.com > /dev/null 2>&1 </dev/null
 	if [[ $? -ne 1 ]]; then
 		print_msg 0 "Problem accessing GitHub with SSH."
 		return 1


### PR DESCRIPTION
In update_revision.sh, a ssh test to github.com was troubleshooting
with stdin. This caused an issue with a calling script, that got
unexpected EOF.
To avoid that issue, ssh gets /dev/null as stdin for the test to
github.com.

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>