### PR TITLE
Fix gcc_2 build with wrong loader name for ppc and ppc64

### DIFF
--- a/configs/10.0/packages/gcc/stage_2
+++ b/configs/10.0/packages/gcc/stage_2
@@ -54,6 +54,13 @@ atcfg_pre_configure() {
 	if [[ "${cross_build}" == "no" && "${build_arch}" == ppc64* ]]; then
 		libdir="${at_dest}/lib64"
 	fi
+	if [[ "${cross_build}" == "no" ]]; then
+		case "${build_arch}" in
+			ppc) ldso="${libdir}/ld.so.1" ;;
+			ppc64) ldso="${libdir}/ld64.so.1" ;;
+			ppc64le) ldso="${libdir}/ld64.so.2" ;;
+		esac
+	fi
 }
 
 # Conditional configure command
@@ -110,7 +117,7 @@ atcfg_configure() {
 			--with-mpc-lib=${libdir} \
 			--with-as="${at_dest}/bin/as" \
 			--with-ld="${at_dest}/bin/ld" \
-			--with-stage1-ldflags="-Wl,--dynamic-linker=${at_dest}/lib64/ld64.so.2"
+			--with-stage1-ldflags="-Wl,--dynamic-linker=${ldso}"
 	else
 		# Configure command for cross builds
 		CC="${system_cc}" \

--- a/configs/11.0/packages/gcc/stage_2
+++ b/configs/11.0/packages/gcc/stage_2
@@ -58,6 +58,13 @@ atcfg_pre_configure() {
 	if [[ "${cross_build}" == "no" && "${build_arch}" == ppc64* ]]; then
 		libdir="${at_dest}/lib64"
 	fi
+	if [[ "${cross_build}" == "no" ]]; then
+		case "${build_arch}" in
+			ppc) ldso="${libdir}/ld.so.1" ;;
+			ppc64) ldso="${libdir}/ld64.so.1" ;;
+			ppc64le) ldso="${libdir}/ld64.so.2" ;;
+		esac
+	fi
 }
 
 # Conditional configure command
@@ -114,7 +121,7 @@ atcfg_configure() {
 			--with-mpc-lib=${libdir} \
 			--with-as="${at_dest}/bin/as" \
 			--with-ld="${at_dest}/bin/ld" \
-			--with-stage1-ldflags="-Wl,--dynamic-linker=${at_dest}/lib64/ld64.so.2"
+			--with-stage1-ldflags="-Wl,--dynamic-linker=${ldso}"
 	else
 		# Configure command for cross builds
 		CC="${system_cc}" \


### PR DESCRIPTION
This commit fixes a bug introduzed in:

    commit: 2273ba38d8a493018e3ab63dc96ea7376e2cd3d0
    subject: Fix: Mixing AT and host env during gcc build stages

Whilst explicitly setting the loader the linker should set for generated
ELFs, I was used the  wrong path and name for the loader in ppc and
ppc64 arquitectures (so, only working on ppc64le).

Signed-off-by: Raoni Fassina Firmino <raoni@linux.ibm.com>

-----------------------------------------------------------------------------------------

More about the bug/fix here:
https://github.com/advancetoolchain/advance-toolchain/pull/1149#discussion_r336489887