### PR TITLE
Remove AT10.0 from install documentation

### DIFF
--- a/docs/adv-tool-usage.html
+++ b/docs/adv-tool-usage.html
@@ -241,6 +241,8 @@ MANPATH="/opt/atX.X/share/man:`manpath`" man lsauxv
     	<li><code>-mcpu=power7</code></li>
 
     	<li><code>-mcpu=power8</code></li>
+
+    	<li><code>-mcpu=power9</code></li>
 </ul>
 
 
@@ -249,7 +251,7 @@ MANPATH="/opt/atX.X/share/man:`manpath`" man lsauxv
 
 
 <ul>
-    	<li>On Advance Toolchain 10.0 and 11.0 the compiler defaults to <code>-mcpu=power8 -mtune=power8</code></li>
+   	<li>On Advance Toolchain 10.0, 11.0, 12.0 and 13.0 the compiler defaults to <code>-mcpu=power8 -mtune=power9</code></li>
 
     	<li>On Advance Toolchain 7.x, 8.0, and 9.0, the compiler defaults to <code>-mcpu=power7 -mtune=power8</code></li>
 

--- a/docs/advtool-installation.html
+++ b/docs/advtool-installation.html
@@ -65,21 +65,9 @@ pre {
       <th>Advance Toolchain 13.0</th>
       <th>Advance Toolchain 12.0</th>
       <th>Advance Toolchain 11.0</th>
-      <th>Advance Toolchain 10.0</th>
     </tr>
   </thead>
   <tbody>
-    <tr>
-      <td>Debian 8</td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td>
-	<p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#installUbuntu">Install Advance Toolchain</a></p><br />
-	<p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
-	<p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian/dists/jessie/at10.0">Repository and release notes</a></p>
-      </td>
-    </tr>
     <tr>
       <td>Debian 9</td>
       <td></td>
@@ -93,7 +81,6 @@ pre {
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian/dists/stretch/at11.0">Repository and release notes</a></p>
       </td>
-      <td></td>
     </tr>
     <tr>
       <td>Debian 10</td>
@@ -102,7 +89,6 @@ pre {
 	<p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
 	<p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian/dists/buster/at13.0">Repository and release notes</a></p>
       </td>
-      <td></td>
       <td></td>
       <td></td>
     </tr>
@@ -119,11 +105,6 @@ pre {
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler/">Install cross compiler</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHEL7/at11.0">Repository and release notes</a></p>
       </td>
-      <td>
-        <p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#redhatinstalltabs">Install Advance Toolchain</a></p><br />
-        <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler/">Install cross compiler</a></p><br />
-        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHEL7/at10.0">Repository and release notes</a></p>
-      </td>
     </tr>
     <tr>
       <td>Red Hat 8</td>
@@ -132,7 +113,6 @@ pre {
 	<p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
 	<p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHEL8/at13.0">Repository and release notes</a></p>
       </td>
-      <td></td>
       <td></td>
       <td></td>
     </tr>
@@ -149,11 +129,6 @@ pre {
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/SLES_12/at11.0">Repository and release notes</a></p>
       </td>
-      <td>
-        <p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#slesinstallation">Install Advance Toolchain</a></p><br />
-        <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
-        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/SLES_12/at10.0">Repository and release notes</a></p>
-      </td>
     </tr>
     <tr>
       <td>SLES 15</td>
@@ -164,18 +139,6 @@ pre {
       </td>
       <td></td>
       <td></td>
-      <td></td>
-    </tr>
-    <tr>
-      <td>Ubuntu 14.04</td>
-      <td></td>
-      <td></td>
-      <td></td>
-      <td>
-	<p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#installUbuntu">Install Advance Toolchain</a></p><br />
-	<p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
-	<p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/trusty/at10.0">Repository and release notes</a></p>
-      </td>
     </tr>
     <tr>
       <td>Ubuntu 16.04</td>
@@ -190,11 +153,6 @@ pre {
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/xenial/at11.0">Repository and release notes</a></p>
       </td>
-      <td>
-        <p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#installUbuntu">Install Advance Toolchain</a></p><br />
-        <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
-        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/xenial/at10.0">Repository and release notes</a></p>
-      </td>
     </tr>
     <tr>
       <td>Ubuntu 18.04</td>
@@ -203,7 +161,6 @@ pre {
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/bionic/at13.0">Repository and release notes</a></p>
       </td>
-      <td></td>
       <td></td>
       <td></td>
     </tr>


### PR DESCRIPTION
As AT 10.0 is no longer supported, updated the documentation to remove the
AT 10.0 column from the installation html file. Side effect, it removed
Debian 8 and Ubuntu 14.04 entries.

Also updated the optimization entry in usage html file.

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>