### PR TITLE
Update gcc on AT next

### DIFF
--- a/configs/next/packages/gcc/sources
+++ b/configs/next/packages/gcc/sources
@@ -22,8 +22,8 @@
 ATSRC_PACKAGE_NAME="GCC (GNU Compiler Collection)"
 ATSRC_PACKAGE_SUBPACKAGE_NAME_0="GNU Standard C++ Library v3 (Libstdc++-v3)"
 ATSRC_PACKAGE_SUBPACKAGE_NAME_1="GNU Libgomp"
-ATSRC_PACKAGE_VER=10.0.0
-ATSRC_PACKAGE_REV=aec6cd6a2a04
+ATSRC_PACKAGE_VER=10.0.1
+ATSRC_PACKAGE_REV=bcf3fa7cf5a3
 ATSRC_PACKAGE_LICENSE="GPL 3.0"
 ATSRC_PACKAGE_DOCLINK="https://gcc.gnu.org/onlinedocs/gcc/"
 ATSRC_PACKAGE_SUBPACKAGE_DOCLINK_0="https://gcc.gnu.org/libstdc++/"
@@ -54,8 +54,8 @@ atsrc_get_patches ()
 
 	# Avoid a misconfiguration of tuned libraries as seen in issue #204.
 	at_get_patch \
-		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/9b646544919d52be95d0190d13187d6ce872ae4d/GCC%20PowerPC%20Backport/9/0001-libssp-Ignore-vsnprintf-test-when-ssp_have_usable_vs.patch' \
-		7a1335e886a2c6fb17e2b6cd283f6d4f || return ${?}
+		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/a51115f619a5210d868819d41ba5f021327ba83a/GCC%20PowerPC%20Backport/9/0001-libssp-Ignore-vsnprintf-test-when-ssp_have_usable_vs.patch' \
+		8ad129baf6f4a6f61572d5c36c57536b || return ${?}
 
 	# Avoid an error on libstdc++ when running msgfmt.
 	at_get_patch \


### PR DESCRIPTION
Bump to version 10.0.1
Bump to revision bcf3fa7cf5a3

The patch related with libssp was updated.

Close #1266 

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>