### PR TITLE
Refactor code for enabling systemtap probes in glibc

### DIFF
--- a/configs/11.0/packages/glibc/stage_1
+++ b/configs/11.0/packages/glibc/stage_1
@@ -44,17 +44,14 @@ ATCFG_HOLD_TEMP_BUILD='no'
 # Build in a new directory
 ATCFG_BUILD_STAGE_T='dir'
 
-find_cross_includedir() {
-	local cc=${at_dest}/bin/${target64:-${target}}-gcc
-	echo ${at_dest}/lib/gcc/${target64:-${target}}/$($cc -dumpversion)/include
-}
-
 atcfg_pre_hacks() {
 	if [[ "${cross_build}" == "yes" ]]; then
-		local includedir=$(find_cross_includedir)
-		# Copy systemtap header files.
-		test ! -d ${includedir}/sys && mkdir -p ${includedir}/sys
-		find /usr/include \( -name sdt.h -o -name sdt-config.h \) -exec cp {} ${includedir}/sys \;
+		# Copy systemtap header files to its own directory inside
+		# the build directory.  We're going to use them during the
+		# build.  Native builds do this at stage 2.
+		test ! -d systemtap/sys && mkdir -p systemtap/sys
+		find /usr/include \( -name sdt.h -o -name sdt-config.h \) \
+		     -exec cp {} systemtap/sys \;
 	fi
 }
 
@@ -118,12 +115,6 @@ EOF
 			    install-locales
 		popd > /dev/null
 		set +e
-	else
-		# Remove two header files related with systemtap.
-		# Those files were needed to compile glibc but they aren't meant
-		# to be distributed.
-		local includedir=$(find_cross_includedir)
-		rm ${includedir}/sys/sdt.h ${includedir}/sys/sdt-config.h
 	fi
 }
 
@@ -183,9 +174,16 @@ atcfg_configure()
 			disable_ssp=yes
 		fi
 
+		# Systemtap headers - In order to build glibc with support for
+		# systemtap probes, the build has to use the systemtap headers
+		# without using the other system headers.  In order to achieve
+		# this, we copy the systemtap headers to the build directory
+		# and add them to CPPFLAGS with -isystem because they need
+		# special treatment like other system headers.
 		AUTOCONF="${autoconf}" \
 		CC="${at_dest}/bin/${target64:-${target}}-gcc -m${AT_BIT_SIZE}" \
 		CFLAGS="-g -O2" \
+		CPPFLAGS="-isystem $(pwd)/systemtap" \
 		CXX="/bin/false" \
 		AR="${at_dest}/bin/${target}-ar" \
 		AS="${at_dest}/bin/${target}-as" \

--- a/configs/11.0/packages/glibc/stage_2
+++ b/configs/11.0/packages/glibc/stage_2
@@ -31,8 +31,12 @@ ATCFG_HOLD_TEMP_BUILD='no'
 ATCFG_BUILD_STAGE_T='dir'
 
 atcfg_pre_hacks() {
-	# Copy systemtap header files.
-	find /usr/include \( -name sdt.h -o -name sdt-config.h \) -exec cp {} ${at_dest}/include/sys \;
+	# Copy systemtap header files to its own directory inside
+	# the build directory.  We're going to use them during the
+	# build.
+	test ! -d systemtap/sys && mkdir -p systemtap/sys
+	find /usr/include \( -name sdt.h -o -name sdt-config.h \) \
+	     -exec cp {} systemtap/sys \;
 }
 
 # Required post install hacks (this one is run after the final install move)
@@ -58,10 +62,6 @@ atcfg_posti_hacks() {
 	echo "GROUP ( libc.so.6 libc_nonshared.a AS_NEEDED ( ${ld_so} ) )"    >> ${libdir}/libc.so
 	[[ -e ${libdir}/libc.so.orig ]] && \
 		rm ${libdir}/libc.so.orig
-	# Remove two header files related with systemtap.
-	# Those files were needed to compile glibc but they aren't meant
-	# to be distributed.
-	rm ${at_dest}/include/sys/sdt.h ${at_dest}/include/sys/sdt-config.h
 }
 
 # Pre configure settings or commands to run
@@ -83,12 +83,19 @@ atcfg_pre_configure() {
 atcfg_configure() {
 	local base_target=$(find_build_target ${AT_BIT_SIZE})
 
+	# Systemtap headers - In order to build glibc with support for
+	# systemtap probes, the build has to use the systemtap headers
+	# without using the other system headers.  In order to achieve
+	# this, we copy the systemtap headers to the build directory
+	# and add them to CPPFLAGS with -isystem because they need
+	# special treatment like other system headers.
 	PATH=${at_dest}/bin:${PATH} \
 	AUTOCONF="${autoconf}" \
 	CC="${at_dest}/bin/gcc -m${AT_BIT_SIZE}" \
 	CXX="${at_dest}/bin/g++ -m${AT_BIT_SIZE}" \
 	CFLAGS="-g -O3 \
 		${with_longdouble:+-mlong-double-128}" \
+	CPPFLAGS="-isystem $(pwd)/systemtap" \
 	CXXFLAGS="-g -O3" \
 	${ATSRC_PACKAGE_WORK}/configure --build=${host} \
 					--host=${base_target} \

--- a/fvtr/systemtap/systemtap.exp
+++ b/fvtr/systemtap/systemtap.exp
@@ -22,17 +22,44 @@ if { $env(AT_MAJOR_VERSION) < 11.0 } {
     printit "Skipping: systemtap isn't enabled on version older than AT 11.0"
     exit $ENOSYS
 }
-set lib "lib64"
-if { $TARGET32 } {
-    set lib "lib"
+
+
+proc check_systemtap {readelf lib} {
+	global WARNING
+	global ERROR
+	if {[catch {exec $readelf --notes $lib | grep stapsdt}]} {
+		printit "Could not find systemtap probes in $lib" $ERROR
+		return 1
+	} else {
+		printit "Systemtap probes found in $lib" $WARNING
+		return 0
+	}
 }
+
+set ret 0
+set readelf_exe [compiler_path readelf]
+
 if { $env(AT_CROSS_BUILD) == "yes" } {
-    set readelf_exe $env(AT_DEST)/bin/$env(AT_TARGET)-readelf
-    set lib $env(AT_BUILD_ARCH)/$lib
+	if { $env(AT_BUILD_ARCH) == "ppc64le" } {
+		set install_prefix "$env(AT_DEST)/$env(AT_BUILD_ARCH)"
+	} else {
+		set install_prefix "$env(AT_DEST)/ppc"
+	}
 } else {
-    set readelf_exe $env(AT_DEST)/bin/readelf
+	set install_prefix $env(AT_DEST)
 }
-if {[catch {exec $readelf_exe --notes {*}[glob $env(AT_DEST)/$lib/libpthread-*.so] | grep stapsdt}]} {
-    exit 1
+
+if { $TARGET32 } {
+	set lib [glob $install_prefix/lib/libpthread-*.so]
+	if {[check_systemtap $readelf_exe $lib]} {
+		set ret 1
+	}
 }
-exit 0
+if { $TARGET64 } {
+	set lib [glob $install_prefix/lib64/libpthread-*.so]
+	if {[check_systemtap $readelf_exe $lib]} {
+		set ret 1
+	}
+}
+
+exit $ret


### PR DESCRIPTION
Replaces the previous code that enabled systemtap probes in glibc with a
new one that copies the header files to the build directory.
This has the advantage of allowing 2 builds (e.g. 32 and 64 bits) to
execute at the same time because each build has its own copy of the
header files.  Its removal will not break the other build.

This is also refactoring the FVTR testcase in order to improve the log
output and to guarantee the test will check both 32 and 64 bit libraries
when necessary.

Related to issue #946.