### PR TITLE
Diverge glibc on AT 13.0 from AT next

### DIFF
--- a/configs/13.0/packages/glibc/sources
+++ b/configs/13.0/packages/glibc/sources
@@ -1,1 +1,38 @@
-../../../next/packages/glibc/sources
+#!/usr/bin/env bash
+#
+# Copyright 2019 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# GLIBC source package and build info
+# ===================================
+#
+
+ATSRC_PACKAGE_NAME="GNU C Library"
+ATSRC_PACKAGE_VER=2.30
+ATSRC_PACKAGE_REV=9ca2648e2aa7
+ATSRC_PACKAGE_LICENSE="LGPL 2.1"
+ATSRC_PACKAGE_DOCLINK="http://www.gnu.org/software/libc/manual/html_node/index.html"
+ATSRC_PACKAGE_RELFIXES=
+ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}"
+ATSRC_PACKAGE_PRE="test -d glibc-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
+ATSRC_PACKAGE_CO=([0]="git clone git://sourceware.org/git/glibc.git")
+ATSRC_PACKAGE_GIT="git checkout -b glibc-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}} ${ATSRC_PACKAGE_REV}"
+ATSRC_PACKAGE_POST="mv glibc glibc-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
+ATSRC_PACKAGE_SRC=${AT_BASE}/sources/glibc-${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}
+ATSRC_PACKAGE_WORK=${AT_WORK_PATH}/glibc
+ATSRC_PACKAGE_MAKE_CHECK=
+ATSRC_PACKAGE_PORTS=
+ATSRC_PACKAGE_DISTRIB=yes
+ATSRC_PACKAGE_BUNDLE=main_toolchain


### PR DESCRIPTION
glibc 2.30 has been released and will be distributed on AT 13.0.
AT next will continue to track glibc master branch.

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>