### PR TITLE
Fix CVE on glibc 2.24 on AT 10.0

### DIFF
--- a/configs/10.0/packages/glibc/sources
+++ b/configs/10.0/packages/glibc/sources
@@ -46,11 +46,18 @@ atsrc_get_patches ()
 	at_get_patch \
 		https://raw.githubusercontent.com/powertechpreview/powertechpreview/c58beed95f1cae9361efc614b1d79483caba95f2/GLIBC%20PowerPC%20Backport/2.22/0001-powerpc-Conditionally-enable-TLE.patch \
 		90fe7a2bf3297885655660f785d9421e || return ${?}
+
+	# CVE-2018-6551
+	at_get_patch \
+		https://raw.githubusercontent.com/powertechpreview/powertechpreview/c3cb75dc95a292a63427cc8868ef96a6c5192603/GLIBC%20PowerPC%20Backport/2.24/0001-CVE-2018-6551.patch \
+		87a2c9376ec027346ff3342236b8b445 || return ${?}
+
 }
 
 atsrc_apply_patches ()
 {
 	patch -p1 < 0001-powerpc-Conditionally-enable-TLE.patch || return ${?}
+	patch -p1 < 0001-CVE-2018-6551.patch || return ${?}
 
 	return 0
 }


### PR DESCRIPTION
Get and apply a patch to fix CVE-2018-6551 related with glibc.
The patch fixes glibc 2.24 provided by AT 10.0.

The fix has been provided upstream since glibc 2.28 (AT >= 12.0).
The fix was backported upstream for the following versions of glibc:
 - 2.22 (AT 9.0)
 - 2.26 (AT 11.0)

Fix #567 

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>