### PR TITLE
Fix pveclib build on ppc64

### DIFF
--- a/configs/13.0/packages/pveclib/pveclib.mk
+++ b/configs/13.0/packages/pveclib/pveclib.mk
@@ -21,7 +21,7 @@ pveclib: $(RCPTS)/pveclib_1.rcpt
 #Add it to the target 3rdparty_libs
 3rdparty_libs-reqs += $(RCPTS)/pveclib_1.rcpt
 
-$(RCPTS)/pveclib_1.rcpt: $(pveclib_1-archdeps)
+$(RCPTS)/pveclib_1.rcpt: $(RCPTS)/pveclib_1-64.b.rcpt
 	@touch $@
 
 $(RCPTS)/pveclib_1-64.a.rcpt: $(RCPTS)/gcc_4.rcpt $(RCPTS)/rsync_pveclib.rcpt

--- a/fvtr/pveclib/pveclib.exp
+++ b/fvtr/pveclib/pveclib.exp
@@ -25,30 +25,22 @@ if { [array names env -exact "AT_PVECLIB_VER"] == "" } {
 	printit "Skipping: pveclib is not available on this build\t\[SUCCESS\]"
 	exit $ENOSYS
 }
+if { $TARGET32 } {
+	printit "Skipping: pveclib is not available in 32 bits\t\[SUCCESS\]"
+	exit $ENOSYS
+}
 
 set at_dir $env(AT_DEST)
 set CC [compiler_path]
 set CFLAGS "-O2 -Wall -c"
-
 set rc 0
-
 set tmp_file [exec mktemp]
 
-if { $TARGET32 } {
-	printit "Testing 32 bit..."
-	if [ compile "${CC} -m32 ${CFLAGS} $FULLPATH/test.c -o ${tmp_file}" ] {
-		set rc 1
-	} else {
-		printitcont "\t\t\t Compiling in 32-bits mode with pveclib headers succeeded"
-	}
-}
-if { $TARGET64 } {
-	printit "Testing 64 bit..."
-	if [ compile "${CC} -m64 ${CFLAGS} $FULLPATH/test.c -o ${tmp_file}" ] {
-		set rc 1
-	} else {
-		printitcont "\t\t\t Compiling in 64-bits mode with pveclib headers succeeded"
-	}
+printit "Testing 64 bits..."
+if [ compile "${CC} -m64 ${CFLAGS} $FULLPATH/test.c -o ${tmp_file}" ] {
+	set rc 1
+} else {
+	printitcont "\t\t\t Compiling in 64-bits mode with pveclib headers succeeded"
 }
 if { $rc == 0 } {
 	printit "Using pveclib headers:\t\t\t\t\t\[SUCCESS\]"


### PR DESCRIPTION
Removed the dependency on 32 bits build.
32 bits and 64 bits builds dependencies were added by a script. As the 32 bits build rule was removed in a previous commit, it ended with an inconsistent Makefile (dependency on nonexistent rule).

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>