### PR TITLE
Fix libnxz deb on AT >= 14.0

### DIFF
--- a/configs/14.0/deb/monolithic/control
+++ b/configs/14.0/deb/monolithic/control
@@ -169,11 +169,15 @@ Description: Advance Toolchain
  toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
  This package contains the NX GZIP Library.
 
+Package: advance-toolchain-libnxz-dbg
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-libnxz-dbg (= __AT_FULL_VER__)
+Description: Advance Toolchain
+ This package contains the NX GZIP Library debugging information.
+
 Package: advance-toolchain-__AT_MAJOR_INTERNAL__-libnxz-dbg
 Architecture: ppc64el
 Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-libnxz (= __AT_FULL_VER__)
 Depends: ${shlibs:Depends} ${misc:Depends}
 Description: Advance Toolchain
- The advance toolchain is a self contained toolchain which provides preview
- toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
  This package contains the NX GZIP Library debugging information.

--- a/configs/14.0/deb/monolithic_cross/control
+++ b/configs/14.0/deb/monolithic_cross/control
@@ -89,9 +89,9 @@ Description: Advance Toolchain
  This package provides the necessary libraries to build multi-threaded
  applications.
 
-Package: advance-toolchain-libnxz
-Architecture: ppc64el
-Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-libnxz (= __AT_FULL_VER__)
+Package: advance-toolchain-cross__BUILD_ARCH__-libnxz
+Architecture: any
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-cross__BUILD_ARCH__-libnxz (= __AT_FULL_VER__)
 Depends: ${shlibs:Depends} ${misc:Depends}
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview
@@ -100,7 +100,7 @@ Description: Advance Toolchain
 
 Package: advance-toolchain-__AT_MAJOR_INTERNAL__-cross__BUILD_ARCH__-libnxz
 Architecture: any
-Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-cross (= __AT_FULL_VER__)
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-cross__BUILD_ARCH__ (= __AT_FULL_VER__)
 Depends: ${shlibs:Depends} ${misc:Depends}
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview

--- a/utils/install_tools.sh
+++ b/utils/install_tools.sh
@@ -48,10 +48,10 @@ install_native ()
 			advance-toolchain-*mcore* \
 			advance-toolchain-*perf* || return ${?}
 		if [ -e advance-toolchain-golang* ]; then
-			sudo rpm -iv advance-toolchain-golang* || return ${?}
+			sudo rpm -${2}v advance-toolchain-golang* || return ${?}
 		fi
-		if [ -e advance-toolchain-*libnxz* ]; then
-			sudo rpm -iv advance-toolchain-*libnxz* || return ${?}
+		if [ -e advance-toolchain-*libnxz-${version}* ]; then
+			sudo rpm -${2}v advance-toolchain-*libnxz* || return ${?}
 		fi
 	fi
 }
@@ -67,15 +67,12 @@ install_cross ()
 			|| return ${?}
 		sudo dpkg -i advance-toolchain-at*cross-ppc*mcore* \
 			advance-toolchain-at*cross-ppc*extras* || return ${?}
-		if [ -e advance-toolchain-*libnxz* ]; then
-			sudo dpkg -i advance-toolchain-*libnxz* || return ${?}
+		if [ -e advance-toolchain-at*cross-ppc*libnxz* ]; then
+			sudo dpkg -i advance-toolchain-at*cross-ppc*libnxz* || return ${?}
 		fi
 	else
 		sudo rpm -${1}v advance-toolchain-*common* || return ${?}
 		sudo rpm -${1}v advance-toolchain-*cross-ppc* || return ${?}
-		if [ -e advance-toolchain-*libnxz* ]; then
-			sudo rpm -iv advance-toolchain-*libnxz* || return ${?}
-		fi
 	fi
 }
 


### PR DESCRIPTION
Fixed the rules that create the deb packages.
Fixed the script that installs libnxz deb/rpm packages.

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>