### PR TITLE
Fix libnxz deb packages

### DIFF
--- a/configs/14.0/deb/monolithic/control
+++ b/configs/14.0/deb/monolithic/control
@@ -154,7 +154,6 @@ Description: Advance Toolchain
 Package: advance-toolchain-libnxz
 Architecture: ppc64el
 Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-libnxz (= __AT_FULL_VER__)
-Depends: ${shlibs:Depends} ${misc:Depends}
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview
  toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.

--- a/configs/14.0/deb/monolithic/libnxz-dbg.postinst
+++ b/configs/14.0/deb/monolithic/libnxz-dbg.postinst
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if [[ "${1}" == configure ]]; then
+	# Create symlinks to the debuginfo files in .debug subdirectories so valgrind
+	# and oprofile can find the symbols.
+	for DIR in $(find __AT_DEST__/lib/debug/__AT_DEST__/lib*/ -type d \
+		     | grep -v build-id); do
+		dest=${DIR#__AT_DEST__/lib/debug}
+		mkdir -p ${dest}/.debug/
+		ln -sf ${DIR}/* ${dest}/.debug/
+	done
+fi

--- a/configs/14.0/deb/monolithic/libnxz.postinst
+++ b/configs/14.0/deb/monolithic/libnxz.postinst
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if [[ "${1}" == configure ]]; then
+	# Update ld.so.cache
+	[[ -f __AT_DEST__/sbin/ldconfig ]] && __AT_DEST__/sbin/ldconfig
+fi

--- a/configs/14.0/deb/monolithic/libnxz.postrm
+++ b/configs/14.0/deb/monolithic/libnxz.postrm
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if [[ "${1}" == configure ]]; then
+	# Update the loader cache after uninstall
+	# We never know the order apt is going to remove/update AT's packages.
+	# So we only need to update the ldconf cache when ldconfig is still
+	# available
+	[[ -f __AT_DEST__/sbin/ldconfig ]] && __AT_DEST__/sbin/ldconfig
+fi

--- a/configs/14.0/deb/monolithic_cross/control
+++ b/configs/14.0/deb/monolithic_cross/control
@@ -92,7 +92,6 @@ Description: Advance Toolchain
 Package: advance-toolchain-cross__BUILD_ARCH__-libnxz
 Architecture: any
 Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-cross__BUILD_ARCH__-libnxz (= __AT_FULL_VER__)
-Depends: ${shlibs:Depends} ${misc:Depends}
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview
  toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.

--- a/scripts/utilities/pkg_build_deb.sh
+++ b/scripts/utilities/pkg_build_deb.sh
@@ -149,9 +149,6 @@ for pkg in $(awk '/^Package:/ { print $2 }' ${deb_d}/control | grep -v dbg); do
 		"runtime-compat")
 			apkg="compat"
 			;;
-		*libnxz)
-			apkg="libnxz"
-			;;
 		cross-ppc*)
 			# In AT versions that support the cross-common package,
 			# the list of files for the main cross package is


### PR DESCRIPTION
The package advance-toolchain-libnxz provided the same files as the package
advance-toolchain-<AT version>-libnxz leading to an error when installing
the packages.

Fix #1553 

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>