### PR TITLE
Force GCC stage 2 bootstrapping to use AT's libc

### DIFF
--- a/configs/11.0/packages/gcc/stage_2
+++ b/configs/11.0/packages/gcc/stage_2
@@ -121,7 +121,7 @@ atcfg_configure() {
 			--with-mpc-lib=${libdir} \
 			--with-as="${at_dest}/bin/as" \
 			--with-ld="${at_dest}/bin/ld" \
-			--with-stage1-ldflags="-Wl,--dynamic-linker=${ldso}"
+			--with-stage1-ldflags="-Wl,--dynamic-linker=${ldso},-rpath=${libdir}"
 	else
 		# Configure command for cross builds
 		CC="${system_cc}" \


### PR DESCRIPTION
**EDIT**: this PR is based on the solution suggested by @ThinkOpenly [here](https://github.com/advancetoolchain/advance-toolchain/issues/1298#issuecomment-584386418).

@ThinkOpenly, this is intended to fix issue #1298.

```
The build of GCC stage 2 is configured to use --with-advance-toolchain
to guarantee that the linker and headers from AT are used instead of the
system's, which includes setting the -rpath linker flag.

However, this setting does not apply to the tools built during GCC's
bootstrap process. The dynamic linker is currently using the system's
libc.so and AT's ld.so, which can cause problems.

This commit sets the correct -rpath to be used by the linker on stage 1
of the bootstrap to fix this issue.
```

Extra considerations:
- I actually tested setting the rpath to `${at_dest}/lib64`, only after I realized that using `${libdir}` is probably better to handle `lib` / `lib64` properly. This PR's automated test will check if this also works =)
- Should I restrict this change only to AT 13 and AT next? Currently it applies all the way back to 11.0
- I'm not completely sure if we also need to use `--with-boot-ldflags` to apply the `-rpath` flag to the other bootstrap stages. Not sure also if this change should apply to AT's GCC stages 3, 4 and opt as well. My test didn't need any of those to pass. 