### PR TITLE
Fix ck_lock_elision test

### DIFF
--- a/fvtr/ck_lock_elision/tle_supported.c
+++ b/fvtr/ck_lock_elision/tle_supported.c
@@ -37,7 +37,8 @@ main ()
 		return EXIT_FAILURE;
 	}
 
-	if (!(hwcap2 & PPC_FEATURE2_HAS_HTM))
+	if (!((hwcap2 & PPC_FEATURE2_HAS_HTM)
+	      && (hwcap2 & PPC_FEATURE2_HTM_NOSC)))
 		return ENOSYS;
 
 	pthread_mutex_t lock = PTHREAD_MUTEX_INITIALIZER;


### PR DESCRIPTION
The test is ignored if the kernel doesn't support htm-nosc.

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>