### PR TITLE
Improve fix of update_revision.sh

### DIFF
--- a/scripts/utilities/update_revision.sh
+++ b/scripts/utilities/update_revision.sh
@@ -154,7 +154,7 @@ get_latest_revision ()
 		# Get which branch is being used.
 		local branch=$(git branch -r --contains ${ATSRC_PACKAGE_REV} \
 				   | cut -d/ -f2- \
-				   | grep -vw "^users")
+				   | grep -Evw "(backport|users)")
 		# When the revision is in HEAD we got a string like:
 		# master -> HEAD
 		# origin/master


### PR DESCRIPTION
This improves commit id 2d381dfdd33c8361ab53bc51b775d310368cd05f.
It ignores branches based on a list of keywords.

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>