### PR TITLE
Make debuginfo usable by `perf`

### DIFF
--- a/configs/14.0/deb/monolithic/devel-dbg.postrm
+++ b/configs/14.0/deb/monolithic/devel-dbg.postrm
@@ -15,16 +15,8 @@
 # limitations under the License.
 #
 
-if [[ "${1}" == configure ]]; then
-	# Create symlinks to the debuginfo files in .debug subdirectories so
-	# valgrind, gdb, and perf can find the symbols.
-	for DIR in $(find __AT_DEST__/lib/debug/__AT_DEST__/*/ -type d \
-		     | grep -v build-id); do
-		dest=${DIR#__AT_DEST__/lib/debug}
-		mkdir -p ${dest}/.debug/
-		ln -sf ${DIR}/* ${dest}/.debug/
-		for FILE in $(ls -1 ${DIR}/*.debug 2>/dev/null); do
-			ln -sf ${FILE} ${dest}/.debug/$(basename ${FILE} .debug)
-		done
-	done
-fi
+case "${1}" in
+	remove|purge)
+		find -L __AT_DEST__ -path '*/.debug/*' -type l -exec rm -f {} \;
+		;;
+esac

--- a/configs/14.0/deb/monolithic/mcore-libs-dbg.postrm
+++ b/configs/14.0/deb/monolithic/mcore-libs-dbg.postrm
@@ -15,16 +15,8 @@
 # limitations under the License.
 #
 
-if [[ "${1}" == configure ]]; then
-	# Create symlinks to the debuginfo files in .debug subdirectories so
-	# valgrind, gdb, and perf can find the symbols.
-	for DIR in $(find __AT_DEST__/lib/debug/__AT_DEST__/*/ -type d \
-		     | grep -v build-id); do
-		dest=${DIR#__AT_DEST__/lib/debug}
-		mkdir -p ${dest}/.debug/
-		ln -sf ${DIR}/* ${dest}/.debug/
-		for FILE in $(ls -1 ${DIR}/*.debug 2>/dev/null); do
-			ln -sf ${FILE} ${dest}/.debug/$(basename ${FILE} .debug)
-		done
-	done
-fi
+case "${1}" in
+	remove|purge)
+		find -L __AT_DEST__ -path '*/.debug/*' -type l -exec rm -f {} \;
+		;;
+esac

--- a/configs/14.0/deb/monolithic/perf-dbg.postrm
+++ b/configs/14.0/deb/monolithic/perf-dbg.postrm
@@ -15,16 +15,8 @@
 # limitations under the License.
 #
 
-if [[ "${1}" == configure ]]; then
-	# Create symlinks to the debuginfo files in .debug subdirectories so
-	# valgrind, gdb, and perf can find the symbols.
-	for DIR in $(find __AT_DEST__/lib/debug/__AT_DEST__/*/ -type d \
-		     | grep -v build-id); do
-		dest=${DIR#__AT_DEST__/lib/debug}
-		mkdir -p ${dest}/.debug/
-		ln -sf ${DIR}/* ${dest}/.debug/
-		for FILE in $(ls -1 ${DIR}/*.debug 2>/dev/null); do
-			ln -sf ${FILE} ${dest}/.debug/$(basename ${FILE} .debug)
-		done
-	done
-fi
+case "${1}" in
+	remove|purge)
+		find -L __AT_DEST__ -path '*/.debug/*' -type l -exec rm -f {} \;
+		;;
+esac

--- a/configs/14.0/deb/monolithic/runtime-dbg.postrm
+++ b/configs/14.0/deb/monolithic/runtime-dbg.postrm
@@ -15,16 +15,8 @@
 # limitations under the License.
 #
 
-if [[ "${1}" == configure ]]; then
-	# Create symlinks to the debuginfo files in .debug subdirectories so
-	# valgrind, gdb, and perf can find the symbols.
-	for DIR in $(find __AT_DEST__/lib/debug/__AT_DEST__/*/ -type d \
-		     | grep -v build-id); do
-		dest=${DIR#__AT_DEST__/lib/debug}
-		mkdir -p ${dest}/.debug/
-		ln -sf ${DIR}/* ${dest}/.debug/
-		for FILE in $(ls -1 ${DIR}/*.debug 2>/dev/null); do
-			ln -sf ${FILE} ${dest}/.debug/$(basename ${FILE} .debug)
-		done
-	done
-fi
+case "${1}" in
+	remove|purge)
+		find -L __AT_DEST__ -path '*/.debug/*' -type l -exec rm -f {} \;
+		;;
+esac

--- a/configs/14.0/specs/monolithic.spec
+++ b/configs/14.0/specs/monolithic.spec
@@ -1,4 +1,4 @@
-# Copyright 2017 IBM Corporation
+# Copyright 2020 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -311,57 +311,70 @@ restorecon -R %{_prefix}/share/zoneinfo
 
 #---------------------------------------------------
 %post runtime-debuginfo
-# Create symlinks to the debuginfo files in .debug subdirectories so valgrind
-# and oprofile can find the symbols.
-for DIR in $(find %{_prefix}/lib/debug/%{_prefix}/lib*/ -type d \
+# Create symlinks to the debuginfo files in .debug subdirectories so valgrind,
+# gdb, and perf can find the symbols.
+for DIR in $(find %{_prefix}/lib/debug/%{_prefix}/*/ -type d \
              | grep -v build-id); do
     dest=${DIR#%{_prefix}/lib/debug}
     mkdir -p ${dest}/.debug/
     ln -sf ${DIR}/* ${dest}/.debug/
-done
-
+    for FILE in $(ls -1 ${DIR}/*.debug 2>/dev/null); do
+        ln -sf ${FILE} ${dest}/.debug/$(basename ${FILE} .debug)
+    done
 #---------------------------------------------------
 %post devel-debuginfo
-# Create symlinks to the debuginfo files in .debug subdirectories so valgrind
-# and oprofile can find the symbols.
-for DIR in $(find %{_prefix}/lib/debug/%{_prefix}/lib*/ -type d \
+# Create symlinks to the debuginfo files in .debug subdirectories so valgrind,
+# gdb, and perf can find the symbols.
+for DIR in $(find %{_prefix}/lib/debug/%{_prefix}/*/ -type d \
              | grep -v build-id); do
     dest=${DIR#%{_prefix}/lib/debug}
     mkdir -p ${dest}/.debug/
     ln -sf ${DIR}/* ${dest}/.debug/
+    for FILE in $(ls -1 ${DIR}/*.debug 2>/dev/null); do
+        ln -sf ${FILE} ${dest}/.debug/$(basename ${FILE} .debug)
+    done
 done
 
 #---------------------------------------------------
 %post mcore-libs-debuginfo
-# Create symlinks to the debuginfo files in .debug subdirectories so valgrind
-# and oprofile can find the symbols.
-for DIR in $(find %{_prefix}/lib/debug/%{_prefix}/lib*/ -type d \
+# Create symlinks to the debuginfo files in .debug subdirectories so valgrind,
+# gdb, and perf can find the symbols.
+for DIR in $(find %{_prefix}/lib/debug/%{_prefix}/*/ -type d \
              | grep -v build-id); do
     dest=${DIR#%{_prefix}/lib/debug}
     mkdir -p ${dest}/.debug/
     ln -sf ${DIR}/* ${dest}/.debug/
+    for FILE in $(ls -1 ${DIR}/*.debug 2>/dev/null); do
+        ln -sf ${FILE} ${dest}/.debug/$(basename ${FILE} .debug)
+    done
 done
 
 #---------------------------------------------------
 %post perf-debuginfo
-# Create symlinks to the debuginfo files in .debug subdirectories so valgrind
-# and oprofile can find the symbols.
-for DIR in $(find %{_prefix}/lib/debug/%{_prefix}/lib*/ -type d \
+# Create symlinks to the debuginfo files in .debug subdirectories so valgrind,
+# gdb, and perf can find the symbols.
+for DIR in $(find %{_prefix}/lib/debug/%{_prefix}/*/ -type d \
              | grep -v build-id); do
     dest=${DIR#%{_prefix}/lib/debug}
     mkdir -p ${dest}/.debug/
     ln -sf ${DIR}/* ${dest}/.debug/
+    for FILE in $(ls -1 ${DIR}/*.debug 2>/dev/null); do
+        ln -sf ${FILE} ${dest}/.debug/$(basename ${FILE} .debug)
+    done
 done
 
 #---------------------------------------------------
 %post libnxz-debuginfo
-# Create symlinks to the debuginfo files in .debug subdirectories so valgrind
-# and oprofile can find the symbols.
-for DIR in $(find %{_prefix}/lib/debug/%{_prefix}/lib*/ -type d \
+# Create symlinks to the debuginfo files in .debug subdirectories so valgrind,
+# gdb, and perf can find the symbols.
+for DIR in $(find %{_prefix}/lib/debug/%{_prefix}/*/ -type d \
              | grep -v build-id); do
     dest=${DIR#%{_prefix}/lib/debug}
     mkdir -p ${dest}/.debug/
     ln -sf ${DIR}/* ${dest}/.debug/
+    for FILE in $(ls -1 ${DIR}/*.debug 2>/dev/null); do
+        ln -sf ${FILE} ${dest}/.debug/$(basename ${FILE} .debug)
+    done
 done
 
 ####################################################
@@ -489,6 +502,26 @@ if [ $1 -eq 0 ] ; then  # final removal
     semanage fcontext -d -t etc_t '%{_prefix}/etc(/.*)?' 2>/dev/null
     restorecon -R %{_prefix}/etc
 fi
+
+%postun runtime-debuginfo
+# Delete symlinks to the now-deleted debuginfo files in .debug subdirectories.
+find -L %{_prefix} -path '*/.debug/*' -type l -exec rm -f {} \;
+
+%postun devel-debuginfo
+# Delete symlinks to the now-deleted debuginfo files in .debug subdirectories.
+find -L %{_prefix} -path '*/.debug/*' -type l -exec rm -f {} \;
+
+%postun mcore-libs-debuginfo
+# Delete symlinks to the now-deleted debuginfo files in .debug subdirectories.
+find -L %{_prefix} -path '*/.debug/*' -type l -exec rm -f {} \;
+
+%postun perf-debuginfo
+# Delete symlinks to the now-deleted debuginfo files in .debug subdirectories.
+find -L %{_prefix} -path '*/.debug/*' -type l -exec rm -f {} \;
+
+%postun libnxz-debuginfo
+# Delete symlinks to the now-deleted debuginfo files in .debug subdirectories.
+find -L %{_prefix} -path '*/.debug/*' -type l -exec rm -f {} \;
 
 
 ####################################################

--- a/configs/9.0/deb/monolithic/mcore-libs-dbg.postinst
+++ b/configs/9.0/deb/monolithic/mcore-libs-dbg.postinst
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2017 IBM Corporation
+# Copyright 2020 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,15 @@
 #
 
 if [[ "${1}" == configure ]]; then
-	# Create symlinks to the debuginfo files in .debug subdirectories so valgrind
-	# and oprofile can find the symbols.
-	for DIR in $(find __AT_DEST__/lib/debug/__AT_DEST__/lib*/ -type d \
+	# Create symlinks to the debuginfo files in .debug subdirectories so
+	# valgrind, gdb, and perf can find the symbols.
+	for DIR in $(find __AT_DEST__/lib/debug/__AT_DEST__/*/ -type d \
 		     | grep -v build-id); do
 		dest=${DIR#__AT_DEST__/lib/debug}
 		mkdir -p ${dest}/.debug/
 		ln -sf ${DIR}/* ${dest}/.debug/
+		for FILE in $(ls -1 ${DIR}/*.debug 2>/dev/null); do
+			ln -sf ${FILE} ${dest}/.debug/$(basename ${FILE} .debug)
+		done
 	done
 fi

--- a/configs/9.0/deb/monolithic/perf-dbg.postinst
+++ b/configs/9.0/deb/monolithic/perf-dbg.postinst
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2017 IBM Corporation
+# Copyright 2020 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,15 @@
 #
 
 if [[ "${1}" == configure ]]; then
-	# Create symlinks to the debuginfo files in .debug subdirectories so valgrind
-	# and oprofile can find the symbols.
-	for DIR in $(find __AT_DEST__/lib/debug/__AT_DEST__/lib*/ -type d \
+	# Create symlinks to the debuginfo files in .debug subdirectories so
+	# valgrind, gdb, and perf can find the symbols.
+	for DIR in $(find __AT_DEST__/lib/debug/__AT_DEST__/*/ -type d \
 		     | grep -v build-id); do
 		dest=${DIR#__AT_DEST__/lib/debug}
 		mkdir -p ${dest}/.debug/
 		ln -sf ${DIR}/* ${dest}/.debug/
+		for FILE in $(ls -1 ${DIR}/*.debug 2>/dev/null); do
+			ln -sf ${FILE} ${dest}/.debug/$(basename ${FILE} .debug)
+		done
 	done
 fi

--- a/configs/9.0/deb/monolithic/runtime-dbg.postinst
+++ b/configs/9.0/deb/monolithic/runtime-dbg.postinst
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2017 IBM Corporation
+# Copyright 2020 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,12 +16,15 @@
 #
 
 if [[ "${1}" == configure ]]; then
-	# Create symlinks to the debuginfo files in .debug subdirectories so valgrind
-	# and oprofile can find the symbols.
-	for DIR in $(find __AT_DEST__/lib/debug/__AT_DEST__/lib*/ -type d \
+	# Create symlinks to the debuginfo files in .debug subdirectories so
+	# valgrind, gdb, and perf can find the symbols.
+	for DIR in $(find __AT_DEST__/lib/debug/__AT_DEST__/*/ -type d \
 		     | grep -v build-id); do
 		dest=${DIR#__AT_DEST__/lib/debug}
 		mkdir -p ${dest}/.debug/
 		ln -sf ${DIR}/* ${dest}/.debug/
+		for FILE in $(ls -1 ${DIR}/*.debug 2>/dev/null); do
+			ln -sf ${FILE} ${dest}/.debug/$(basename ${FILE} .debug)
+		done
 	done
 fi

--- a/fvtr/perf/perf.exp
+++ b/fvtr/perf/perf.exp
@@ -1,0 +1,59 @@
+#!/usr/bin/expect
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Check if the `perf` command can utilize AT debuginfo.
+
+source ./shared.exp
+
+set traced_events "/sys/kernel/debug/tracing/uprobe_events"
+
+if {![file writable $traced_events]} {
+	printit "$traced_events is not writable." $WARNING
+	printit "  You may be able to resolve this by:"
+	printit "  $ /usr/bin/sudo mount -o remount,mode=755 /sys/kernel/debug"
+	printit "  $ /usr/bin/sudo mount -o remount,mode=755 /sys/kernel/debug/tracing"
+	printit "  $ /usr/bin/sudo chmod a+rw /sys/kernel/debug/tracing/uprobe_events"
+	printit "Skipping..."
+	exit $ENOSYS
+}
+
+set fail 0
+
+printit "Attempt to create a probe using a variable name..."
+
+set at_object "ld"
+set at_object_path "$env(AT_DEST)/bin/$at_object"
+set at_object_sym "main"
+set at_object_arg "argc"
+
+# Attempt to set a user probe in `ld` at `main`, variable `argc`.
+# All of these are arbitrary, and perhaps a bit fragile, as they
+# depend on a certain binary (`ld`) containing a certain symbol (`main')
+# which accepts a certain named argument (`argc`), but they are arguably
+# less fragile than most other choices.
+
+set status [catch {exec perf probe -v -x $at_object_path \
+			"test_perf_debug=$at_object_sym $at_object_arg" 2>@1} out]
+printit $out
+
+if { $status > 0 } {
+	incr fail
+} else {
+	set out [exec perf probe --list]
+	printit $out
+	set out [exec perf probe -v --del=probe_$at_object:test_perf_debug 2>@1]
+	printit $out
+}
+exit $fail


### PR DESCRIPTION
The debuginfo packages are not usable by the `perf` command, since
for a library `/opt/at{version}/lib64/libA.so.0`, perf looks for
`/opt/at{version}/lib64/.debug/libA-{libversion}.so`, resulting in:
```
$ perf probe -v -x /opt/at13.0/lib64/libpthread.so.0 --add 'pthread_mutex_trylock%return $retval'
[...]
Could not open debuginfo. Try to use symbols.
[...]
```

AT currently creates symlinks for
`/opt/at{version}/lib64/.debug/libA-{libversion}.so.debug`
to point to the actual debuginfo file, but not for
`/opt/at{version}/lib64/.debug/libA-{libversion}.so`

Adding the latter, as this patch does, results in:
```
$ perf probe -v -x /opt/at13.0/lib64/libpthread.so.0 --add 'pthread_mutex_trylock%return $retval'
[...]
Open Debuginfo file: /opt/at13.0/lib64/.debug/libpthread-2.30.so
Try to find probe point from debuginfo.
Symbol pthread_mutex_trylock address found : d7a0
Matched function: __pthread_mutex_trylock [66780]
Probe point found: __pthread_mutex_trylock+0
[...]
```

Also added some `postun` scripts, as currently the uninstall of debuginfo packages would leave behind broken symlinks.

Fixes #965

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>