### PR TITLE
update gcc on AT next

### DIFF
--- a/configs/next/packages/gcc/sources
+++ b/configs/next/packages/gcc/sources
@@ -23,7 +23,7 @@ ATSRC_PACKAGE_NAME="GCC (GNU Compiler Collection)"
 ATSRC_PACKAGE_SUBPACKAGE_NAME_0="GNU Standard C++ Library v3 (Libstdc++-v3)"
 ATSRC_PACKAGE_SUBPACKAGE_NAME_1="GNU Libgomp"
 ATSRC_PACKAGE_VER=10.0.0
-ATSRC_PACKAGE_REV=af79fe45c3ac
+ATSRC_PACKAGE_REV=84d7f8c57b19
 ATSRC_PACKAGE_LICENSE="GPL 3.0"
 ATSRC_PACKAGE_DOCLINK="https://gcc.gnu.org/onlinedocs/gcc/"
 ATSRC_PACKAGE_SUBPACKAGE_DOCLINK_0="https://gcc.gnu.org/libstdc++/"
@@ -54,8 +54,8 @@ atsrc_get_patches ()
 
 	# Avoid a misconfiguration of tuned libraries as seen in issue #204.
 	at_get_patch \
-		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/d74e6318679606541d9cb5fd5f88589d3f8496ff/GCC%20PowerPC%20Backport/9/0001-libssp-Ignore-vsnprintf-test-when-ssp_have_usable_vs.patch' \
-		f2e9fb2e57c6a33b90c29940e365df13 || return ${?}
+		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/9b646544919d52be95d0190d13187d6ce872ae4d/GCC%20PowerPC%20Backport/9/0001-libssp-Ignore-vsnprintf-test-when-ssp_have_usable_vs.patch' \
+		7a1335e886a2c6fb17e2b6cd283f6d4f || return ${?}
 
 	# Avoid an error on libstdc++ when running msgfmt.
 	at_get_patch \


### PR DESCRIPTION
Bump to revision 84d7f8c57b19.
The patch related with libssp was updated.

Close #1150 
Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>