### PR TITLE
Exclude more python tests in the FVTR

### DIFF
--- a/fvtr/python/python.exp
+++ b/fvtr/python/python.exp
@@ -124,17 +124,21 @@ if { "$pyver" == "2.6" } {
 	# making them unreliable for this kind of tests.
 	set spawn_cmd "spawn $env(AT_DEST)/bin/python3 $test_script \
 		-j$CORES -x $common_exclude_tests \
+		test_asyncgen \
 		test_compileall \
 		test_faulthandler \
 		test_gdb \
 		test_httpservers \
 		test_imaplib \
+		test_logging \
 		test_os \
+		test_poplib \
 		test_posix \
 		test_selectors \
 		test_site \
 		test_smtplib \
 		test_socket \
+		test_threading \
 		test_time"
 } else {
 	set spawn_cmd "spawn $env(AT_DEST)/bin/python $test_script"


### PR DESCRIPTION
In order for the FVTR to work, we need reliable tests.
Unfortunately, some of the python tests have been failing intermittently,
making it difficult to trust the entire python FVTR test.

In order to improve this situation, this patch excludes the following
python tests from the FVTR:
 - test_asyncgen
 - test_logging
 - test_poplib
 - test_threading

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>