### PR TITLE
Fix remote-build.exp remote-home commit

### DIFF
--- a/remote-build.exp
+++ b/remote-build.exp
@@ -206,6 +206,8 @@ foreach server $servers {
 		}
 	}
 
+	flush_expect
+
 	set host_trayprefix $trayprefix
 	set host_destprefix $destprefix
 


### PR DESCRIPTION
Previous commit for issue #1282 can be flaky if there is a fair amount
of text after logging in and before the first command can be executed.

Flushing this data before executing that first command is essential.

Fixes #1282.

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>