### PR TITLE
at_downloader.sh: update server reference

### DIFF
--- a/utils/at_downloader/at_downloader.sh
+++ b/utils/at_downloader/at_downloader.sh
@@ -18,7 +18,7 @@
 # version.
 #
 echo "Advance Toolchain downloader"
-at_url="ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/"
+at_url="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/"
 # Initialize the variables.
 pwd=$(pwd)
 tmp_file="${pwd}/temp.out"


### PR DESCRIPTION
Replaced Unicamp reference with new IBM FTP location.

This will replace at_downloader.sh in ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/at_downloader/

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>