### PR TITLE
Stop checking for binary gdbserver on cross compiler

### DIFF
--- a/fvtr/ck_binaries/ck_binaries.exp
+++ b/fvtr/ck_binaries/ck_binaries.exp
@@ -63,12 +63,12 @@ if { $env(AT_MAJOR_VERSION) >= 9.0 } {
 }
 
 # Binaries distributed with a different name on cross and non-cross
-set dif_exec {cpp elfedit embedspu gdb gdbserver gprof readelf}
+set dif_exec {cpp elfedit embedspu gdb gprof readelf}
 if { $env(AT_CROSS_BUILD) == "yes" } {
 	set alt_exec [concat ${alt_exec} ${dif_exec}]
 	set tgt_exec [concat ${tgt_exec} ${dif_exec}]
 } else {
-	set n_exec [concat ${n_exec} ${dif_exec}]
+	set n_exec [concat ${n_exec} ${dif_exec} gdbserver]
 }
 
 printit "Checking if some binaries are available..."


### PR DESCRIPTION
The binary gdbserver is only available on native builds and should not
be checked on cross compilers.

Fixes: 2781f58f58d5 ("Disable gdbserver build on Binutils")
Fixes #1552.