### PR TITLE
Update gcc on AT next

### DIFF
--- a/configs/next/packages/gcc/sources
+++ b/configs/next/packages/gcc/sources
@@ -23,7 +23,7 @@ ATSRC_PACKAGE_NAME="GCC (GNU Compiler Collection)"
 ATSRC_PACKAGE_SUBPACKAGE_NAME_0="GNU Standard C++ Library v3 (Libstdc++-v3)"
 ATSRC_PACKAGE_SUBPACKAGE_NAME_1="GNU Libgomp"
 ATSRC_PACKAGE_VER=11.0.0
-ATSRC_PACKAGE_REV=c22027a00ede
+ATSRC_PACKAGE_REV=aef6e234a8a7
 ATSRC_PACKAGE_LICENSE="GPL 3.0"
 ATSRC_PACKAGE_DOCLINK="https://gcc.gnu.org/onlinedocs/gcc/"
 ATSRC_PACKAGE_SUBPACKAGE_DOCLINK_0="https://gcc.gnu.org/libstdc++/"
@@ -54,8 +54,8 @@ atsrc_get_patches ()
 
 	# Avoid a misconfiguration of tuned libraries as seen in issue #204.
 	at_get_patch \
-		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/e33a3dd405ee40492b9f25fc1ece49cdecc00c93/GCC%20PowerPC%20Backport/9/0001-libssp-Ignore-vsnprintf-test-when-ssp_have_usable_vs.patch' \
-		2a757025a949d5d7e5e675bafa423e9a || return ${?}
+		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/704c09577104f48acca9eb267e5c5afda183eb71/GCC%20PowerPC%20Backport/9/0001-libssp-Ignore-vsnprintf-test-when-ssp_have_usable_vs.patch' \
+		f62370874f2717c6e530d27083434fe8 || return ${?}
 
 	# Avoid an error on libstdc++ when running msgfmt.
 	at_get_patch \


### PR DESCRIPTION
There was another change to `libssp/configure` upstream, so our patch had to be updated again.

Bump to revision aef6e234a8a7 and update libssp patch.

Close #1464.