### PR TITLE
Allow the installation tool to install AT next packages

### DIFF
--- a/utils/install_tools.sh
+++ b/utils/install_tools.sh
@@ -28,6 +28,7 @@ install_native ()
 	local version=${1}
 
 	if [[ ${debian} == "yes" ]]; then
+		[[ "${version}" == "next" ]] && version=
 		sudo dpkg -i advance-toolchain-at*runtime_${version}* \
 			|| return ${?}
 		sudo dpkg -i advance-toolchain-at*devel_* \


### PR DESCRIPTION
When building AT next, the packages have the next version of AT in their name,
not "next". So, when the installation tool installs those packages it fails
because of this mistmatch.
The installation tool has been updated to find the AT next packages.

This is part of a request to build AT next on a weekly basis.

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>