### PR TITLE
Fix at-create-ibmcmp-cfg.sh for recent AT versions

### DIFF
--- a/scripts/distributed/at-create-ibmcmp-cfg.sh
+++ b/scripts/distributed/at-create-ibmcmp-cfg.sh
@@ -151,9 +151,9 @@ create_config ()
 			# internal config files of the referred XL compiler, so
 			# it doesn't touch those configs inside Advance
 			# Toolchain folder tree, generated above.
-			echo "    ${config_script} -at"
+			echo "    ${config_script} -at ${at}"
 			{
-				${config_script} -at
+				${config_script} -at ${at}
 			}  &> ${logfile}
 		# Without a valid license, instruct user and abort configuration
 		else
@@ -161,7 +161,7 @@ create_config ()
 			     "Aborting XLC/XLF config file generation."
 			echo "A log is available at ${logfile}"
 			echo "Please accept the XLC/XLF license prior to" \
-			     "this, and only then run '${config_script} -at'" \
+			     "this, and only then run '${config_script} -at ${at}'" \
 			     "manually."
 			exit 1
 		fi
@@ -172,7 +172,7 @@ create_config ()
 			echo "Your XLC/XLF license wasn't accepted yet." \
 			     "Aborting XLC/XLF config file generation."
 			echo "A log is available at ${logfile}"
-			echo "Run '${new_install} -at' manually."
+			echo "Run '${new_install} -at ${at}' manually."
 			exit 1
 		fi
 


### PR DESCRIPTION
`at-create-ibmcmp-cfg.sh` invokes `xlc_configure -at`.
Without specifying the AT version, only "supported" versions
of AT are found by `xlc_configure`, and current versions
of XL C/C++ only support AT 8, 9, 10, and 11.  AT versions
12 and 13 will report an error at install or upgrade, or
when manually attempting to generate the configuration files:
```
$ /usr/bin/sudo /opt/at13.0/scripts/at-create-ibmcmp-cfg.sh
Testing for optional IBM XL compilers installation...
This will check for XLC/XLF availability and create config files for them in /opt/at13.0/scripts
IBM XL compilers found in /opt/ibm
File /opt/at13.0/scripts/xlC-16_1_1-AT13_0.dfp.cfg already exists. Recreating it!
    /opt/ibm/xlC/16.1.1/bin/xlc_configure -gcc /opt/at13.0 -o /opt/at13.0/scripts/xlC-16_1_1-AT13_0.dfp.cfg
    /opt/ibm/xlC/16.1.1/bin/xlc_configure -at
Error creating the config file. Aborting XLC/XLF config file generation.
A log is available at /tmp/at-xlC.DEOAL9
If you need config files for XLC/XLF, please refer to your XLC/XLF config documentation on how to create them manually.
$ /usr/bin/sudo cat /tmp/at-xlC.DEOAL9
ERROR: /opt/at11.0, /opt/at9.0, /opt/at8.0, and /opt/at10.0 do not exist, specify a path to the advance toolchain
```

Specifying the AT version to `xlc_configure` eliminates the error:
```
$ /usr/bin/sudo /opt/at13.0/scripts/at-create-ibmcmp-cfg.sh
Testing for optional IBM XL compilers installation...
This will check for XLC/XLF availability and create config files for them in /opt/at13.0/scripts
IBM XL compilers found in /opt/ibm
    /opt/ibm/xlC/16.1.1/bin/xlc_configure -gcc /opt/at13.0 -o /opt/at13.0/scripts/xlC-16_1_1-at13.0.dfp.cfg
    /opt/ibm/xlC/16.1.1/bin/xlc_configure -at /opt/at13.0
All config files created in /opt/at13.0/scripts and are ready for use.
If you need to use XLC/XLF with the Advance Toolchain, invoke the XL compiler suite using -F/opt/at13.0/scripts/<generated_config_file>.
```

Fixes #1542 

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>