### PR TITLE
Add zlib optimizations for Power

### DIFF
--- a/configs/next/packages/zlib/sources
+++ b/configs/next/packages/zlib/sources
@@ -39,3 +39,18 @@ ATSRC_PACKAGE_TARS=""
 ATSRC_PACKAGE_MAKE_CHECK=""
 ATSRC_PACKAGE_DISTRIB=no
 ATSRC_PACKAGE_BUNDLE=toolchain_extra
+
+atsrc_get_patches ()
+{
+	# Patch to add optimized functions using vector instructions.
+	at_get_patch \
+		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/72276acb91f36d054474257a9c50b47ea997a03b/Zlib%20Patches/zlib-power-optimizations.patch' \
+		844df338108c775afc8f6ec890f84e1a || return ${?}
+
+	return 0
+}
+
+atsrc_apply_patches ()
+{
+	patch -p1 < zlib-power-optimizations.patch || return ${?}
+}

--- a/configs/next/packages/zlib/sources
+++ b/configs/next/packages/zlib/sources
@@ -1,1 +1,41 @@
-../../../13.0/packages/zlib/sources
+#!/usr/bin/env bash
+#
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# ZLIB source package and build info
+# ==================================
+#
+
+ATSRC_PACKAGE_NAME="ZLIB Compression Library"
+ATSRC_PACKAGE_VER=1.2.11
+ATSRC_PACKAGE_REV=ba9df2111e9c
+ATSRC_PACKAGE_VERID="${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
+ATSRC_PACKAGE_LICENSE="Zlib License"
+ATSRC_PACKAGE_DOCLINK="http://www.zlib.net/manual.html"
+ATSRC_PACKAGE_RELFIXES=
+ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}"
+ATSRC_PACKAGE_PRE="test -d zlib-${ATSRC_PACKAGE_VERID}"
+ATSRC_PACKAGE_CO=([0]="wget -O zlib-${ATSRC_PACKAGE_VERID}.tar.gz https://github.com/madler/zlib/archive/${ATSRC_PACKAGE_REV}.tar.gz")
+ATSRC_PACKAGE_POST="tar xzf zlib-${ATSRC_PACKAGE_VERID}.tar.gz --transform=s/zlib-${ATSRC_PACKAGE_REV}[^\\/]*/zlib-${ATSRC_PACKAGE_VERID}/"
+ATSRC_PACKAGE_SRC="${AT_BASE}/sources/zlib-${ATSRC_PACKAGE_VERID}"
+ATSRC_PACKAGE_WORK=${AT_WORK_PATH}/zlib
+ATSRC_PACKAGE_MLS=""
+ATSRC_PACKAGE_ALOC=""
+ATSRC_PACKAGE_PATCHES=""
+ATSRC_PACKAGE_TARS=""
+ATSRC_PACKAGE_MAKE_CHECK=""
+ATSRC_PACKAGE_DISTRIB=no
+ATSRC_PACKAGE_BUNDLE=toolchain_extra


### PR DESCRIPTION
There was a recent effort to optimize some hot functions from zlib
to increase its performance on Power processors. Patch sets have
already been sent to the community to optimize the following functions:
  - longest_match
  - slide_hash
  - adler32
  - crc32

Performance tests show considerable improvements on compression and
decompression throughputs, ranging from 4% up to 160%.

As of now, all patches have already been waiting reviews for a few
months, without any indication that this will happen any time soon.

This commit incorporates those optimizations in the zlib package
distributed with AT as out-of-tree patches while they are not
integrated upstream.