### PR TITLE
Add the package systemtap-sdt-dev to requirements

### DIFF
--- a/configs/11.0/distros/redhat-7.mk
+++ b/configs/11.0/distros/redhat-7.mk
@@ -92,7 +92,7 @@ ifndef AT_DISTRO_REQ_PKGS
                           rsync curl bc automake libstdc\\+\\+-static \
                           redhat-lsb-core autoconf bzip2-[0-9] libtool-[0-9] \
                           gzip rpm-build-[0-9] rpm-sign gcc-c++ imake wget \
-                          docbook2X
+                          docbook2X systemtap-sdt-devel
     AT_CROSS_PGMS_REQ :=
     AT_NATIVE_PGMS_REQ :=
     AT_COMMON_PGMS_REQ := git_1.7

--- a/configs/11.0/distros/suse-12.mk
+++ b/configs/11.0/distros/suse-12.mk
@@ -75,7 +75,7 @@ ifndef AT_DISTRO_REQ_PKGS
     AT_COMMON_PKGS_REQ := zlib-devel ncurses-devel flex bison texinfo \
                           createrepo subversion cvs gawk autoconf rsync curl \
                           bc automake rpm-build gcc-c++ xorg-x11-util-devel \
-                          docbook2x wget
+                          docbook2x wget systemtap-sdt-devel
     AT_CROSS_PGMS_REQ :=
     AT_NATIVE_PGMS_REQ :=
     AT_COMMON_PGMS_REQ := git_1.7

--- a/configs/11.0/distros/ubuntu-14.mk
+++ b/configs/11.0/distros/ubuntu-14.mk
@@ -70,7 +70,7 @@ ifndef AT_DISTRO_REQ_PKGS
     AT_COMMON_PKGS_REQ := zlib1g-dev libncurses5-dev ncurses-term flex bison \
                           texinfo subversion cvs gawk fakeroot debhelper \
                           autoconf rsync curl bc libxml2-utils automake \
-                          docbook2x dpkg-sig xutils-dev wget
+                          docbook2x dpkg-sig xutils-dev wget systemtap-sdt-dev
     AT_CROSS_PGMS_REQ :=
     AT_NATIVE_PGMS_REQ := pkg-config /opt/ibm/java-ppc64le-71/bin/java
     AT_COMMON_PGMS_REQ := git_1.7

--- a/configs/11.0/distros/ubuntu-16.mk
+++ b/configs/11.0/distros/ubuntu-16.mk
@@ -71,7 +71,7 @@ ifndef AT_DISTRO_REQ_PKGS
                           texinfo subversion cvs gawk fakeroot debhelper \
                           autoconf rsync curl bc libxml2-utils automake \
                           dpkg-sig xutils-dev libtool wget dh-systemd \
-                          docbook2x pkg-config
+                          docbook2x pkg-config systemtap-sdt-dev
     AT_CROSS_PGMS_REQ :=
     AT_NATIVE_PGMS_REQ := /opt/ibm/java-ppc64le-80/jre/bin/java
     AT_COMMON_PGMS_REQ := git_2.7

--- a/configs/11.0/packages/glibc/stage_2
+++ b/configs/11.0/packages/glibc/stage_2
@@ -30,6 +30,11 @@ ATCFG_HOLD_TEMP_BUILD='no'
 # Build in a new directory
 ATCFG_BUILD_STAGE_T='dir'
 
+atcfg_pre_hacks() {
+	# Copy systemtap header files.
+	find /usr/include \( -name sdt.h -o -name sdt-config.h \) -exec cp {} ${at_dest}/include/sys \;
+}
+
 # Required post install hacks (this one is run after the final install move)
 atcfg_posti_hacks() {
 	local base_libdir=$(find_build_libdir ${AT_BIT_SIZE})
@@ -53,6 +58,10 @@ atcfg_posti_hacks() {
 	echo "GROUP ( libc.so.6 libc_nonshared.a AS_NEEDED ( ${ld_so} ) )"    >> ${libdir}/libc.so
 	[[ -e ${libdir}/libc.so.orig ]] && \
 		rm ${libdir}/libc.so.orig
+	# Remove two header files related with systemtap.
+	# Those files were needed to compile glibc but they aren't meant
+	# to be distributed.
+	rm ${at_dest}/include/sys/sdt.h ${at_dest}/include/sys/sdt-config.h
 }
 
 # Pre configure settings or commands to run

--- a/configs/11.0/packages/glibc/stage_2
+++ b/configs/11.0/packages/glibc/stage_2
@@ -1,1 +1,138 @@
-../../../10.0/packages/glibc/stage_2
+#!/usr/bin/env bash
+#
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# GLIBC build parameters for stage 2 32/64 bits
+# =============================================
+#
+
+# The build of glibc was almost full featured.  In this build the new GCC is
+# used to compile a highly optimized glibc with all the required features.
+
+# Include some standard functions
+source ${utilities}/bitsize_selection.sh
+
+ATCFG_HOLD_TEMP_INSTALL='no'
+ATCFG_HOLD_TEMP_BUILD='no'
+# Build in a new directory
+ATCFG_BUILD_STAGE_T='dir'
+
+# Required post install hacks (this one is run after the final install move)
+atcfg_posti_hacks() {
+	local base_libdir=$(find_build_libdir ${AT_BIT_SIZE})
+	# Set the base library path
+	libdir=${at_dest}/${base_libdir}
+	# Find the proper glibc final libc filename
+	libname=$(basename $(ls ${libdir}/libc{-[0-9]*,}.so))
+	# Set the name of the loader to use based on bit size
+	local ld_so=$(basename $(ls ${libdir}/ld${AT_BIT_SIZE%32}.so.[0-9]))
+	# Replace ${at_dest}/lib/libc.so with a version compatible with binutils
+	# built with the --with_sysroot option set to ${at_dest}
+	[[ -e ${libdir}/libc.so ]] && \
+		mv -f ${libdir}/libc.so ${libdir}/libc.so.orig
+	echo "/* GNU ld script"                                                > ${libdir}/libc.so
+	echo "   Use the shared library, but some functions are only in"      >> ${libdir}/libc.so
+	echo "   the static library, so try that secondarily."                >> ${libdir}/libc.so
+	echo "   You will notice that the paths do not contain ${at_dest}."   >> ${libdir}/libc.so
+	echo "   This is because the Advance Toolchain binutils uses"         >> ${libdir}/libc.so
+	echo "   --with-sysroot which causes the linker to append ${at_dest}" >> ${libdir}/libc.so
+	echo "   onto the paths found in this ld script.  */"                 >> ${libdir}/libc.so
+	echo "GROUP ( libc.so.6 libc_nonshared.a AS_NEEDED ( ${ld_so} ) )"    >> ${libdir}/libc.so
+	[[ -e ${libdir}/libc.so.orig ]] && \
+		rm ${libdir}/libc.so.orig
+}
+
+# Pre configure settings or commands to run
+atcfg_pre_configure() {
+	local base_libdir=$(find_build_libdir ${AT_BIT_SIZE})
+	local base_bindir=$(find_build_bindir ${AT_BIT_SIZE})
+	local base_sbindir=$(find_build_sbindir ${AT_BIT_SIZE})
+	local base_libexecdir=$(find_build_libexecdir ${AT_BIT_SIZE})
+	echo slibdir="${at_dest}/${base_libdir}"        >  ./configparms
+	echo libdir="${at_dest}/${base_libdir}"         >> ./configparms
+	echo bindir="${at_dest}/${base_bindir}"         >> ./configparms
+	echo sbindir="${at_dest}/${base_sbindir}"       >> ./configparms
+	echo libexecdir="${at_dest}/${base_libexecdir}" >> ./configparms
+	echo rootsbindir="${at_dest}/${base_sbindir}"   >> ./configparms
+	echo cross-compiling=no                         >> ./configparms
+}
+
+# Configure command for builds
+atcfg_configure() {
+	local base_target=$(find_build_target ${AT_BIT_SIZE})
+
+	PATH=${at_dest}/bin:${PATH} \
+	AUTOCONF="${autoconf}" \
+	CC="${at_dest}/bin/gcc -m${AT_BIT_SIZE}" \
+	CXX="${at_dest}/bin/g++ -m${AT_BIT_SIZE}" \
+	CFLAGS="-g -O3 \
+		${with_longdouble:+-mlong-double-128}" \
+	CXXFLAGS="-g -O3" \
+	${ATSRC_PACKAGE_WORK}/configure --build=${host} \
+					--host=${base_target} \
+					--prefix="${at_dest}" \
+					--with-headers="${at_dest}/include" \
+					--enable-add-ons \
+					--with-__thread \
+					--enable-shared \
+					--enable-multi-arch \
+					--enable-experimental-malloc \
+					--with-cpu=${build_load_arch/ppc/} \
+					--without-gd \
+					--without-selinux \
+					--enable-kernel="${kernel}" \
+					--enable-obsolete-rpc \
+					--enable-lock-elision=yes \
+					--enable-systemtap
+}
+
+# Make build command
+atcfg_make() {
+	PATH=${at_dest}/bin:${PATH} ${SUB_MAKE}
+}
+
+# Conditional install build command
+atcfg_install() {
+	if [[ "${cross_build}" == "no" ]]; then
+		PATH=${at_dest}/bin:${PATH} ${SUB_MAKE} install install_root="${install_place}"
+	else
+		PATH=${at_dest}/bin:${PATH} ${SUB_MAKE} install install_root="${install_place}/${dest_cross}"
+	fi
+}
+
+# Conditinal post install settings or commands to run
+atcfg_post_install() {
+	local base_libdir=$(find_build_libdir ${AT_BIT_SIZE})
+	if [[ "${cross_build}" == "no" ]]; then
+		# Remove unused Makefile from install
+		rm -rf "${install_transfer}/var/db/Makefile"
+		# Removing the created ld.so.cache to avoid further problems
+		rm -rf "${install_transfer}/etc/ld.so.cache"
+		set -e
+                # Hack around to avoid ld.so.cache getting the libs from the
+                # system as ldconfig puts platform based directories preceding
+                # other directories.
+		${AT_BASE}/scripts/utilities/create_lib_symlinks.sh \
+			  "${install_transfer}/${base_libdir}/" \
+			  "${install_transfer}/${base_libdir}/${build_load_arch}"
+		set +e
+	else
+		# Remove unused Makefile from install
+		rm -rf "${install_place}/${dest_cross}/var/db/Makefile"
+		# Removing the created ld.so.cache to avoid further problems
+		rm -rf "${install_place}/${dest_cross}/etc/ld.so.cache"
+	fi
+}

--- a/configs/12.0/distros/redhat-7.mk
+++ b/configs/12.0/distros/redhat-7.mk
@@ -92,7 +92,7 @@ ifndef AT_DISTRO_REQ_PKGS
                           rsync curl bc automake libstdc\\+\\+-static \
                           redhat-lsb-core autoconf bzip2-[0-9] libtool-[0-9] \
                           gzip rpm-build-[0-9] rpm-sign gcc-c++ imake wget \
-                          docbook2X autoconf-archive
+                          docbook2X autoconf-archive systemtap-sdt-devel
     AT_CROSS_PGMS_REQ :=
     AT_NATIVE_PGMS_REQ :=
     AT_COMMON_PGMS_REQ := git_1.7 make_4.0

--- a/configs/12.0/distros/suse-12.mk
+++ b/configs/12.0/distros/suse-12.mk
@@ -75,7 +75,8 @@ ifndef AT_DISTRO_REQ_PKGS
     AT_COMMON_PKGS_REQ := zlib-devel ncurses-devel flex bison texinfo \
                           createrepo subversion cvs gawk autoconf rsync curl \
                           bc automake rpm-build gcc-c++ xorg-x11-util-devel \
-                          docbook2x wget autoconf-archive make
+                          docbook2x wget autoconf-archive make \
+                          systemtap-sdt-devel
     AT_CROSS_PGMS_REQ :=
     AT_NATIVE_PGMS_REQ :=
     AT_COMMON_PGMS_REQ := git_1.7

--- a/configs/12.0/distros/ubuntu-16.mk
+++ b/configs/12.0/distros/ubuntu-16.mk
@@ -71,7 +71,8 @@ ifndef AT_DISTRO_REQ_PKGS
                           texinfo subversion cvs gawk fakeroot debhelper \
                           autoconf rsync curl bc libxml2-utils automake \
                           dpkg-sig xutils-dev libtool wget dh-systemd \
-                          docbook2x pkg-config autoconf-archive make
+                          docbook2x pkg-config autoconf-archive make \
+                          systemtap-sdt-dev
     AT_CROSS_PGMS_REQ :=
     AT_NATIVE_PGMS_REQ := /opt/ibm/java-ppc64le-80/jre/bin/java
     AT_COMMON_PGMS_REQ := git_2.7

--- a/configs/next/distros/redhat-7.mk
+++ b/configs/next/distros/redhat-7.mk
@@ -92,7 +92,8 @@ ifndef AT_DISTRO_REQ_PKGS
                           rsync curl bc automake libstdc\\+\\+-static \
                           redhat-lsb-core autoconf bzip2-[0-9] libtool-[0-9] \
                           gzip rpm-build-[0-9] rpm-sign gcc-c++ imake wget \
-                          docbook2X autoconf-archive libffi-devel python34
+                          docbook2X autoconf-archive libffi-devel python34 \
+                          systemtap-sdt-devel
     AT_CROSS_PGMS_REQ :=
     AT_NATIVE_PGMS_REQ :=
     AT_COMMON_PGMS_REQ := git_1.7 make_4.0

--- a/configs/next/distros/suse-12.mk
+++ b/configs/next/distros/suse-12.mk
@@ -76,7 +76,7 @@ ifndef AT_DISTRO_REQ_PKGS
                           createrepo subversion cvs gawk autoconf rsync curl \
                           bc automake rpm-build gcc-c++ xorg-x11-util-devel \
                           docbook2x wget autoconf-archive make \
-                          libffi48-devel python3
+                          libffi48-devel python3 systemtap-sdt-devel
     AT_CROSS_PGMS_REQ :=
     AT_NATIVE_PGMS_REQ :=
     AT_COMMON_PGMS_REQ := git_1.7

--- a/configs/next/distros/ubuntu-16.mk
+++ b/configs/next/distros/ubuntu-16.mk
@@ -72,7 +72,7 @@ ifndef AT_DISTRO_REQ_PKGS
                           autoconf rsync curl bc libxml2-utils automake \
                           dpkg-sig xutils-dev libtool wget dh-systemd \
                           docbook2x pkg-config autoconf-archive make \
-                          libffi-dev python3
+                          libffi-dev python3 systemtap-sdt-dev
     AT_CROSS_PGMS_REQ :=
     AT_NATIVE_PGMS_REQ := /opt/ibm/java-ppc64le-80/jre/bin/java
     AT_COMMON_PGMS_REQ := git_2.7

--- a/configs/next/distros/ubuntu-18.mk
+++ b/configs/next/distros/ubuntu-18.mk
@@ -72,7 +72,7 @@ ifndef AT_DISTRO_REQ_PKGS
                           autoconf rsync curl bc libxml2-utils automake \
                           dpkg-sig xutils-dev libtool wget dh-systemd \
                           docbook2x pkg-config autoconf-archive make \
-                          libffi-dev python3 git
+                          libffi-dev python3 git systemtap-sdt-dev
     AT_CROSS_PGMS_REQ :=
     AT_NATIVE_PGMS_REQ :=
     AT_COMMON_PGMS_REQ :=

--- a/fvtr/systemtap/systemtap.exp
+++ b/fvtr/systemtap/systemtap.exp
@@ -1,0 +1,40 @@
+#! /usr/bin/expect
+# Copyright 2019 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# Check if Glibc has SDTs defined.
+
+source shared.exp
+
+if { $env(AT_MAJOR_VERSION) < 11.0 } {
+    printit "Skipping: systemtap isn't enabled on version older than AT 11.0"
+    exit $ENOSYS
+}
+set lib "lib64"
+if { $TARGET32 } {
+    set lib "lib"
+}
+if { $env(AT_CROSS_BUILD) == "yes" } {
+    set readelf_exe $env(AT_DEST)/bin/$env(AT_TARGET)-readelf
+} else {
+    set readelf_exe $env(AT_DEST)/bin/readelf
+}
+set sdt [exec $readelf_exe --notes {*}[glob $env(AT_DEST)/$lib/libpthread-*.so] | \
+	     grep stapsdt | wc -l]
+if { $sdt > 0 } {
+    exit 0
+}
+
+exit 1


### PR DESCRIPTION
Added the package to requirement on AT 11.0, 12.0 and next.
Enabled systemptap when building glibc.

Fix #946 
    
Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>
