### PR TITLE
Replace ftp:// links with https:// links in doc

### DIFF
--- a/docs/advtool-compiler.html
+++ b/docs/advtool-compiler.html
@@ -126,7 +126,7 @@ pre {
 
 	<li>The gpg public key <code>gpg-pubkey-6976a827-5164221b</code> is provided in the IBM repositories. This public key is used to verify the authenticity of both the Advance Toolchain packages and the repository contents. Download the gpg public key for your Linux distribution and import it using the following commands:
 <pre>
-wget ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHEL7/gpg-pubkey-6976a827-5164221b
+wget https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHEL7/gpg-pubkey-6976a827-5164221b
 rpm --import gpg-pubkey-6976a827-5164221b
 </pre>
 <p>Notes:</p>
@@ -136,11 +136,11 @@ rpm --import gpg-pubkey-6976a827-5164221b
 # Begin of configuration file
 [advance-toolchain]
 name=Advance Toolchain IBM FTP
-baseurl=ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/<em>RHELX</em>
+baseurl=https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/<em>RHELX</em>
 failovermethod=priority
 enabled=1
 gpgcheck=1
-gpgkey=ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/<em>RHELX</em>/gpg-pubkey-6976a827-5164221b
+gpgkey=https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/<em>RHELX</em>/gpg-pubkey-6976a827-5164221b
 # End of configuration file
 </pre>
 <p>Replace <em>RHELX </em>with the Red Hat release that you are using.</p>
@@ -160,7 +160,7 @@ gpgkey=ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/
 
 	<li>The gpg public key <code>gpg-pubkey-6976a827-5164221b</code> is provided in the IBM repositories. This public key is used to verify the authenticity of both the Advance Toolchain packages and the repository contents. Download the gpg public key for your Linux distribution and import it using the following commands:
 <pre>
-wget ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHEL7/gpg-pubkey-6976a827-5164221b
+wget https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHEL7/gpg-pubkey-6976a827-5164221b
 rpm --import gpg-pubkey-6976a827-5164221b
 </pre>
 </li>
@@ -169,11 +169,11 @@ rpm --import gpg-pubkey-6976a827-5164221b
 # Begin of configuration file
 [advance-toolchain]
 name=Advance Toolchain IBM FTP
-baseurl=ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/SLES_12
+baseurl=https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/SLES_12
 failovermethod=priority
 enabled=1
 gpgcheck=1
-gpgkey=ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/SLES_12/gpg-pubkey-6976a827-5164221b
+gpgkey=https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/SLES_12/gpg-pubkey-6976a827-5164221b
 # End of configuration file
 </pre>
 </li>
@@ -195,7 +195,7 @@ gpgkey=ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/SL
 
 <ol><li>As root, add the IBM FTP to the repository list:
 <pre>
-zypper addrepo ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/SLES_12 "Advance Toolchain"
+zypper addrepo https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/SLES_12 "Advance Toolchain"
 </pre>
 <p>This will create a new repository entry called "Advance Toolchain" pointing to the IBM FTP site</p>
 <li>To install the cross-compiler, run the following command: <code>zypper install advance-toolchain-atX.X-cross-ppc64</code>
@@ -214,14 +214,14 @@ zypper addrepo ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at
 
 	<li>The gpg public key <code>gpg-pubkey-6976a827-5164221b</code> is provided in the repositories. This public key is used to verify the authenticity of both the Advance Toolchain packages and the repository contents. Download the gpg public key for your Linux distribution and import it using the following commands:
 <pre>
-wget ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/trusty/6976a827.gpg.key
+wget https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/trusty/6976a827.gpg.key
 sudo apt-key add 6976a827.gpg.key
 </pre>
 </li>
 <li>Configure the Advance Toolchain repositories by adding the following line to <code>/etc/apt/sources.list</code>:
 <p>On ppc64el or amd64:</p>
 <pre>
-deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu trusty atX.X
+deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu trusty atX.X
 </pre>
 
 <p>Notes:</p>
@@ -229,15 +229,15 @@ deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu tru
 <ul>
 	<li>When installing on Ubuntu 16.04 (xenial) or Ubuntu 14.10 (utopic), point to its respective repository:
 <pre>
-deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu xenial atX.X
-deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu utopic atX.X
+deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu xenial atX.X
+deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu utopic atX.X
 </pre>
 	</li>
 
 
     	<li>When installing on Debian 8 (jessie), point to its respective repository:
 <pre>
-deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian jessie atX.X
+deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian jessie atX.X
 </pre>
 	</li>
 </ul>

--- a/docs/advtool-installation.html
+++ b/docs/advtool-installation.html
@@ -74,12 +74,12 @@ pre {
       <td>
         <p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#installUbuntu">Install Advance Toolchain</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
-        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian/dists/stretch/at12.0">Repository and release notes</a></p>
+        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian/dists/stretch/at12.0">Repository and release notes</a></p>
       </td>
       <td>
         <p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#installUbuntu">Install Advance Toolchain</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
-        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian/dists/stretch/at11.0">Repository and release notes</a></p>
+        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian/dists/stretch/at11.0">Repository and release notes</a></p>
       </td>
     </tr>
     <tr>
@@ -87,7 +87,7 @@ pre {
       <td>
 	<p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#installUbuntu">Install Advance Toolchain</a></p><br />
 	<p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
-	<p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian/dists/buster/at13.0">Repository and release notes</a></p>
+	<p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian/dists/buster/at13.0">Repository and release notes</a></p>
       </td>
       <td></td>
       <td></td>
@@ -98,12 +98,12 @@ pre {
       <td>
         <p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#redhatinstalltabs">Install Advance Toolchain</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler/">Install cross compiler</a></p><br />
-        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHEL7/at12.0">Repository and release notes</a></p>
+        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHEL7/at12.0">Repository and release notes</a></p>
       </td>
       <td>
         <p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#redhatinstalltabs">Install Advance Toolchain</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler/">Install cross compiler</a></p><br />
-        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHEL7/at11.0">Repository and release notes</a></p>
+        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHEL7/at11.0">Repository and release notes</a></p>
       </td>
     </tr>
     <tr>
@@ -111,7 +111,7 @@ pre {
       <td>
         <p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#redhatinstalltabs">Install Advance Toolchain</a></p><br />
 	<p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
-	<p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHEL8/at13.0">Repository and release notes</a></p>
+	<p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHEL8/at13.0">Repository and release notes</a></p>
       </td>
       <td></td>
       <td></td>
@@ -122,12 +122,12 @@ pre {
       <td>
         <p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#slesinstallation">Install Advance Toolchain</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
-        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/SLES_12/at12.0">Repository and release notes</a></p>
+        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/SLES_12/at12.0">Repository and release notes</a></p>
       </td>
       <td>
         <p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#slesinstallation">Install Advance Toolchain</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
-        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/SLES_12/at11.0">Repository and release notes</a></p>
+        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/SLES_12/at11.0">Repository and release notes</a></p>
       </td>
     </tr>
     <tr>
@@ -135,7 +135,7 @@ pre {
       <td>
         <p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#slesinstallation">Install Advance Toolchain</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
-        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/SLES_15/at13.0">Repository and release notes</a></p>
+        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/SLES_15/at13.0">Repository and release notes</a></p>
       </td>
       <td></td>
       <td></td>
@@ -146,12 +146,12 @@ pre {
       <td>
         <p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#installUbuntu">Install Advance Toolchain</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
-        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/xenial/at12.0">Repository and release notes</a></p>
+        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/xenial/at12.0">Repository and release notes</a></p>
       </td>
       <td>
         <p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#installUbuntu">Install Advance Toolchain</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
-        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/xenial/at11.0">Repository and release notes</a></p>
+        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/xenial/at11.0">Repository and release notes</a></p>
       </td>
     </tr>
     <tr>
@@ -159,7 +159,7 @@ pre {
       <td>
         <p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#installUbuntu">Install Advance Toolchain</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
-        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/bionic/at13.0">Repository and release notes</a></p>
+        <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/bionic/at13.0">Repository and release notes</a></p>
       </td>
       <td></td>
       <td></td>
@@ -209,7 +209,7 @@ pre {
 
     <li>The gpg public key <code>gpg-pubkey-6976a827-5164221b</code> is provided in the IBM repositories. This public key is used to verify the authenticity of both the Advance Toolchain packages and the repository contents. Download the gpg public key for your Linux distribution and import it using the following commands:
 <pre>
-wget ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHEL7/gpg-pubkey-6976a827-5164221b
+wget https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHEL7/gpg-pubkey-6976a827-5164221b
 rpm --import gpg-pubkey-6976a827-5164221b
 </pre>
       <p>Notes:</p>
@@ -222,11 +222,11 @@ rpm --import gpg-pubkey-6976a827-5164221b
 # Begin of configuration file
 [advance-toolchain]
 name=Advance Toolchain IBM FTP
-baseurl=ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/<em>RHELX</em>
+baseurl=https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/<em>RHELX</em>
 failovermethod=priority
 enabled=1
 gpgcheck=1
-gpgkey=ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/<em>RHELX</em>/gpg-pubkey-6976a827-5164221b
+gpgkey=https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/<em>RHELX</em>/gpg-pubkey-6976a827-5164221b
 # End of configuration file
 </pre>
       <p>Replace <em>RHELX</em> with the Red Hat release that you are using.</p>
@@ -244,7 +244,7 @@ yum install advance-toolchain-atX.X-runtime \
 
 <div id="redhattab3" class="ibm-tabs-content">
 
-  <p class="ibm-light">You can use the <a href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/at_downloader/" target="_blank">Advance Toolchain (AT) downloader tool</a> to download the latest version of <i>all of</i> the AT packages for a supported distribution and create an ISO image if desired. This script looks at the official FTP sites to find the available distributions and versions and then downloads them to your system.  You can then manually install the packages. This method is intended for users with limited Internet access to their Power Systems.</p>
+  <p class="ibm-light">You can use the <a href="https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/at_downloader/" target="_blank">Advance Toolchain (AT) downloader tool</a> to download the latest version of <i>all of</i> the AT packages for a supported distribution and create an ISO image if desired. This script looks at the official FTP sites to find the available distributions and versions and then downloads them to your system.  You can then manually install the packages. This method is intended for users with limited Internet access to their Power Systems.</p>
   <p class="ibm-light">If you are installing the rpm files manually you will need to install them in the following order (due to prerequisites):</p>
 
 <pre>
@@ -336,7 +336,7 @@ rpm -ivh ibm-power-repo-latest.noarch.rpm
   <ol>
     <li>The gpg public key <code>gpg-pubkey-6976a827-5164221b</code> is provided in the IBM repositories. This public key is used to verify the authenticity of both the Advance Toolchain packages and the repository contents. Download the gpg public key for your Linux distribution and import it using the following commands:
 <pre>
-wget ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/SLES_12/gpg-pubkey-6976a827-5164221b
+wget https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/SLES_12/gpg-pubkey-6976a827-5164221b
 rpm --import gpg-pubkey-6976a827-5164221b
 </pre>
     </li>
@@ -369,13 +369,13 @@ rpm --import gpg-pubkey-6976a827-5164221b
   <ol>
     <li>The gpg public key <code>gpg-pubkey-6976a827-5164221b</code> is provided in the IBM repositories. This public key is used to verify the authenticity of both the Advance Toolchain packages and the repository contents. Download the gpg public key for your Linux distribution and import it using the following commands:
 <pre>
-wget ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/SLES_12/gpg-pubkey-6976a827-5164221b
+wget https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/SLES_12/gpg-pubkey-6976a827-5164221b
 rpm --import gpg-pubkey-6976a827-5164221b
 </pre>
 
     <li>Add IBM FTP to the repository list:
 <pre>
-zypper addrepo ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/<em>SLES_X</em> "Advance Toolchain"
+zypper addrepo https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/suse/<em>SLES_X</em> "Advance Toolchain"
 </pre>
       <p>Replace <em>SLES_X</em> with the SLES release that you are using.</p>
       <p>This command creates a new repository entry called "Advance Toolchain" pointing to the IBM FTP site.</p>
@@ -397,7 +397,7 @@ zypper install advance-toolchain-atX.X-runtime \
 </div>
 
 <div id="slestab3" class="ibm-tabs-content">
-  <p class="ibm-light">You can use the <a href="ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/at_downloader/" target="_blank">Advance Toolchain (AT) downloader tool</a> to download the latest version of <i>all of</i> the AT packages for a supported distribution and create an ISO image if desired. This script looks at the official FTP sites to find the available distributions and versions and then downloads them to your system.  You can then manually install the packages. This method is intended for users with limited Internet access to their Power Systems.</p>
+  <p class="ibm-light">You can use the <a href="https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/at_downloader/" target="_blank">Advance Toolchain (AT) downloader tool</a> to download the latest version of <i>all of</i> the AT packages for a supported distribution and create an ISO image if desired. This script looks at the official FTP sites to find the available distributions and versions and then downloads them to your system.  You can then manually install the packages. This method is intended for users with limited Internet access to their Power Systems.</p>
   <p class="ibm-light">If you are installing the rpm files manually you will need to install them in the following order (due to prerequisites):</p>
 
 <pre>
@@ -491,7 +491,7 @@ rpm -ivh ibm-power-repo-latest.noarch.rpm
 	      <li>
                 The gpg public key <code>gpg-pubkey-6976a827-5164221b</code> is provided in the repositories. This public key is used to verify the authenticity of both the Advance Toolchain packages and the repository contents. Download the gpg public key for your Linux distribution and import it using the following commands:
 <pre>
-wget ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/trusty/6976a827.gpg.key
+wget https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/trusty/6976a827.gpg.key
 sudo apt-key add 6976a827.gpg.key
 </pre>
               </li>
@@ -499,24 +499,24 @@ sudo apt-key add 6976a827.gpg.key
                 Configure the Advance Toolchain repositories by adding the following line to <code>/etc/apt/sources.list</code>:
                 <p>On ppc64el or amd64:</p>
 <pre>
-deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu trusty atX.X
+deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu trusty atX.X
 </pre>
                 <p>Notes:</p>
 
                 <ul>
                   <li>When installing on Ubuntu 14.04 (trusty), Ubuntu 16.04 (xenial) or Ubuntu 18.04 (bionic), point to its respective repository:
 <pre>
-deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu trusty atX.X
-deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu xenial atX.X
-deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu bionic atX.X
+deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu trusty atX.X
+deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu xenial atX.X
+deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu bionic atX.X
 </pre>
                   </li>
 	          <li>
                     When installing on Debian 8 (jessie), Debian 9 (stretch) or Debian 10 (buster), point to its respective repository:
 <pre>
-deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian jessie atX.X
-deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian stretch atX.X
-deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian buster atX.X
+deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian jessie atX.X
+deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian stretch atX.X
+deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian buster atX.X
 </pre>
                   </li>
                 </ul>
@@ -548,7 +548,7 @@ sudo aptitude install advance-toolchain-atX.X-runtime \
     <li>
       The gpg public key <code>gpg-pubkey-6976a827-5164221b</code> is provided in the repositories. This public key is used to verify the authenticity of both the Advance Toolchain packages and the repository contents. Download the gpg public key for your Linux distribution and import it using the following commands:
 <pre>
-wget ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/trusty/6976a827.gpg.key
+wget https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/trusty/6976a827.gpg.key
 sudo apt-key add 6976a827.gpg.key
 </pre>
     </li>
@@ -556,23 +556,23 @@ sudo apt-key add 6976a827.gpg.key
       Configure the Advance Toolchain repositories by adding the following line to <code>/etc/apt/sources.list</code>:
       <p>On ppc64el or amd64:</p>
 <pre>
-deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu trusty atX.
+deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu trusty atX.
 </pre>
       <p>Notes:</p>
       <ul>
         <li>When installing on Ubuntu 14.04 (trusty), Ubuntu 16.04 (xenial) or Ubuntu 18.04 (bionic), point to its respective repository:
 <pre>
-deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu trusty atX.X
-deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu xenial atX.X
-deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu bionic atX.X
+deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu trusty atX.X
+deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu xenial atX.X
+deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu bionic atX.X
 </pre>
         </li>
         <li>
           When installing on Debian 8 (jessie), Debian 9 (stretch) or Debian 10 (buster), point to its respective repository:
 <pre>
-deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian jessie atX.X
-deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian stretch atX.X
-deb ftp://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian buster atX.X
+deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian jessie atX.X
+deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian stretch atX.X
+deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian buster atX.X
 </pre>
 
         </li>


### PR DESCRIPTION
Ubuntu 20.04 starts to complain about ftp:// links.
Replacing ftp:// links with https:// links as public.dhe.ibm.com supports it.

Fix #1544 

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>