### PR TITLE
Disable gdbserver build on Binutils

### DIFF
--- a/configs/14.0/packages/binutils/stage_1
+++ b/configs/14.0/packages/binutils/stage_1
@@ -1,1 +1,99 @@
-../../../13.0/packages/binutils/stage_1
+#!/usr/bin/env bash
+#
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# binutils build parameters for stage 1
+# =====================================
+#
+
+ATCFG_HOLD_TEMP_INSTALL='no'
+ATCFG_HOLD_TEMP_BUILD='no'
+# Build in a new directory
+ATCFG_BUILD_STAGE_T='dir'
+
+# Conditional configure command
+atcfg_configure() {
+	if [[ "${cross_build}" == "no" ]]; then
+		sysroot=/
+	else
+		sysroot=${dest_cross}
+	fi
+
+	CC=${system_cc} \
+	CFLAGS="-g -O" \
+	CXXFLAGS="-g -O" \
+	${ATSRC_PACKAGE_WORK}/configure --build=${host} \
+					--host=${host} \
+					--target=${target} \
+					${alternate_target:+--enable-targets=${alternate_target}} \
+					--with-sysroot=${sysroot} \
+					--prefix=${at_dest} \
+					--disable-gdb \
+					--disable-readline \
+					--disable-libdecnumber \
+					--disable-sim \
+					--disable-nls
+
+}
+
+# Make command for build
+atcfg_make() {
+	${SUB_MAKE} all
+}
+
+# atcfg_make_check() done at stage_2
+
+# Install command for build
+atcfg_install() {
+	make install DESTDIR=${install_place}
+}
+
+# Post install settings or commands to run
+atcfg_post_install() {
+	# Create the required symlinks to install, which are a requirement for
+	# cross builds, but now, we are assuming that every build should have the
+	# triple shortcut installed. So, create binutils ${target(32|64)}-* symlinks
+	pushd ${install_place}/${at_dest}/bin
+	for CMD in addr2line ar as c++filt ld nm objcopy objdump ranlib size strings strip; do
+		if [[ -x ${CMD} ]] && [[ ! -e ${target32}-${CMD} ]]; then
+			ln -sfn ${CMD} ${target32}-${CMD}
+		fi
+	done
+	for CMD in addr2line ar c++filt nm objcopy objdump ranlib size strings strip; do
+		if [[ -x ${CMD} ]] && [[ ! -e ${target64}-${CMD} ]]; then
+			ln -sfn ${CMD} ${target64}-${CMD}
+		fi
+	done
+	if [[ "${target}" == "${target64}" ]]; then
+		if [[ ! -e ${target64}-as ]]; then
+			echo -e "#!/bin/bash\nexec ${at_dest}/bin/as \"${@}\"" > ${target64}-as
+			chmod a+x ${target64}-as
+		fi
+		if [[ ! -e ${target64}-ld ]]; then
+			echo -e "#!/bin/bash\nexec ${at_dest}/bin/ld \"${@}\"" > ${target64}-ld
+			chmod a+x ${target64}-ld
+		fi
+	fi
+	# This was needed to fix the cross build which defaults to ${target64}
+	# target. So, create binutils ${target32}-* symlinks
+	for CMD in addr2line ar as c++filt elfedit embedspu gprof ld nm objcopy objdump ranlib readelf size strings strip; do
+		if [[ -x ${target64}-${CMD} ]] && \
+		   [[ ! -f ${target32}-${CMD} ]]; then
+			ln -sfn ${target64}-${CMD} ${target32}-${CMD}
+		fi
+	done
+	popd
+}

--- a/configs/14.0/packages/binutils/stage_1
+++ b/configs/14.0/packages/binutils/stage_1
@@ -42,6 +42,7 @@ atcfg_configure() {
 					--with-sysroot=${sysroot} \
 					--prefix=${at_dest} \
 					--disable-gdb \
+					--disable-gdbserver \
 					--disable-readline \
 					--disable-libdecnumber \
 					--disable-sim \

--- a/configs/14.0/packages/binutils/stage_2
+++ b/configs/14.0/packages/binutils/stage_2
@@ -38,6 +38,7 @@ atcfg_configure() {
 						--prefix=${at_dest} \
 						--libdir=${at_dest}/lib${compiler##32} \
 						--disable-gdb \
+						--disable-gdbserver \
 						--disable-readline \
 						--disable-libdecnumber \
 						--disable-sim \
@@ -62,6 +63,7 @@ atcfg_configure() {
 						--with-sysroot=${dest_cross} \
 						--prefix=${at_dest} \
 						--disable-gdb \
+						--disable-gdbserver \
 						--disable-readline \
 						--disable-libdecnumber \
 						--disable-sim \

--- a/configs/14.0/packages/binutils/stage_2
+++ b/configs/14.0/packages/binutils/stage_2
@@ -1,1 +1,90 @@
-../../../13.0/packages/binutils/stage_2
+#!/usr/bin/env bash
+#
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+
+ATCFG_HOLD_TEMP_INSTALL='no'
+ATCFG_HOLD_TEMP_BUILD='no'
+# Build in a new directory
+ATCFG_BUILD_STAGE_T='dir'
+
+# Conditional configure command
+atcfg_configure() {
+	if [[ "${cross_build}" == "no" ]]; then
+		# Configure command for native builds
+		CC=${at_dest}/bin/gcc \
+		CXX=${at_dest}/bin/g++ \
+		CFLAGS="-g -O2 -Wno-error=stringop-truncation" \
+		CXXFLAGS="-g -O2" \
+		${ATSRC_PACKAGE_WORK}/configure --build=${host} \
+						--host=${target} \
+						--target=${target} \
+						${alternate_target:+--enable-targets=${alternate_target}} \
+						--with-sysroot=/ \
+						--prefix=${at_dest} \
+						--libdir=${at_dest}/lib${compiler##32} \
+						--disable-gdb \
+						--disable-readline \
+						--disable-libdecnumber \
+						--disable-sim \
+						--disable-nls \
+						--enable-shared \
+						--enable-plugins \
+						--enable-install-libiberty=./ \
+						--enable-gold
+	else
+		# Configure command for cross builds
+		# TODO: Since Binutils 2.31, gold requires to build with
+		# -std=c++11.  Please review if it's possible to remove this
+		# later.
+		CC=${system_cc} \
+		CXX=${system_cxx} \
+		CFLAGS="-g -O" \
+		CXXFLAGS="-g -O -std=c++11" \
+		${ATSRC_PACKAGE_WORK}/configure --build=${host} \
+						--host=${host} \
+						--target=${target} \
+						${target64:+--enable-targets=${target64}} \
+						--with-sysroot=${dest_cross} \
+						--prefix=${at_dest} \
+						--disable-gdb \
+						--disable-readline \
+						--disable-libdecnumber \
+						--disable-sim \
+						--disable-nls \
+						--enable-plugins \
+						--enable-gold
+	fi
+}
+
+
+# Make command for build
+atcfg_make() {
+	${SUB_MAKE} all
+}
+
+# Make command for build
+atcfg_make_check() {
+	PATH=${at_dest}/bin:${PATH} \
+	${SUB_MAKE} check
+}
+
+
+# Install command for build
+atcfg_install() {
+	${SUB_MAKE} install DESTDIR=${install_place}
+}

--- a/configs/14.0/packages/binutils/stage_3
+++ b/configs/14.0/packages/binutils/stage_3
@@ -1,1 +1,68 @@
-../../../13.0/packages/binutils/stage_3
+#!/usr/bin/env bash
+#
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# binutils build parameters for 32 bits
+# =====================================
+#
+
+ATCFG_HOLD_TEMP_INSTALL='no'
+ATCFG_HOLD_TEMP_BUILD='no'
+# Build in a new directory
+ATCFG_BUILD_STAGE_T='dir'
+
+
+# Configure command for native builds
+atcfg_configure() {
+	PATH=${at_dest}/bin:${PATH} \
+	CC="${at_dest}/bin/gcc" \
+	CXX="${at_dest}/bin/g++" \
+	CFLAGS="-m32 -g -O2" \
+	CXXFLAGS="-m32 -g -O2" \
+	${ATSRC_PACKAGE_WORK}/configure \
+		--build=${target32} \
+		--host=${target32} \
+		--target=${target32} \
+		--with-sysroot=/ \
+		--prefix="${at_dest}" \
+		--libdir="${at_dest}/lib" \
+		--disable-nls \
+		--disable-gdb \
+		--disable-readline \
+		--disable-libdecnumber \
+		--disable-sim \
+		--enable-shared \
+		--enable-plugins \
+		--enable-install-libiberty=./
+}
+
+
+# Make command for build
+atcfg_make() {
+	PATH=${at_dest}/bin:${PATH} \
+	${SUB_MAKE} all-libiberty all-bfd
+}
+
+# atcfg_make_check()  is done at stage_2
+
+# Install command for build
+atcfg_install() {
+	PATH=${at_dest}/bin:${PATH} \
+	${SUB_MAKE} install-libiberty install-bfd DESTDIR=${install_place}
+}
+
+# SPECIAL SETTINGS
+# =========================================================

--- a/configs/14.0/packages/binutils/stage_3
+++ b/configs/14.0/packages/binutils/stage_3
@@ -41,6 +41,7 @@ atcfg_configure() {
 		--libdir="${at_dest}/lib" \
 		--disable-nls \
 		--disable-gdb \
+		--disable-gdbserver \
 		--disable-readline \
 		--disable-libdecnumber \
 		--disable-sim \

--- a/configs/next/packages/gdb/stage_1
+++ b/configs/next/packages/gdb/stage_1
@@ -1,1 +1,82 @@
-../../../14.0/packages/gdb/stage_1
+#!/usr/bin/env bash
+#
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# GDB build parameters for stage 1
+# ================================
+#
+
+source ${AT_BASE}/scripts/utilities/bitsize_selection.sh
+
+# Tell the build system to hold the temp install folder
+ATCFG_HOLD_TEMP_INSTALL='no'
+# Tell the build system to hold the temp build folder
+ATCFG_HOLD_TEMP_BUILD='no'
+# Build in a new directory
+ATCFG_BUILD_STAGE_T='dir'
+
+
+atcfg_configure() {
+	local base_libdir="lib64"
+	local enable_bfd="--enable-64-bit-bfd"
+	local bit_size=64
+
+	if [[ "${cross_build}" == "yes" ]]; then
+		CC="${system_cc}" \
+		CFLAGS="-g -m${env_build_arch}" \
+		${ATSRC_PACKAGE_WORK}/configure --build=${host} \
+			--host=${host} \
+			--target=${target64:-$target} \
+			--prefix="${at_dest}" \
+			--libdir="${at_dest}/lib${compiler##32}" \
+			${disable_multilib: +--disable_multilb} \
+			--with-separate-debug-dir="/usr/lib64/debug" \
+			--enable-werror=no \
+			--with-libexpat-prefix=${tmp_dir}
+	else
+		if [[ "${build_arch}" == "ppc" ]]; then
+			base_libdir="lib"
+			enable_bfd=
+		fi
+		PATH=${at_dest}/bin:${PATH} \
+		CC="${at_dest}/bin/gcc" \
+		CFLAGS="-g -m${bit_size}" \
+		PYTHONHOME="${at_dest}" \
+		${ATSRC_PACKAGE_WORK}/configure \
+			--host=${target} \
+			--target=${target} \
+			--build=${target} \
+			--prefix="${at_dest}" \
+			--libdir="${at_dest}/${base_libdir}" \
+			${enable_bfd} \
+			--disable-sim \
+			--with-python="${at_dest}/bin/python3" \
+			--with-separate-debug-dir="${at_dest}/lib/debug:/usr/lib/debug" \
+			--enable-werror=no
+	fi
+}
+
+
+atcfg_make() {
+	PATH=${at_dest}/bin:${PATH} \
+		${SUB_MAKE} all-gdb
+}
+
+
+atcfg_install() {
+	PATH=${at_dest}/bin:${PATH} \
+		${SUB_MAKE} install-gdb DESTDIR=${install_place}
+}

--- a/configs/next/packages/gdb/stage_1
+++ b/configs/next/packages/gdb/stage_1
@@ -72,11 +72,12 @@ atcfg_configure() {
 
 atcfg_make() {
 	PATH=${at_dest}/bin:${PATH} \
-		${SUB_MAKE} all-gdb
+		${SUB_MAKE} all-gdbsupport all-gdb all-gdbserver
 }
 
 
 atcfg_install() {
 	PATH=${at_dest}/bin:${PATH} \
-		${SUB_MAKE} install-gdb DESTDIR=${install_place}
+		${SUB_MAKE} install-gdbsupport install-gdb install-gdbserver \
+			    DESTDIR=${install_place}
 }

--- a/fvtr/ck_binaries/ck_binaries.exp
+++ b/fvtr/ck_binaries/ck_binaries.exp
@@ -43,7 +43,7 @@ regexp "($gcc_ver\[^\[:blank:\]\]+)" \
 set as_exec {ar as ld nm objcopy objdump ranlib strip}
 
 set alt_exec $as_exec
-lappend addr2line c++filt size strings
+lappend alt_exec addr2line c++filt size strings
 
 set n_exec $alt_exec
 lappend n_exec c++ g++ gcc gfortran
@@ -63,7 +63,7 @@ if { $env(AT_MAJOR_VERSION) >= 9.0 } {
 }
 
 # Binaries distributed with a different name on cross and non-cross
-set dif_exec {cpp elfedit embedspu gprof readelf}
+set dif_exec {cpp elfedit embedspu gdb gdbserver gprof readelf}
 if { $env(AT_CROSS_BUILD) == "yes" } {
 	set alt_exec [concat ${alt_exec} ${dif_exec}]
 	set tgt_exec [concat ${tgt_exec} ${dif_exec}]


### PR DESCRIPTION
Binutils has recently changed its build environment and moved gdbserver
to the root directory.  Now, gdbserver is built by default causing a
conflict with the gdbserver build with gdb.