### PR TITLE
remote-build.exp: harden check for `screen`

### DIFF
--- a/remote-build.exp
+++ b/remote-build.exp
@@ -342,7 +342,7 @@ ${server}.\n"
 	set screen 1
 	send "which screen\n"
 	expect {
-		-re $prompt { }
+		"/screen" { }
 		"no screen" {
 			set screen 0 }
 		default {


### PR DESCRIPTION
`remote-build.exp` checks for `screen`, and will fallback to `tmux`
if not found.  The `expect` check runs `which screen` and looks for
either "no screen" or a command prompt.  Unfortunately, the command
prompt will always be displayed after `which screen`, regardless of
whether `screen` was found:

```
$ which screen
/usr/bin/screen
$
```
```
$ which screen
which: no screen in (/home/user/bin:/usr/bin:/usr/sbin)
$
```

The result of the `expect` check is fragile, sometimes detecting
the prompt first, and assuming `screen` was found, when it wasn't.

Harden this check by looking for either "no screen" or "/screen".

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>