### PR TITLE
Replace links to Unicamp with links to IBM

### DIFF
--- a/docs/advtool-compiler.html
+++ b/docs/advtool-compiler.html
@@ -118,9 +118,9 @@
 
 <ol>
 
-	<li>The gpg public key <code>gpg-pubkey-6976a827-5164221b</code> is provided in the University of Campinas (Unicamp) repositories. This public key is used to verify the authenticity of both the Advance Toolchain packages and the repository contents. Download the gpg public key for your Linux distribution and import it using the following commands:<pre>
+	<li>The gpg public key <code>gpg-pubkey-6976a827-5164221b</code> is provided in the IBM repositories. This public key is used to verify the authenticity of both the Advance Toolchain packages and the repository contents. Download the gpg public key for your Linux distribution and import it using the following commands:<pre>
 
-    wget ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/redhat/RHEL7/gpg-pubkey-6976a827-5164221b
+    wget ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHEL7/gpg-pubkey-6976a827-5164221b
     rpm --import gpg-pubkey-6976a827-5164221b
 </pre>
 <p>Notes:</p>
@@ -128,12 +128,12 @@
 <li>Create a configuration file for the Advance Toolchain repository configuration file: <code>/etc/yum.repos.d/<em>advance-toolchain.repo</em></code>. Add the following content:
 <pre># Begin of configuration file
 [advance-toolchain]
-name=Advance Toolchain Unicamp FTP
-baseurl=ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/redhat/<em>RHELX</em>
+name=Advance Toolchain IBM FTP
+baseurl=ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/<em>RHELX</em>
 failovermethod=priority
 enabled=1
 gpgcheck=1
-gpgkey=ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/redhat/<em>RHELX</em>/gpg-pubkey-6976a827-5164221b
+gpgkey=ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/<em>RHELX</em>/gpg-pubkey-6976a827-5164221b
 # End of configuration file</pre>
 <p>Replace <em>RHELX </em>with the Red Hat release that you are using.</p>
 </li>
@@ -150,21 +150,21 @@ gpgkey=ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/redhat/<em>RHELX</em>/gp
 
 <ol>
 
-	<li>The gpg public key <code>gpg-pubkey-6976a827-5164221b</code> is provided in the University of Campinas (Unicamp) repositories. This public key is used to verify the authenticity of both the Advance Toolchain packages and the repository contents. Download the gpg public key for your Linux distribution and import it using the following commands:<pre>
+	<li>The gpg public key <code>gpg-pubkey-6976a827-5164221b</code> is provided in the IBM repositories. This public key is used to verify the authenticity of both the Advance Toolchain packages and the repository contents. Download the gpg public key for your Linux distribution and import it using the following commands:<pre>
 
-    wget ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/redhat/RHEL7/gpg-pubkey-6976a827-5164221b
+    wget ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHEL7/gpg-pubkey-6976a827-5164221b
     rpm --import gpg-pubkey-6976a827-5164221b
 </pre>
 </li>
 <li>Create a configuration file for the Advance Toolchain repository configuration file: <code>/etc/yum.repos.d/advance-toolchain.repo</code>.  Add the following content:
 <pre># Begin of configuration file
 [advance-toolchain]
-name=Advance Toolchain Unicamp FTP
-baseurl=ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/suse/SLES_12
+name=Advance Toolchain IBM FTP
+baseurl=ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/SLES_12
 failovermethod=priority
 enabled=1
 gpgcheck=1
-gpgkey=ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/suse/SLES_12/gpg-pubkey-6976a827-5164221b
+gpgkey=ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/SLES_12/gpg-pubkey-6976a827-5164221b
 # End of configuration file</pre>
 </li>
 <li>To install the cross compiler using YAST, follow these steps:
@@ -172,8 +172,8 @@ gpgkey=ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/suse/SLES_12/gpg-pubkey-
 <li>Run yast2 as root.</li>
 <li>Select Add-on Product.</li>
 <li>From Media Type, select the FTP Protocol:  <code>(x) FTP...</code></li>
-<li>Under Server name, enter <code>ftp.unicamp.br</code>.
-<li>Under Directory on Server, enter  <code>/pub/linuxpatch/toolchain/at/suse/SLES_12</code>
+<li>Under Server name, enter <code>public.dhe.ibm.com</code>.
+<li>Under Directory on Server, enter  <code>/software/server/POWER/Linux/toolchain/at/suse/SLES_12</code>
 <p>You will get a warning about there being no product information available at the given location. This is because the repomd-based repository does not contain the YaST product information. This is not a bug. Select [Continue].</p></li>
 <li>Under the Software Management interface, search for "advance toolchain", and select <code>advance-toolchain-atX.X-cross-ppc64</code> or <code>advance-toolchain-atX.X-cross-ppc64le</code>.
 
@@ -183,10 +183,10 @@ gpgkey=ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/suse/SLES_12/gpg-pubkey-
 </li>
 <li>To install the cross-compiler with Zypper:
 
-<ol><li>As root, add the Unicamp FTP to the repository list:
+<ol><li>As root, add the IBM FTP to the repository list:
 
-    <pre>zypper addrepo ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/suse/SLES_12 "Advance Toolchain" </pre>
-<p>This will create a new repository entry called "Advance Toolchain" pointing to the Unicamp FTP site</p>
+    <pre>zypper addrepo ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/SLES_12 "Advance Toolchain" </pre>
+<p>This will create a new repository entry called "Advance Toolchain" pointing to the IBM FTP site</p>
 <li>To install the cross-compiler, run the following command: <code>zypper install advance-toolchain-atX.X-cross-ppc64</code>
 </li>
 </ol>
@@ -203,27 +203,27 @@ gpgkey=ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/suse/SLES_12/gpg-pubkey-
 
 	<li>The gpg public key <code>gpg-pubkey-6976a827-5164221b</code> is provided in the repositories. This public key is used to verify the authenticity of both the Advance Toolchain packages and the repository contents. Download the gpg public key for your Linux distribution and import it using the following commands:
 <pre>
-wget ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/ubuntu/dists/trusty/6976a827.gpg.key
+wget ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/trusty/6976a827.gpg.key
 sudo apt-key add 6976a827.gpg.key
 </pre>
 </li>
 <li>Configure the Advance Toolchain repositories by adding the following line to <code>/etc/apt/sources.list</code>:
 <p>On ppc64el or amd64:</p>
 
-<pre>    deb ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/ubuntu trusty atX.X </pre>
+<pre>    deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu trusty atX.X </pre>
 
 <p>Notes:</p>
 
 <ul>
     	<li>When installing on Ubuntu 16.04 (xenial) or Ubuntu 14.10 (utopic), point to its respective repository:
 
-<pre>         deb ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/ubuntu xenial atX.X
-              deb ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/ubuntu utopic atX.X</pre></li>
+<pre>         deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu xenial atX.X
+              deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu utopic atX.X</pre></li>
 
 
     	<li>When installing on Debian 8 (jessie), point to its respective repository:
 
-         <pre>deb ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/debian jessie atX.X</pre></li>
+         <pre>deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian jessie atX.X</pre></li>
 </ul>
 </li>
 	<li>Refresh the cache by running: <code>sudo aptitude update</code> or <code>sudo apt-get update</code>.</li>

--- a/docs/advtool-installation.html
+++ b/docs/advtool-installation.html
@@ -68,19 +68,19 @@
       <td></td>
       <td><p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#installUbuntu">Install Advance Toolchain</a></p><br />
       <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
-      <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/debian/dists/jessie/at10.0">Repository and release notes</a></p></td>
+      <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian/dists/jessie/at10.0">Repository and release notes</a></p></td>
     </tr>
     <tr>
       <td>Debian 9</td>
       <td>
         <p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#installUbuntu">Install Advance Toolchain</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
-        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/debian/dists/stretch/at12.0">Repository and release notes</a></p>
+        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian/dists/stretch/at12.0">Repository and release notes</a></p>
       </td>
       <td>
         <p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#installUbuntu">Install Advance Toolchain</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
-        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/debian/dists/stretch/at11.0">Repository and release notes</a></p>
+        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian/dists/stretch/at11.0">Repository and release notes</a></p>
       </td>
       <td></td>
     </tr>
@@ -89,17 +89,17 @@
       <td>
         <p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#redhatinstalltabs">Install Advance Toolchain</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler/">Install cross compiler</a></p><br />
-        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/redhat/RHEL7/at12.0">Repository and release notes</a></p>
+        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHEL7/at12.0">Repository and release notes</a></p>
       </td>
       <td>
         <p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#redhatinstalltabs">Install Advance Toolchain</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler/">Install cross compiler</a></p><br />
-        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/redhat/RHEL7/at11.0">Repository and release notes</a></p>
+        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHEL7/at11.0">Repository and release notes</a></p>
       </td>
       <td>
         <p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#redhatinstalltabs">Install Advance Toolchain</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler/">Install cross compiler</a></p><br />
-        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/redhat/RHEL7/at10.0">Repository and release notes</a></p>
+        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHEL7/at10.0">Repository and release notes</a></p>
       </td>
     </tr>
     <tr>
@@ -107,17 +107,17 @@
       <td>
         <p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#slesinstallation">Install Advance Toolchain</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
-        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/suse/SLES_12/at12.0">Repository and release notes</a></p>
+        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/SLES_12/at12.0">Repository and release notes</a></p>
       </td>
       <td>
         <p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#slesinstallation">Install Advance Toolchain</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
-        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/suse/SLES_12/at11.0">Repository and release notes</a></p>
+        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/SLES_12/at11.0">Repository and release notes</a></p>
       </td>
       <td>
         <p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#slesinstallation">Install Advance Toolchain</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
-        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/suse/SLES_12/at10.0">Repository and release notes</a></p>
+        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/SLES_12/at10.0">Repository and release notes</a></p>
       </td>
     </tr>
     <tr>
@@ -126,24 +126,24 @@
       <td></td>
       <td><p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#installUbuntu">Install Advance Toolchain</a></p><br />
       <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
-      <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/ubuntu/dists/trusty/at10.0">Repository and release notes</a></p></td>
+      <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/trusty/at10.0">Repository and release notes</a></p></td>
     </tr>
     <tr>
       <td>Ubuntu 16.04</td>
       <td>
         <p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#installUbuntu">Install Advance Toolchain</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
-        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/ubuntu/dists/xenial/at12.0">Repository and release notes</a></p>
+        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/xenial/at12.0">Repository and release notes</a></p>
       </td>
       <td>
         <p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#installUbuntu">Install Advance Toolchain</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
-        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/ubuntu/dists/xenial/at11.0">Repository and release notes</a></p>
+        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/xenial/at11.0">Repository and release notes</a></p>
       </td>
       <td>
         <p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#installUbuntu">Install Advance Toolchain</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
-        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/ubuntu/dists/xenial/at10.0">Repository and release notes</a></p>
+        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/xenial/at10.0">Repository and release notes</a></p>
       </td>
     </tr>
   </tbody>
@@ -189,8 +189,8 @@
   <p class="ibm-light">Use these steps to download the public key, create a repository configuration file, and install the Advance Toolchain packages.</p>
   <ol>
 
-    <li>The gpg public key <code>gpg-pubkey-6976a827-5164221b</code> is provided in the University of Campinas (Unicamp) repositories. This public key is used to verify the authenticity of both the Advance Toolchain packages and the repository contents. Download the gpg public key for your Linux distribution and import it using the following commands:
-      <pre>    wget ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/redhat/RHEL7/gpg-pubkey-6976a827-5164221b
+    <li>The gpg public key <code>gpg-pubkey-6976a827-5164221b</code> is provided in the IBM repositories. This public key is used to verify the authenticity of both the Advance Toolchain packages and the repository contents. Download the gpg public key for your Linux distribution and import it using the following commands:
+      <pre>    wget ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHEL7/gpg-pubkey-6976a827-5164221b
     rpm --import gpg-pubkey-6976a827-5164221b</pre>
       <p>Notes:</p>
         <ul>
@@ -200,12 +200,12 @@
     <li>Create a configuration file for the Advance Toolchain repository configuration file: <code>/etc/yum.repos.d/<em>advance-toolchain.repo</em></code>. Add the following content:
       <pre># Begin of configuration file
 [advance-toolchain]
-name=Advance Toolchain Unicamp FTP
-baseurl=ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/redhat/<em>RHELX</em>
+name=Advance Toolchain IBM FTP
+baseurl=ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/<em>RHELX</em>
 failovermethod=priority
 enabled=1
 gpgcheck=1
-gpgkey=ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/redhat/<em>RHELX</em>/gpg-pubkey-6976a827-5164221b
+gpgkey=ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/<em>RHELX</em>/gpg-pubkey-6976a827-5164221b
 # End of configuration file</pre>
       <p>Replace <em>RHELX </em>with the Red Hat release that you are using.</p>
     </li>
@@ -220,7 +220,7 @@ gpgkey=ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/redhat/<em>RHELX</em>/gp
 
 <div id="redhattab3" class="ibm-tabs-content">
 
-  <p class="ibm-light">You can use the <a href="ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/at_downloader/" target="_blank">Advance Toolchain (AT) downloader tool</a> to download the latest version of <i>all of</i> the AT packages for a supported distribution and create an ISO image if desired. This script looks at the official FTP sites to find the available distributions and versions and then downloads them to your system.  You can then manually install the packages. This method is intended for users with limited Internet access to their Power Systems.</p>
+  <p class="ibm-light">You can use the <a href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/at_downloader/" target="_blank">Advance Toolchain (AT) downloader tool</a> to download the latest version of <i>all of</i> the AT packages for a supported distribution and create an ISO image if desired. This script looks at the official FTP sites to find the available distributions and versions and then downloads them to your system.  You can then manually install the packages. This method is intended for users with limited Internet access to their Power Systems.</p>
   <p class="ibm-light">If you are installing the rpm files manually you will need to install them in the following order (due to prerequisites):</p>
 
   <div class="ibm-syntax-container" style="padding-top: 20px;">
@@ -303,14 +303,14 @@ advance-toolchain-atX.X-mcore-libs</pre>
   <p class="ibm-h3 ibm-light">With Yast</p>
   <p class="ibm-light">Use these steps to download the public key, create a repository configuration file, and install the Advance Toolchain packages.</p>
   <ol>
-    <li>The gpg public key <code>gpg-pubkey-6976a827-5164221b</code> is provided in the University of Campinas (Unicamp) repositories. This public key is used to verify the authenticity of both the Advance Toolchain packages and the repository contents. Download the gpg public key for your Linux distribution and import it using the following commands:
-      <pre>    wget ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/suse/SLES_12/gpg-pubkey-6976a827-5164221b
+    <li>The gpg public key <code>gpg-pubkey-6976a827-5164221b</code> is provided in the IBM repositories. This public key is used to verify the authenticity of both the Advance Toolchain packages and the repository contents. Download the gpg public key for your Linux distribution and import it using the following commands:
+      <pre>    wget ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/SLES_12/gpg-pubkey-6976a827-5164221b
     rpm --import gpg-pubkey-6976a827-5164221b</pre></li>
     <li>Run yast2 as root.</li>
     <li>Select Add-on Product.</li>
     <li>From Media Type, select the FTP Protocol:  <code>(x) FTP...</code></li>
-    <li>Under Server name, enter <code>ftp.unicamp.br</code>.</li>
-    <li>Under Directory on Server, enter  <code>/pub/linuxpatch/toolchain/at/suse/SLES_12</code>
+    <li>Under Server name, enter <code>public.dhe.ibm.com</code>.</li>
+    <li>Under Directory on Server, enter  <code>/software/server/POWER/Linux/toolchain/at/suse/SLES_12</code>
       <p>You will get a warning about there being no product information available at the given location. This is because the repomd-based repository does not contain the YaST product information. This is not a bug. Select [Continue].</p></li>
     <li>Under the Software Management interface, search for "advance toolchain" and select the following packages:
       <ul>
@@ -329,12 +329,12 @@ advance-toolchain-atX.X-mcore-libs</pre>
 <div id="slestab2" class="ibm-tabs-content">
   <p class="ibm-light">Use these steps to download the public key, create a repository configuration file, and install the Advance Toolchain packages.</p>
   <ol>
-    <li>The gpg public key <code>gpg-pubkey-6976a827-5164221b</code> is provided in the University of Campinas (Unicamp) repositories. This public key is used to verify the authenticity of both the Advance Toolchain packages and the repository contents. Download the gpg public key for your Linux distribution and import it using the following commands:
-      <pre>    wget ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/suse/SLES_12/gpg-pubkey-6976a827-5164221b
+    <li>The gpg public key <code>gpg-pubkey-6976a827-5164221b</code> is provided in the IBM repositories. This public key is used to verify the authenticity of both the Advance Toolchain packages and the repository contents. Download the gpg public key for your Linux distribution and import it using the following commands:
+      <pre>    wget ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/SLES_12/gpg-pubkey-6976a827-5164221b
     rpm --import gpg-pubkey-6976a827-5164221b</pre>
 
-    <li>Add Unicamp FTP to the repository list: <code>zypper addrepo ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/suse/SLES_12 "Advance Toolchain"</code>
-      <p>This command creates a new repository entry called "Advance Toolchain" pointing to the Unicamp FTP site.</p>
+    <li>Add IBM FTP to the repository list: <code>zypper addrepo ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/SLES_12 "Advance Toolchain"</code>
+      <p>This command creates a new repository entry called "Advance Toolchain" pointing to the IBM FTP site.</p>
     </li>
     <li>Run zypper to install the packages:
       <pre>zypper install advance-toolchain-atX.X-runtime \
@@ -351,7 +351,7 @@ advance-toolchain-atX.X-mcore-libs</pre>
 </div>
 
 <div id="slestab3" class="ibm-tabs-content">
-  <p class="ibm-light">You can use the <a href="ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/at_downloader/" target="_blank">Advance Toolchain (AT) downloader tool</a> to download the latest version of <i>all of</i> the AT packages for a supported distribution and create an ISO image if desired. This script looks at the official FTP sites to find the available distributions and versions and then downloads them to your system.  You can then manually install the packages. This method is intended for users with limited Internet access to their Power Systems.</p>
+  <p class="ibm-light">You can use the <a href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/at_downloader/" target="_blank">Advance Toolchain (AT) downloader tool</a> to download the latest version of <i>all of</i> the AT packages for a supported distribution and create an ISO image if desired. This script looks at the official FTP sites to find the available distributions and versions and then downloads them to your system.  You can then manually install the packages. This method is intended for users with limited Internet access to their Power Systems.</p>
   <p class="ibm-light">If you are installing the rpm files manually you will need to install them in the following order (due to prerequisites):</p>
 
   <div class="ibm-syntax-container" style="padding-top: 20px;">
@@ -437,24 +437,24 @@ advance-toolchain-atX.X-runtime-atX.X-compat-X.X</pre>
             <ol>
 	      <li>
                 The gpg public key <code>gpg-pubkey-6976a827-5164221b</code> is provided in the repositories. This public key is used to verify the authenticity of both the Advance Toolchain packages and the repository contents. Download the gpg public key for your Linux distribution and import it using the following commands:
-                <pre>wget ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/ubuntu/dists/trusty/6976a827.gpg.key
+                <pre>wget ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/trusty/6976a827.gpg.key
 sudo apt-key add 6976a827.gpg.key</pre>
               </li>
               <li>
                 Configure the Advance Toolchain repositories by adding the following line to /etc/apt/sources.list:
                 <p>On ppc64el or amd64:</p>
-                <pre>deb ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/ubuntu trusty atX.X </pre>
+                <pre>deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu trusty atX.X </pre>
                 <p>Notes:</p>
 
                 <ul>
                   <li>When installing on Ubuntu 16.04 (xenial) or Ubuntu 14.04 (trusty), point to its respective repository:
-                    <pre>deb ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/ubuntu xenial atX.X
-deb ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/ubuntu trusty atX.X</pre>
+                    <pre>deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu xenial atX.X
+deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu trusty atX.X</pre>
                   </li>
 	          <li>
                     When installing on Debian 8 (jessie) or Debian 9 (stretch), point to its respective repository:
-                    <pre>deb ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/debian jessie atX.X
-deb ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/debian stretch atX.X</pre>
+                    <pre>deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian jessie atX.X
+deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian stretch atX.X</pre>
                   </li>
                 </ul>
 
@@ -478,23 +478,23 @@ deb ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/debian stretch atX.X</pre>
   <ol>
     <li>
       The gpg public key <code>gpg-pubkey-6976a827-5164221b</code> is provided in the repositories. This public key is used to verify the authenticity of both the Advance Toolchain packages and the repository contents. Download the gpg public key for your Linux distribution and import it using the following commands:
-      <pre>wget ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/ubuntu/dists/trusty/6976a827.gpg.key
+      <pre>wget ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/trusty/6976a827.gpg.key
 sudo apt-key add 6976a827.gpg.key</pre>
     </li>
     <li>
       Configure the Advance Toolchain repositories by adding the following line to <code>/etc/apt/sources.list</code>:
       <p>On ppc64el and amd64:</p>
-      <pre>deb ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/ubuntu trusty atX.X </pre>
+      <pre>deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu trusty atX.X </pre>
       <p>Notes:</p>
       <ul>
         <li>
           When installing on Ubuntu 16.04 (xenial) or Ubuntu 14.04 (trusty), point to its respective repository:
-          <pre>deb ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/ubuntu xenial atX.X
-deb ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/ubuntu trusty atX.X</pre>
+          <pre>deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu xenial atX.X
+deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu trusty atX.X</pre>
         </li>
         <li>
           When installing on Debian 8 (jessie), point to its respective repository:
-          <pre>deb ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/debian jessie atX.X</pre>
+          <pre>deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian jessie atX.X</pre>
         </li>
       </ul>
     </li>


### PR DESCRIPTION
IBM FTP has been the new repository for AT packages since a few weeks.
The links to Unicamp FTP server need to been replaced with links to the
IBM FTP server.

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>