### PR TITLE
Make debuginfo usable by `perf`

### DIFF
--- a/configs/14.0/specs/monolithic.spec
+++ b/configs/14.0/specs/monolithic.spec
@@ -318,6 +318,9 @@ for DIR in $(find %{_prefix}/lib/debug/%{_prefix}/lib*/ -type d \
     dest=${DIR#%{_prefix}/lib/debug}
     mkdir -p ${dest}/.debug/
     ln -sf ${DIR}/* ${dest}/.debug/
+    for FILE in $(ls -1 ${DIR}/*.debug 2>/dev/null); do
+        ln -sf ${FILE} ${dest}/.debug/$(basename ${FILE} .debug)
+    done
 done
 
 #---------------------------------------------------
@@ -329,6 +332,9 @@ for DIR in $(find %{_prefix}/lib/debug/%{_prefix}/lib*/ -type d \
     dest=${DIR#%{_prefix}/lib/debug}
     mkdir -p ${dest}/.debug/
     ln -sf ${DIR}/* ${dest}/.debug/
+    for FILE in $(ls -1 ${DIR}/*.debug 2>/dev/null); do
+        ln -sf ${FILE} ${dest}/.debug/$(basename ${FILE} .debug)
+    done
 done
 
 #---------------------------------------------------
@@ -340,6 +346,9 @@ for DIR in $(find %{_prefix}/lib/debug/%{_prefix}/lib*/ -type d \
     dest=${DIR#%{_prefix}/lib/debug}
     mkdir -p ${dest}/.debug/
     ln -sf ${DIR}/* ${dest}/.debug/
+    for FILE in $(ls -1 ${DIR}/*.debug 2>/dev/null); do
+        ln -sf ${FILE} ${dest}/.debug/$(basename ${FILE} .debug)
+    done
 done
 
 #---------------------------------------------------
@@ -351,6 +360,9 @@ for DIR in $(find %{_prefix}/lib/debug/%{_prefix}/lib*/ -type d \
     dest=${DIR#%{_prefix}/lib/debug}
     mkdir -p ${dest}/.debug/
     ln -sf ${DIR}/* ${dest}/.debug/
+    for FILE in $(ls -1 ${DIR}/*.debug 2>/dev/null); do
+        ln -sf ${FILE} ${dest}/.debug/$(basename ${FILE} .debug)
+    done
 done
 
 #---------------------------------------------------
@@ -362,6 +374,9 @@ for DIR in $(find %{_prefix}/lib/debug/%{_prefix}/lib*/ -type d \
     dest=${DIR#%{_prefix}/lib/debug}
     mkdir -p ${dest}/.debug/
     ln -sf ${DIR}/* ${dest}/.debug/
+    for FILE in $(ls -1 ${DIR}/*.debug 2>/dev/null); do
+        ln -sf ${FILE} ${dest}/.debug/$(basename ${FILE} .debug)
+    done
 done
 
 ####################################################


### PR DESCRIPTION
The debuginfo packages are not usable by the `perf` command, since
for a library `/opt/at{version}/lib64/libA.so.0`, perf looks for
`/opt/at{version}/lib64/.debug/libA-{libversion}.so`, resulting in:
```
$ perf probe -v -x /opt/at13.0/lib64/libpthread.so.0 --add 'pthread_mutex_trylock%return $retval'
[...]
Could not open debuginfo. Try to use symbols.
[...]
```

AT currently creates symlinks for
`/opt/at{version}/lib64/.debug/libA-{libversion}.so.debug`
to point to the actual debuginfo file, but not for
`/opt/at{version}/lib64/.debug/libA-{libversion}.so`

Adding the latter, as this patch does, results in:
```
$ perf probe -v -x /opt/at13.0/lib64/libpthread.so.0 --add 'pthread_mutex_trylock%return $retval'
[...]
Open Debuginfo file: /opt/at13.0/lib64/.debug/libpthread-2.30.so
Try to find probe point from debuginfo.
Symbol pthread_mutex_trylock address found : d7a0
Matched function: __pthread_mutex_trylock [66780]
Probe point found: __pthread_mutex_trylock+0
[...]
```

Fixes #965

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>