### PR TITLE
Fix #1159

### DIFF
--- a/configs/next/packages/gcc/sources
+++ b/configs/next/packages/gcc/sources
@@ -23,7 +23,7 @@ ATSRC_PACKAGE_NAME="GCC (GNU Compiler Collection)"
 ATSRC_PACKAGE_SUBPACKAGE_NAME_0="GNU Standard C++ Library v3 (Libstdc++-v3)"
 ATSRC_PACKAGE_SUBPACKAGE_NAME_1="GNU Libgomp"
 ATSRC_PACKAGE_VER=10.0.0
-ATSRC_PACKAGE_REV=af79fe45c3ac
+ATSRC_PACKAGE_REV=84d7f8c57b19
 ATSRC_PACKAGE_LICENSE="GPL 3.0"
 ATSRC_PACKAGE_DOCLINK="https://gcc.gnu.org/onlinedocs/gcc/"
 ATSRC_PACKAGE_SUBPACKAGE_DOCLINK_0="https://gcc.gnu.org/libstdc++/"
@@ -54,8 +54,8 @@ atsrc_get_patches ()
 
 	# Avoid a misconfiguration of tuned libraries as seen in issue #204.
 	at_get_patch \
-		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/d74e6318679606541d9cb5fd5f88589d3f8496ff/GCC%20PowerPC%20Backport/9/0001-libssp-Ignore-vsnprintf-test-when-ssp_have_usable_vs.patch' \
-		f2e9fb2e57c6a33b90c29940e365df13 || return ${?}
+		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/9b646544919d52be95d0190d13187d6ce872ae4d/GCC%20PowerPC%20Backport/9/0001-libssp-Ignore-vsnprintf-test-when-ssp_have_usable_vs.patch' \
+		7a1335e886a2c6fb17e2b6cd283f6d4f || return ${?}
 
 	# Avoid an error on libstdc++ when running msgfmt.
 	at_get_patch \

--- a/configs/next/packages/glibc/stage_1
+++ b/configs/next/packages/glibc/stage_1
@@ -153,7 +153,7 @@ atcfg_configure()
 	if [[ "${cross_build}" == "no" ]]; then
 		AUTOCONF="${autoconf}" \
 		CC="${at_dest}/bin/gcc -m${AT_BIT_SIZE}" \
-		CFLAGS="-g -O2 ${secure_plt:+-msecure-plt}" \
+		CFLAGS="-g -O2 ${secure_plt:+-msecure-plt} -fcommon" \
 		CXX="/bin/false" \
 		libc_cv_forced_unwind="yes" \
 		libc_cv_c_cleanup="yes" \

--- a/configs/next/packages/glibc/stage_1
+++ b/configs/next/packages/glibc/stage_1
@@ -1,1 +1,289 @@
-../../../13.0/packages/glibc/stage_1
+#!/usr/bin/env bash
+#
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# GLIBC build parameters for stage 1 32/64 bits
+# =============================================
+#
+
+# We can't use the newly built gcc to compile glibc because it will set the
+# dynamic linker to be ${dest}/lib/ld.so.1, which isn't installed until the
+# glibc build finishes.  So trying to run anything compiled with the new gcc
+# will fail, in particular, glibc configure tests.  I suppose you might be
+# able to supply glibc configure with lots of libc_cv_* variables to
+# avoid this, but then you'd forever be changing this script to keep up with
+# new glibc configure tests.
+# Note that dynamically linked programs built here with the old host gcc are
+# subtly broken too;  The glibc build sets their dynamic linker to
+# ${dest}/lib/ld.so.1 but doesn't provide rpath.  Which means you'll get the
+# new ld.so trying to use the system libc.so, which doesn't work.  ld.so and
+# libc.so share data structures so are tightly coupled.  To run the new
+# programs, you need to set LD_LIBRARY_PATH for them, or better (so as to not
+# affect forked commands that might need the system libs), run ld.so.x
+# explicitly, passing --library-path as is done for localedef below.
+# This is one of the reasons why you need to build glibc twice.
+
+# Include some standard functions
+source ${utilities}/bitsize_selection.sh
+
+ATCFG_HOLD_TEMP_INSTALL='no'
+ATCFG_HOLD_TEMP_BUILD='no'
+# Build in a new directory
+ATCFG_BUILD_STAGE_T='dir'
+
+atcfg_pre_hacks() {
+	if [[ "${cross_build}" == "yes" ]]; then
+		# Copy systemtap header files to its own directory inside
+		# the build directory.  We're going to use them during the
+		# build.  Native builds do this at stage 2.
+		test ! -d systemtap/sys && mkdir -p systemtap/sys
+		find /usr/include \( -name sdt.h -o -name sdt-config.h \) \
+		     -exec cp {} systemtap/sys \;
+	fi
+}
+
+# Required post install hacks (this one is run after the final install move)
+atcfg_posti_hacks()
+{
+	# Set location of base directory to replace depending on ${cross_build}
+	if [[ "${cross_build}" == "no" ]]; then
+		local basedir="${at_dest}"
+		local libdir=${basedir}/$(find_build_libdir ${AT_BIT_SIZE})
+	else
+		local basedir="${dest_cross}"
+		# On cross compilers, libraries are installed under usr/lib*/,
+		# instead of lib*/.  But the most important C libraries are
+		# still available at lib*/, e.i. ld.so.
+		local libdir=${basedir}/usr/$(find_build_libdir ${AT_BIT_SIZE})
+	fi
+
+	local bindir=${basedir}/$(find_build_bindir ${AT_BIT_SIZE})
+	local lddir=${basedir}/$(find_build_libdir ${AT_BIT_SIZE})
+
+	set -e
+	# Set the name of the loader to use based on bit size
+	local ld_so=$(basename $(ls ${lddir}/ld${AT_BIT_SIZE%32}.so.[0-9]))
+	# Replace ${libdir}/libc.so with a version compatible with binutils
+	# built with the --with_sysroot option set to ${at_dest}
+	[[ -e ${libdir}/libc.so ]] \
+		&& mv -f ${libdir}/libc.so ${libdir}/libc.so.orig
+	cat > ${libdir}/libc.so <<EOF
+/* GNU ld script
+   Use the shared library, but some functions are only in
+   the static library, so try that secondarily.
+   You will notice that the paths do not contain ${at_dest}.
+   This is because the Advance Toolchain binutils uses
+   --with-sysroot which causes the linker to append ${at_dest}
+   onto the paths found in this ld script.  */
+GROUP ( libc.so.6 libc_nonshared.a AS_NEEDED ( ${ld_so} ) )
+EOF
+	[[ -e ${libdir}/libc.so.orig ]] && rm ${libdir}/libc.so.orig
+	set +e
+
+	if [[ "${cross_build}" == "no" ]]; then
+
+		set -e
+		# Generate the required locales
+		# Remove the locale-archive, because localedef does not read
+		# empty files.  This was a dummy file created during the
+		rm -f "${libdir}/locale/locale-archive"
+
+		# Temporarily save the current build directory
+		local build_stage_work="$(pwd)"
+		pushd ${build_stage_work}/localedata > /dev/null
+		# Install locales with a single job in order to avoid
+		# concurrent access to the locale archive.  This used to
+		# cause issues.
+		${SUB_MAKE} -j 1 \
+			    -C "${ATSRC_PACKAGE_WORK}/localedata" \
+			    objdir="${build_stage_work}" \
+			    install_root="/" \
+			    subdir=localedata \
+			    install-locales
+		popd > /dev/null
+		set +e
+	fi
+}
+
+atcfg_pre_configure()
+{
+	local base_libdir=$(find_build_libdir ${AT_BIT_SIZE})
+	local base_bindir=$(find_build_bindir ${AT_BIT_SIZE})
+	local base_sbindir=$(find_build_sbindir ${AT_BIT_SIZE})
+	local base_libexecdir=$(find_build_libexecdir ${AT_BIT_SIZE})
+	if [[ "${cross_build}" == "no" ]]; then
+		echo cross-compiling=yes                        >  ./configparms
+		echo slibdir="${at_dest}/${base_libdir}"        >> ./configparms
+		echo libdir="${at_dest}/${base_libdir}"         >> ./configparms
+		echo bindir="${at_dest}/${base_bindir}"         >> ./configparms
+		echo sbindir="${at_dest}/${base_sbindir}"       >> ./configparms
+		echo libexecdir="${at_dest}/${base_libexecdir}" >> ./configparms
+		echo rootsbindir="${at_dest}/${base_sbindir}"   >> ./configparms
+	else
+		echo cross-compiling=yes > ./configparms
+	fi
+}
+
+atcfg_configure()
+{
+	local base_target=$(find_build_target ${AT_BIT_SIZE})
+	# CXX - In a bootstrap build, the first glibc build should not be
+	#       built with a functional C++ compiler because it will be used to
+	#       enable glibc features that should be disabled at this stage.
+	#       A blank CXX used to work until glibc 2.28, but it started to
+	#       fail in glibc 2.29 after a patch to add support for
+	#       test-in-containers started to use the system C++  compiler
+	#       automatically.  In order to avoid this problem, we set CXX to
+	#       /bin/false, disabling all C++ features in this stage.
+	#       For more information, see
+	#       https://github.com/advancetoolchain/advance-toolchain/pull/630
+	if [[ "${cross_build}" == "no" ]]; then
+		AUTOCONF="${autoconf}" \
+		CC="${at_dest}/bin/gcc -m${AT_BIT_SIZE}" \
+		CFLAGS="-g -O2 ${secure_plt:+-msecure-plt}" \
+		CXX="/bin/false" \
+		libc_cv_forced_unwind="yes" \
+		libc_cv_c_cleanup="yes" \
+		${ATSRC_PACKAGE_WORK}/configure \
+			--build=${host} \
+			--host=${base_target} \
+			--prefix="${at_dest}" \
+			--with-headers="${at_dest}/include" \
+			--enable-add-ons \
+			--enable-obsolete-rpc \
+			--without-gd \
+			--without-selinux \
+			--enable-kernel="${kernel}"
+	else
+		# glibc can't detect correctly if the stack protector works on
+		# ppc64le.
+		if [[ "${base_target}" == powerpc*le-* ]]; then
+			disable_ssp=yes
+		fi
+
+		# Systemtap headers - In order to build glibc with support for
+		# systemtap probes, the build has to use the systemtap headers
+		# without using the other system headers.  In order to achieve
+		# this, we copy the systemtap headers to the build directory
+		# and add them to CPPFLAGS with -isystem because they need
+		# special treatment like other system headers.
+		AUTOCONF="${autoconf}" \
+		CC="${at_dest}/bin/${target64:-${target}}-gcc -m${AT_BIT_SIZE}" \
+		CFLAGS="-g -O2" \
+		CPPFLAGS="-isystem $(pwd)/systemtap" \
+		CXX="/bin/false" \
+		AR="${at_dest}/bin/${target}-ar" \
+		AS="${at_dest}/bin/${target}-as" \
+		RANLIB="${at_dest}/bin/${target}-ranlib" \
+		libc_cv_forced_unwind="yes" \
+		libc_cv_c_cleanup="yes" \
+		${ATSRC_PACKAGE_WORK}/configure \
+			--build=${host} \
+			--host=${base_target} \
+			--prefix="/usr" \
+			--with-headers="${dest_cross}/usr/include" \
+			--enable-add-ons \
+			--enable-obsolete-rpc \
+			--disable-profile \
+			--without-gd \
+			--with-cpu=${build_load_arch} \
+			--with-__thread \
+			--without-gd \
+			--without-selinux \
+			--enable-systemtap \
+			--enable-kernel="${kernel}" \
+			${disable_ssp:+libc_cv_ssp="no"}
+	fi
+}
+
+atcfg_make()
+{
+	${SUB_MAKE}
+}
+
+atcfg_install()
+{
+	if [[ "${cross_build}" == "no" ]]; then
+		${SUB_MAKE} install install_root="${install_place}"
+	else
+		${SUB_MAKE} install \
+			install_root="${install_place}/${dest_cross}"
+	fi
+}
+
+atcfg_post_install()
+{
+	local base_libdir=$(find_build_libdir ${AT_BIT_SIZE})
+	if [[ "${cross_build}" == "no" ]]; then
+		rm -rf "${install_transfer}/var/db/Makefile"
+		# Prepare the locale archive for inclusion in RPM.
+		# We can't generate it yet because the files aren't available
+		# on ${at_dest} yet, so we need a dummy file to guarantee it'll
+		# be included in the package later.
+		mkdir -p "${install_transfer}/${base_libdir}/locale"
+		touch "${install_transfer}/${base_libdir}/locale/locale-archive"
+
+		# Re-use time zone information available in the system.
+		ln -s /usr/share/zoneinfo/ ${install_transfer}/share/zoneinfo
+	else
+		rm -rf "${install_place}/${dest_cross}/var/db/Makefile"
+	fi
+
+	local basedirs=""
+	# Set location of base directory to replace depending on ${cross_build}
+	if [[ "${cross_build}" == "no" ]]; then
+		basedirs="${install_transfer}"
+	else
+		basedirs="${install_place}/${dest_cross} \
+			  ${install_place}/${dest_cross}/usr"
+	fi
+
+	# The powerpc64le ABIv2 doesn't support 32 bits yet.  However, we still
+	# plan to provide libraries under lib64 instead of lib in order to let
+	# AT work in the same way as for powerpc64 (this approach is also used
+	# by Fedora).  However, GCC expects files under lib/ when built with
+	# --disable-multilib, so we need to symlink lib/ to lib64/.
+	if [[ "${cross_build}" == "yes" ]] \
+	      &&  [[ "${target}" == powerpc64le* ]] \
+	      && [[ -z "${target32}" && -n "${target64}" ]]; then
+		for dir in ${basedirs}; do
+			pushd ${dir} > /dev/null
+			ln -s lib64 lib
+			popd
+		done
+	fi
+	# Remove duplicated header files prior to final install when building
+	# for the alternate target because the main target already provides
+	# them. Leave only the non-common headers.
+	local base_target=$(find_build_target ${AT_BIT_SIZE})
+	# Check the correct install place (native x cross)
+	if [[ "${cross_build}" == "yes" ]]; then
+		local check_install="${install_place}/${dest_cross}/usr/include"
+	else
+		local check_install="${install_place}/${at_dest}/include"
+	fi
+	# Perform the clean of these unneeded include files
+	if [[ "${base_target}" == "${alternate_target}" ]]; then
+		# Run the remove command to clean up include files
+		find ${check_install} -type f \
+			-not -name "stubs-${AT_BIT_SIZE}.h" \
+			-delete
+		# Clean any remaining empty directories
+		find ${check_install} \
+			-depth -empty \
+			-delete
+	fi
+}

--- a/configs/next/packages/glibc/stage_2
+++ b/configs/next/packages/glibc/stage_2
@@ -1,1 +1,154 @@
-../../../13.0/packages/glibc/stage_2
+#!/usr/bin/env bash
+#
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# GLIBC build parameters for stage 2 32/64 bits
+# =============================================
+#
+
+# The build of glibc was almost full featured.  In this build the new GCC is
+# used to compile a highly optimized glibc with all the required features.
+
+# Include some standard functions
+source ${utilities}/bitsize_selection.sh
+
+ATCFG_HOLD_TEMP_INSTALL='no'
+ATCFG_HOLD_TEMP_BUILD='no'
+# Build in a new directory
+ATCFG_BUILD_STAGE_T='dir'
+
+atcfg_pre_hacks() {
+	# Copy systemtap header files to its own directory inside
+	# the build directory.  We're going to use them during the
+	# build.
+	test ! -d systemtap/sys && mkdir -p systemtap/sys
+	find /usr/include \( -name sdt.h -o -name sdt-config.h \) \
+	     -exec cp {} systemtap/sys \;
+}
+
+# Required post install hacks (this one is run after the final install move)
+atcfg_posti_hacks() {
+	local base_libdir=$(find_build_libdir ${AT_BIT_SIZE})
+	# Set the base library path
+	libdir=${at_dest}/${base_libdir}
+	# Find the proper glibc final libc filename
+	libname=$(basename $(ls ${libdir}/libc{-[0-9]*,}.so))
+	# Set the name of the loader to use based on bit size
+	local ld_so=$(basename $(ls ${libdir}/ld${AT_BIT_SIZE%32}.so.[0-9]))
+	# Replace ${at_dest}/lib/libc.so with a version compatible with binutils
+	# built with the --with_sysroot option set to ${at_dest}
+	[[ -e ${libdir}/libc.so ]] && \
+		mv -f ${libdir}/libc.so ${libdir}/libc.so.orig
+	echo "/* GNU ld script"                                                > ${libdir}/libc.so
+	echo "   Use the shared library, but some functions are only in"      >> ${libdir}/libc.so
+	echo "   the static library, so try that secondarily."                >> ${libdir}/libc.so
+	echo "   You will notice that the paths do not contain ${at_dest}."   >> ${libdir}/libc.so
+	echo "   This is because the Advance Toolchain binutils uses"         >> ${libdir}/libc.so
+	echo "   --with-sysroot which causes the linker to append ${at_dest}" >> ${libdir}/libc.so
+	echo "   onto the paths found in this ld script.  */"                 >> ${libdir}/libc.so
+	echo "GROUP ( libc.so.6 libc_nonshared.a AS_NEEDED ( ${ld_so} ) )"    >> ${libdir}/libc.so
+	[[ -e ${libdir}/libc.so.orig ]] && \
+		rm ${libdir}/libc.so.orig
+}
+
+# Pre configure settings or commands to run
+atcfg_pre_configure() {
+	local base_libdir=$(find_build_libdir ${AT_BIT_SIZE})
+	local base_bindir=$(find_build_bindir ${AT_BIT_SIZE})
+	local base_sbindir=$(find_build_sbindir ${AT_BIT_SIZE})
+	local base_libexecdir=$(find_build_libexecdir ${AT_BIT_SIZE})
+	echo slibdir="${at_dest}/${base_libdir}"        >  ./configparms
+	echo libdir="${at_dest}/${base_libdir}"         >> ./configparms
+	echo bindir="${at_dest}/${base_bindir}"         >> ./configparms
+	echo sbindir="${at_dest}/${base_sbindir}"       >> ./configparms
+	echo libexecdir="${at_dest}/${base_libexecdir}" >> ./configparms
+	echo rootsbindir="${at_dest}/${base_sbindir}"   >> ./configparms
+	echo cross-compiling=no                         >> ./configparms
+}
+
+# Configure command for builds
+atcfg_configure() {
+	local base_target=$(find_build_target ${AT_BIT_SIZE})
+
+	# Systemtap headers - In order to build glibc with support for
+	# systemtap probes, the build has to use the systemtap headers
+	# without using the other system headers.  In order to achieve
+	# this, we copy the systemtap headers to the build directory
+	# and add them to CPPFLAGS with -isystem because they need
+	# special treatment like other system headers.
+	PATH=${at_dest}/bin:${PATH} \
+	AUTOCONF="${autoconf}" \
+	CC="${at_dest}/bin/gcc -m${AT_BIT_SIZE}" \
+	CXX="${at_dest}/bin/g++ -m${AT_BIT_SIZE}" \
+	CFLAGS="-g -O3 \
+		${with_longdouble:+-mlong-double-128}" \
+	CPPFLAGS="-isystem $(pwd)/systemtap" \
+	CXXFLAGS="-g -O3" \
+	${ATSRC_PACKAGE_WORK}/configure --build=${host} \
+					--host=${base_target} \
+					--prefix="${at_dest}" \
+					--with-headers="${at_dest}/include" \
+					--enable-add-ons \
+					--with-__thread \
+					--enable-shared \
+					--enable-multi-arch \
+					--enable-experimental-malloc \
+					--with-cpu=${build_load_arch/ppc/} \
+					--without-gd \
+					--without-selinux \
+					--enable-kernel="${kernel}" \
+					--enable-obsolete-rpc \
+					--enable-lock-elision=yes \
+					--enable-systemtap
+}
+
+# Make build command
+atcfg_make() {
+	PATH=${at_dest}/bin:${PATH} ${SUB_MAKE}
+}
+
+# Conditional install build command
+atcfg_install() {
+	if [[ "${cross_build}" == "no" ]]; then
+		PATH=${at_dest}/bin:${PATH} ${SUB_MAKE} install install_root="${install_place}"
+	else
+		PATH=${at_dest}/bin:${PATH} ${SUB_MAKE} install install_root="${install_place}/${dest_cross}"
+	fi
+}
+
+# Conditinal post install settings or commands to run
+atcfg_post_install() {
+	local base_libdir=$(find_build_libdir ${AT_BIT_SIZE})
+	if [[ "${cross_build}" == "no" ]]; then
+		# Remove unused Makefile from install
+		rm -rf "${install_transfer}/var/db/Makefile"
+		# Removing the created ld.so.cache to avoid further problems
+		rm -rf "${install_transfer}/etc/ld.so.cache"
+		set -e
+                # Hack around to avoid ld.so.cache getting the libs from the
+                # system as ldconfig puts platform based directories preceding
+                # other directories.
+		${AT_BASE}/scripts/utilities/create_lib_symlinks.sh \
+			  "${install_transfer}/${base_libdir}/" \
+			  "${install_transfer}/${base_libdir}/${build_load_arch}"
+		set +e
+	else
+		# Remove unused Makefile from install
+		rm -rf "${install_place}/${dest_cross}/var/db/Makefile"
+		# Removing the created ld.so.cache to avoid further problems
+		rm -rf "${install_place}/${dest_cross}/etc/ld.so.cache"
+	fi
+}

--- a/configs/next/packages/glibc/stage_2
+++ b/configs/next/packages/glibc/stage_2
@@ -94,7 +94,10 @@ atcfg_configure() {
 	CC="${at_dest}/bin/gcc -m${AT_BIT_SIZE}" \
 	CXX="${at_dest}/bin/g++ -m${AT_BIT_SIZE}" \
 	CFLAGS="-g -O3 \
-		${with_longdouble:+-mlong-double-128}" \
+		${with_longdouble:+-mlong-double-128} \
+		-fcommon \
+		-Wno-error=stringop-overflow= \
+		-Wno-error=maybe-uninitialized" \
 	CPPFLAGS="-isystem $(pwd)/systemtap" \
 	CXXFLAGS="-g -O3" \
 	${ATSRC_PACKAGE_WORK}/configure --build=${host} \

--- a/configs/next/packages/glibc/stage_optimized
+++ b/configs/next/packages/glibc/stage_optimized
@@ -1,1 +1,145 @@
-../../../13.0/packages/glibc/stage_optimized
+#!/usr/bin/env bash
+#
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# GLIBC build parameters for CPU optimized 32/64 bits
+# ===================================================
+#
+
+# Include some standard functions
+source ${utilities}/bitsize_selection.sh
+
+ATCFG_HOLD_TEMP_INSTALL='no'
+ATCFG_HOLD_TEMP_BUILD='no'
+# Build in a new directory
+ATCFG_BUILD_STAGE_T='dir'
+
+# GLIBC BUILD HACKS
+# =========================================================
+# Required post install hacks (this one is run after the final install move)
+atcfg_posti_hacks() {
+	local base_libdir=$(find_build_libdir ${AT_BIT_SIZE})
+	# Set the base library path
+	libdir=${at_dest}/${base_libdir}
+	# Find the proper glibc final libc filename
+	libname=$(basename $(ls ${libdir}/${AT_OPTIMIZE_CPU}/libc{-[0-9]*,}.so))
+	local ld_so=$(basename $(ls ${libdir}/ld${AT_BIT_SIZE%32}.so.[0-9]))
+	# Replace ${libdir}/${AT_OPTIMIZE_CPU}/libc.so with a version compatible with binutils
+	# built with the --with_sysroot option set to ${at_dest}
+	[[ -e ${libdir}/${AT_OPTIMIZE_CPU}/libc.so ]] && \
+		mv -f ${libdir}/${AT_OPTIMIZE_CPU}/libc.so ${libdir}/${AT_OPTIMIZE_CPU}/libc.so.orig
+	echo "/* GNU ld script"                                                > ${libdir}/${AT_OPTIMIZE_CPU}/libc.so
+	echo "   Use the shared library, but some functions are only in"      >> ${libdir}/${AT_OPTIMIZE_CPU}/libc.so
+	echo "   the static library, so try that secondarily."                >> ${libdir}/${AT_OPTIMIZE_CPU}/libc.so
+	echo "   You will notice that the paths do not contain ${at_dest}."   >> ${libdir}/${AT_OPTIMIZE_CPU}/libc.so
+	echo "   This is because the Advance Toolchain binutils uses"         >> ${libdir}/${AT_OPTIMIZE_CPU}/libc.so
+	echo "   --with-sysroot which causes the linker to append ${at_dest}" >> ${libdir}/${AT_OPTIMIZE_CPU}/libc.so
+	echo "   onto the paths found in this ld script.  */"                 >> ${libdir}/${AT_OPTIMIZE_CPU}/libc.so
+	echo "GROUP ( libc.so.6 libc_nonshared.a AS_NEEDED ( ${ld_so} ) )"     >> ${libdir}/${AT_OPTIMIZE_CPU}/libc.so
+	[[ -e ${libdir}/${AT_OPTIMIZE_CPU}/libc.so.orig ]] && \
+		rm ${libdir}/${AT_OPTIMIZE_CPU}/libc.so.orig
+}
+
+
+# ATCFG_CONFIGURE SETTINGS
+# =========================================================
+# Pre configure settings or commands to run
+atcfg_pre_configure() {
+	local base_libdir=$(find_build_libdir ${AT_BIT_SIZE})
+	local base_bindir=$(find_build_bindir ${AT_BIT_SIZE})
+	local base_sbindir=$(find_build_sbindir ${AT_BIT_SIZE})
+	local base_libexecdir=$(find_build_libexecdir ${AT_BIT_SIZE})
+	echo slibdir="${at_dest}/${base_libdir}"        >  ./configparms
+	echo libdir="${at_dest}/${base_libdir}"         >> ./configparms
+	echo bindir="${at_dest}/${base_bindir}"         >> ./configparms
+	echo sbindir="${at_dest}/${base_sbindir}"       >> ./configparms
+	echo libexecdir="${at_dest}/${base_libexecdir}" >> ./configparms
+	echo rootsbindir="${at_dest}/${base_sbindir}"   >> ./configparms
+	if [[ "${at_build_cpu}" == "${AT_OPTIMIZE_CPU}" ]]; then
+		echo cross-compiling=no                     >> ./configparms
+	else
+		echo cross-compiling=yes                    >> ./configparms
+	fi
+}
+# Configure command for native builds
+atcfg_configure() {
+	local base_target=$(find_build_target ${AT_BIT_SIZE})
+
+	PATH=${at_dest}/bin:${PATH} \
+	AUTOCONF="${autoconf}" \
+	CC="${at_dest}/bin/gcc -m${AT_BIT_SIZE}" \
+	CXX="${at_dest}/bin/g++ -m${AT_BIT_SIZE}" \
+	CFLAGS="-g -O3 \
+		${with_longdouble:+-mlong-double-128}" \
+	CXXFLAGS="-g -O3" \
+	${ATSRC_PACKAGE_WORK}/configure --build=${target} \
+					--host=${base_target} \
+					--prefix="${at_dest}" \
+					--with-headers="${at_dest}/include" \
+					--enable-add-ons \
+					--with-__thread \
+					--enable-shared \
+					--enable-multi-arch \
+					--enable-experimental-malloc \
+					--enable-obsolete-rpc \
+					--without-gd \
+					--without-selinux \
+					--with-cpu=${AT_OPTIMIZE_CPU/ppc/} \
+					--enable-kernel="${kernel}" \
+					--enable-obsolete-rpc \
+					--enable-lock-elision=yes
+}
+
+
+# ATCFG_MAKE SETTINGS
+# =========================================================
+# Make build command
+atcfg_make() {
+	PATH=${at_dest}/bin:${PATH} ${SUB_MAKE}
+}
+
+
+# ATCFG_INSTALL SETTINGS
+# =========================================================
+# Install build command
+atcfg_install() {
+	PATH=${at_dest}/bin:${PATH} ${SUB_MAKE} install install_root="${install_place}"
+}
+# Post install settings or commands to run
+atcfg_post_install() {
+	local base_libdir=$(find_build_libdir ${AT_BIT_SIZE})
+	# Remove unneeded install files
+	find "${install_place}/${at_dest}" -type d -name "gconv" -print -execdir rm -rf {} +
+	find "${install_place}/${at_dest}" -type d -name "audit" -print -execdir rm -rf {} +
+	find "${install_place}/${at_dest}" -name "ld*.so.*" -print -delete
+	find "${install_place}/${at_dest}" -name "ld*.so" -print -delete
+	find "${install_place}/${at_dest}" -name "libdl*.so*" -print -delete
+	find "${install_place}/${at_dest}" -name "libdl.a" -print -delete
+	find "${install_place}/${at_dest}" -name "libmemusage.so.*" -print -delete
+	# Save all libraries into a tar file
+	pushd "${install_place}/${at_dest}/${base_libdir}"
+	tar czf "${install_place}/${AT_OPTIMIZE_CPU}.tar.gz" \
+	    $(find . -name "*.so" -o -name "*.so.*" -o -name "*.a")
+	popd
+	# Remove all installed built files
+	rm -rf "${install_place}/${at_dest}"
+	# Create processor lib target
+	mkdir -p "${install_place}/${at_dest}/${base_libdir}/${AT_OPTIMIZE_CPU}"
+	# Place saved libs on created final target
+	pushd "${install_place}/${at_dest}/${base_libdir}/${AT_OPTIMIZE_CPU}"
+	tar xzf "${install_place}/${AT_OPTIMIZE_CPU}.tar.gz"
+	popd
+}

--- a/configs/next/packages/glibc/stage_optimized
+++ b/configs/next/packages/glibc/stage_optimized
@@ -83,7 +83,10 @@ atcfg_configure() {
 	CC="${at_dest}/bin/gcc -m${AT_BIT_SIZE}" \
 	CXX="${at_dest}/bin/g++ -m${AT_BIT_SIZE}" \
 	CFLAGS="-g -O3 \
-		${with_longdouble:+-mlong-double-128}" \
+		${with_longdouble:+-mlong-double-128} \
+		-fcommon \
+		-Wno-error=stringop-overflow= \
+		-Wno-error=maybe-uninitialized" \
 	CXXFLAGS="-g -O3" \
 	${ATSRC_PACKAGE_WORK}/configure --build=${target} \
 					--host=${base_target} \


### PR DESCRIPTION
Recent updates to GCC caused some errors AT next builds on glibc stages (PR #1159). This PR adds some flags needed for the build to succeed.

This is intended as a temporary fix, the actual causes of the errors should be investigated and fixed.