### PR TITLE
Fix pveclib build on ppc64

### DIFF
--- a/configs/13.0/packages/pveclib/pveclib.mk
+++ b/configs/13.0/packages/pveclib/pveclib.mk
@@ -24,8 +24,5 @@ pveclib: $(RCPTS)/pveclib_1.rcpt
 $(RCPTS)/pveclib_1.rcpt: $(pveclib_1-archdeps)
 	@touch $@
 
-$(RCPTS)/pveclib_1-32.a.rcpt: $(RCPTS)/gcc_4.rcpt $(RCPTS)/rsync_pveclib.rcpt
-	@touch $@
-
 $(RCPTS)/pveclib_1-64.a.rcpt: $(RCPTS)/gcc_4.rcpt $(RCPTS)/rsync_pveclib.rcpt
 	@touch $@

--- a/configs/13.0/packages/pveclib/stage_1
+++ b/configs/13.0/packages/pveclib/stage_1
@@ -95,9 +95,13 @@ atcfg_configure() {
 	# ranlib, so that they work on both native and cross build.
 	configure_cc="${at_dest}/bin/${target64:-${target}}-gcc"
 
+	flags=
+	if [[ ("${cross_build}" == 'yes') && ("${build_arch}" == ppc64) ]]; then
+	        flags="-mcpu=power8"
+	fi
 	PATH=${at_dest}/bin:${PATH} \
 	CC="${configure_cc} -m${AT_BIT_SIZE}" \
-	CFLAGS="-g -O" \
+	CFLAGS="-g -O ${flags}" \
 	${ATSRC_PACKAGE_WORK}/configure \
 		--build=${configure_build} \
 		--host=${configure_host} \


### PR DESCRIPTION
Added -mcpu=power8 to build on ppc64 64 bits.
Dropped the 32 bits build as __int128 is not supported on this target.

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>