### PR TITLE
Update python on AT next

### DIFF
--- a/configs/next/packages/python/sources
+++ b/configs/next/packages/python/sources
@@ -21,7 +21,7 @@
 
 ATSRC_PACKAGE_NAME="Python"
 ATSRC_PACKAGE_VER=3.7
-ATSRC_PACKAGE_REV=83638fe0a7b9
+ATSRC_PACKAGE_REV=5157506e043f
 ATSRC_PACKAGE_LICENSE="Python Software Foundation License 2"
 ATSRC_PACKAGE_DOCLINK="https://docs.python.org/3.7/"
 ATSRC_PACKAGE_RELFIXES=
@@ -43,9 +43,10 @@ ATSRC_PACKAGE_BUNDLE=toolchain_extra
 
 atsrc_get_patches ()
 {
+    # Update python lib path to AT's
 	at_get_patch \
-		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/master/Python%20Fixes/python-3.7-getlib64s2.patch' \
-		fdbf84e9eedfcfb2ef86c7807967f5a1 || return ${?}
+		https://raw.githubusercontent.com/powertechpreview/powertechpreview/8bb1ab91e86e801a9f9f62d7c5f0ca64c9d5cb37/Python%20Fixes/python-3.7-getlib64s3.patch \
+		2e0d53b0549b9036642e0241dda098b5 || return ${?}
 
 	# Disable test_random_fork (test_ssl).
 	# See https://github.com/advancetoolchain/advance-toolchain/issues/201
@@ -63,7 +64,7 @@ atsrc_get_patches ()
 
 atsrc_apply_patches ()
 {
-	patch -p1 < python-3.7-getlib64s2.patch || return ${?}
+	patch -p1 < python-3.7-getlib64s3.patch || return ${?}
 	patch -p1 < python-3.7-disable-zlib-version-check.patch || return ${?}
 	patch -p1 < python-3.6.3-skip_test_random_fork.patch || return ${?}
 }


### PR DESCRIPTION
Bump to revision 5157506e043f

The bump includes a commit that causes conflicts with one of the
patches we apply for AT. This commit also changes that patch to a
newer version to overcome those.

Signed-off-by: Matheus Castanho <msc@linux.ibm.com>

Supersedes #1326