### PR TITLE
Fix AT >= 13.0 builds on RHEL8

### DIFF
--- a/configs/13.0/distros/redhat-8.mk
+++ b/configs/13.0/distros/redhat-8.mk
@@ -71,7 +71,13 @@ endef
 # Inform the list of packages to check
 ifndef AT_DISTRO_REQ_PKGS
     AT_CROSS_PKGS_REQ :=
-    AT_NATIVE_PKGS_REQ := libxslt docbook-style-xsl qt5-devel \
+    # NOTE: qt5 devel packages are also required. A `qt5-devel` meta
+    # package is provided by RHEL8, which has all needed packages listed
+    # as dependencies. However, it is temporarily unavailable on the repos
+    # configured on our build server, so we are TEMPORARILY removing this
+    # dependecy from AT_NATIVE_PKGS_REQ. It should be re-added as soon as
+    # it can be installed to the build server again.
+    AT_NATIVE_PKGS_REQ := libxslt docbook-style-xsl \
                           autogen-libopts sqlite-devel
     AT_COMMON_PKGS_REQ := zlib-devel ncurses-devel flex bison texinfo \
                           createrepo glibc-devel subversion cvs gawk \

--- a/configs/13.0/packages/gcc/sources
+++ b/configs/13.0/packages/gcc/sources
@@ -64,6 +64,11 @@ atsrc_get_patches ()
 		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/master/GCC%20libstdc%2B%2B%20PowerPC%20Patches/9/0001-libstdc-Prevent-LD_LIBRARY_PATH-from-leaking-to-msgf.patch' \
 		9cba9a9b94ca9c1b8958c0d722a9c06b || return ${?}
 
+	# Skip machine_name fix on GCC fixincludes step.
+	at_get_patch \
+		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/fb462137df68be149d94b1cbde1dd141f32361fa/GCC%20PowerPC%20Backport/9/0001-Skip-machine_name-fix-for-powerpc-on-fixincludes-ste.patch' \
+		7b6e39981c83b5f4634693034c7ffbc7 || return ${?}
+
 	return 0
 }
 
@@ -75,5 +80,9 @@ atsrc_apply_patches ()
 
 	patch -p1 \
 	      < 0001-libstdc-Prevent-LD_LIBRARY_PATH-from-leaking-to-msgf.patch \
+		|| return ${?}
+
+	patch -p1 \
+	      < 0001-Skip-machine_name-fix-for-powerpc-on-fixincludes-ste.patch \
 		|| return ${?}
 }

--- a/configs/next/packages/gcc/sources
+++ b/configs/next/packages/gcc/sources
@@ -62,6 +62,11 @@ atsrc_get_patches ()
 		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/master/GCC%20libstdc%2B%2B%20PowerPC%20Patches/9/0001-libstdc-Prevent-LD_LIBRARY_PATH-from-leaking-to-msgf.patch' \
 		9cba9a9b94ca9c1b8958c0d722a9c06b || return ${?}
 
+	# Skip machine_name fix on GCC fixincludes step.
+	at_get_patch \
+		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/fb462137df68be149d94b1cbde1dd141f32361fa/GCC%20PowerPC%20Backport/9/0001-Skip-machine_name-fix-for-powerpc-on-fixincludes-ste.patch' \
+		7b6e39981c83b5f4634693034c7ffbc7 || return ${?}
+
 	return 0
 }
 
@@ -73,5 +78,9 @@ atsrc_apply_patches ()
 
 	patch -p1 \
 	      < 0001-libstdc-Prevent-LD_LIBRARY_PATH-from-leaking-to-msgf.patch \
+		|| return ${?}
+
+	patch -p1 \
+	      < 0001-Skip-machine_name-fix-for-powerpc-on-fixincludes-ste.patch \
 		|| return ${?}
 }


### PR DESCRIPTION
The `fixincludes` step performed during GCC compilation is currently fixing system headers from `/usr/include`, rather than from `<at-build-dir>/opt/*`. This can cause problems due to a mismatch between header versions installed in the system and the ones used by AT. The commit messages have more detail about it.

This problem is likely due to some missing/wrong GCC configuration or by the way `--with-advance-toolchain` flag works. I'm still investigating the root cause.

Meanwhile, I'm adding a hotfix to just skip the specific fix from `fixincludes` that causes the problem (see commit msg to understand why this is OK).

I'm also removing the requirement for `qt5-devel` on RHEL8, as it is not necessary.