### PR TITLE
Update valgrind on AT next

### DIFF
--- a/configs/next/packages/valgrind/sources
+++ b/configs/next/packages/valgrind/sources
@@ -21,7 +21,7 @@
 
 ATSRC_PACKAGE_NAME="Valgrind"
 ATSRC_PACKAGE_VER=3.14.0
-ATSRC_PACKAGE_REV=0c701ba2a4b1
+ATSRC_PACKAGE_REV=de7fc1a0593c
 ATSRC_PACKAGE_LICENSE="GPL 2.0"
 ATSRC_PACKAGE_DOCLINK="http://valgrind.org/docs/"
 ATSRC_PACKAGE_RELFIXES=
@@ -44,8 +44,8 @@ ATSRC_PACKAGE_BUNDLE=profile
 atsrc_get_patches ()
 {
 	at_get_patch \
-		https://github.com/powertechpreview/powertechpreview/raw/be030afbf8d78018ab77aeea58092e03d483e8ce/Valgrind%20iTrace%20Patches/3.11/vg-3110-itrace.v1.tgz \
-		337042b8ea29d476b69d439c154d62f0 || return ${?}
+		https://github.com/powertechpreview/powertechpreview/raw/07c79e0f6534069c5655083dc978e450a45d59fe/Valgrind%20iTrace%20Patches/3.11/vg-3110-itrace.v1.tgz \
+		9b44cb5beb15fd89bde3f8fa3030d8ce || return ${?}
 
 	# Update itrace to Valgrind 3.14.
 	at_get_patch \

--- a/fvtr/valgrind/valgrind.exp
+++ b/fvtr/valgrind/valgrind.exp
@@ -70,11 +70,15 @@ switch -regexp $env(AT_BUILD_ARCH) {
 }
 
 # List of libraries that should be present.
+set experimental exp-
+if { $env(AT_MAJOR_VERSION) > 12.0 } {
+	set experimental ""
+}
 set lib_list {}
 if { ${TARGET32} } {
 	lappend lib_list vgpreload_core-${arch32}-linux \
 			 vgpreload_drd-${arch32}-linux \
-			 vgpreload_exp-dhat-${arch32}-linux \
+			 vgpreload_${experimental}dhat-${arch32}-linux \
 			 vgpreload_helgrind-${arch32}-linux \
 			 vgpreload_massif-${arch32}-linux \
 			 vgpreload_memcheck-${arch32}-linux
@@ -82,10 +86,10 @@ if { ${TARGET32} } {
 if { ${TARGET64} } {
 	lappend lib_list vgpreload_core-${arch64}-linux \
 			 vgpreload_drd-${arch64}-linux \
-			 vgpreload_exp-dhat-${arch64}-linux \
+			 vgpreload_${experimental}dhat-${arch64}-linux \
 			 vgpreload_helgrind-${arch64}-linux \
 			 vgpreload_massif-${arch64}-linux \
-			 vgpreload_memcheck-${arch64}-linux \
+			 vgpreload_memcheck-${arch64}-linux
 }
 
 # Some files were included in Valgrind 3.7.


### PR DESCRIPTION
Bump to revision de7fc1a0593c
In addition it takes a newer itrace tarball including an update to fit with a change in Makefile.am in valgrind and it uses an updated test of valgrind.

Closes #823 

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>