### PR TITLE
Remove last vestiges of OProfile

### DIFF
--- a/configs/14.0/deb/monolithic/control
+++ b/configs/14.0/deb/monolithic/control
@@ -22,7 +22,7 @@ Architecture: ppc64el
 Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__)
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview
- toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
 
 Package: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime
 Architecture: ppc64el
@@ -30,7 +30,7 @@ Build-Depends: dh-systemd
 Depends: ${shlibs:Depends} ${misc:Depends}
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview
- toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
 
 Package: advance-toolchain-runtime-dbg
 Architecture: ppc64el
@@ -51,7 +51,7 @@ Conflicts: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime
 Depends: ${shlibs:Depends}
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview
- toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
 
 Package: advance-toolchain-devel
 Architecture: ppc64el
@@ -59,7 +59,7 @@ Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-devel (= __AT_FULL_VER__)
 Depends: ${shlibs:Depends} ${misc:Depends}
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview
- toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
  This package provides the packages necessary to build applications that use the
  features provided by the Advance Toolchain.
 
@@ -70,7 +70,7 @@ Depends: ${shlibs:Depends} ${misc:Depends}
 Suggests: environment-modules
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview
- toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
  This package provides the packages necessary to build applications that use the
  features provided by the Advance Toolchain.
 
@@ -92,7 +92,7 @@ Architecture: ppc64el
 Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-mcore-libs (= __AT_FULL_VER__)
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview
- toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
  This package provides the necessary libraries to build multi-threaded
  applications.
 
@@ -102,7 +102,7 @@ Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__)
 Depends: ${shlibs:Depends} ${misc:Depends}
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview
- toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
  This package provides the necessary libraries to build multi-threaded
  applications.
 
@@ -124,9 +124,8 @@ Architecture: ppc64el
 Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-perf (= __AT_FULL_VER__)
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview
- toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
- This package contains the performance library install targets for Valgrind
- and OProfile.
+ toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
+ This package contains the performance library install targets for Valgrind.
 
 Package: advance-toolchain-__AT_MAJOR_INTERNAL__-perf
 Architecture: ppc64el
@@ -134,9 +133,8 @@ Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__)
 Depends: ${shlibs:Depends} ${misc:Depends}
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview
- toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
- This package contains the performance library install targets for Valgrind
- and OProfile.
+ toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
+ This package contains the performance library install targets for Valgrind.
 
 Package: advance-toolchain-perf-dbg
 Architecture: ppc64el
@@ -157,7 +155,7 @@ Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-libnxz (= __AT_FULL_VER__)
 Depends: ${shlibs:Depends} ${misc:Depends}
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview
- toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
  This package contains the NX GZIP Library.
 
 Package: advance-toolchain-__AT_MAJOR_INTERNAL__-libnxz
@@ -166,7 +164,7 @@ Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__)
 Depends: ${shlibs:Depends} ${misc:Depends}
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview
- toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
  This package contains the NX GZIP Library.
 
 Package: advance-toolchain-libnxz-dbg

--- a/configs/14.0/deb/monolithic_cross/control
+++ b/configs/14.0/deb/monolithic_cross/control
@@ -75,7 +75,7 @@ Architecture: any
 Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-cross__BUILD_ARCH__-mcore-libs (= __AT_FULL_VER__)
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview
- toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
  This package provides the necessary libraries to build multi-threaded
  applications.
 
@@ -85,7 +85,7 @@ Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-cross__BUILD_ARCH__ (= __AT
 Depends: ${shlibs:Depends} ${misc:Depends}
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview
- toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
  This package provides the necessary libraries to build multi-threaded
  applications.
 
@@ -95,7 +95,7 @@ Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-cross__BUILD_ARCH__-libnxz 
 Depends: ${shlibs:Depends} ${misc:Depends}
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview
- toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
  This package contains the NX GZIP Library.
 
 Package: advance-toolchain-__AT_MAJOR_INTERNAL__-cross__BUILD_ARCH__-libnxz
@@ -104,5 +104,5 @@ Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-cross__BUILD_ARCH__ (= __AT
 Depends: ${shlibs:Depends} ${misc:Depends}
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview
- toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
  This package contains the NX GZIP Library.

--- a/configs/14.0/packages/binutils/binutils.mk
+++ b/configs/14.0/packages/binutils/binutils.mk
@@ -1,1 +1,44 @@
-../../../13.0/packages/binutils/binutils.mk
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+#
+$(eval $(call set_provides,binutils_1,single,cross_yes))
+$(eval $(call set_provides,binutils_2,single,cross_yes))
+
+ifeq ($(CROSS_BUILD),no)
+	binutils_2-req = $(RCPTS)/ldconfig_2.rcpt
+else
+	binutils_2-req = 
+endif
+
+
+binutils_1: $(RCPTS)/binutils_1.rcpt
+
+binutils_2: $(RCPTS)/binutils_2.rcpt
+
+
+$(RCPTS)/binutils_1.rcpt: $(binutils_1-archdeps)
+	@touch $@
+
+$(RCPTS)/binutils_2.rcpt: $(binutils_2-archdeps)
+	@touch $@
+
+
+$(RCPTS)/binutils_1.a.rcpt: $(RCPTS)/rsync_binutils.rcpt
+	@touch $@
+
+$(RCPTS)/binutils_2.a.rcpt: $(RCPTS)/glibc_2.rcpt $(RCPTS)/gcc_3.rcpt $(binutils_2-req)
+	@touch $@
+

--- a/configs/14.0/release_notes/release_notes-body.html
+++ b/configs/14.0/release_notes/release_notes-body.html
@@ -123,7 +123,6 @@ rpm -Uvh advance-toolchain-__VERSION__-runtime-__VERSION_RELEASE__.ppc64.rpm \
 				<li>linux kernel (GPL 2.0)</li>
 				<li>mpc (GPL 3.0)</li>
 				<li>mpfr (GPL 3.0)</li>
-				<li>oprofile (GPL 2.0)</li>
 				<li>Userspace RCU (LGPL 2.1)</li>
 				<li>Valgrind (GPL 2.0)</li>
 				<li>libnxz (GPL 2.0)</li>

--- a/configs/14.0/specs/metapkgs.spec
+++ b/configs/14.0/specs/metapkgs.spec
@@ -1,1 +1,117 @@
-../../13.0/specs/metapkgs.spec
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+%description
+The advance toolchain is a self contained toolchain which provides preview
+toolchain functionality in GCC, binutils and GLIBC, as well as the debug and
+profile tools GDB and Valgrind.
+It also provides a group of optimized threading libraries as well.
+
+####################################################
+%package runtime
+Summary: Advance Toolchain
+Requires: __AT_RUNTIME_REQ__
+Group: Development/Libraries
+AutoReqProv: no
+Requires: __RUNTIME_DEPENDENT_PACKAGES__
+
+%description runtime
+The advance toolchain is a self contained toolchain which provides preview
+toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
+This package contains the runtime libraries to run programs built with the
+advance toolchain.
+
+####################################################
+%package runtime-compat
+Summary: Advance Toolchain
+Requires: __AT_RUNTIME_COMPAT_REQ__Conflicts: advance-toolchain-%{at_major}-runtime
+Group: Development/Libraries
+AutoReqProv: no
+Requires: __RUNCOMPAT_DEPENDENT_PACKAGES__
+
+%description runtime-compat
+The advance toolchain is a self contained toolchain which provides preview
+toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
+
+
+####################################################
+%package devel
+Summary: Advance Toolchain
+Requires: advance-toolchain-%{at_major}-runtime = %{at_major_version}-%{at_revision_number}, __AT_DEVEL_REQ__
+Group: Development/Libraries
+AutoReqProv: no
+Provides: advance-toolchain-devel = %{at_major_version}-%{at_revision_number}
+Requires: __DEVEL_DEPENDENT_PACKAGES__
+
+%description devel
+The advance toolchain is a self contained toolchain which provides preview
+toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
+This package provides the packages necessary to build applications that use the
+features provided by the Advance Toolchain.
+
+
+####################################################
+%package mcore-libs
+Summary: Advance Toolchain
+Requires: advance-toolchain-%{at_major}-runtime = %{at_major_version}-%{at_revision_number}, __AT_MCORE_LIBS_REQ__
+Group: Development/Libraries
+AutoReqProv: no
+Requires: __MCORE_DEPENDENT_PACKAGES__
+
+%description mcore-libs
+The advance toolchain is a self contained toolchain which provides preview
+toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
+This package provides the necessary libraries to build multi-threaded applications
+using the specialized multi-threaded libraries Amino-CBB, URCU and Threading
+Building Blocks.
+
+
+####################################################
+%package perf
+Summary: Advance Toolchain
+Requires: advance-toolchain-%{at_major}-devel = %{at_major_version}-%{at_revision_number}, __AT_PERF_REQ__
+Group: Development/Libraries
+AutoReqProv: no
+Requires: __PERF_DEPENDENT_PACKAGES__
+Provides: advance-toolchain-perf = %{at_major_version}-%{at_revision_number}
+
+%description perf
+The advance toolchain is a self contained toolchain which provides preview
+toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
+This package 'perf' package contains the performance library install targets
+for Valgrind.
+
+
+####################################################
+%files runtime
+
+#---------------------------------------------------
+%files runtime-compat
+
+#---------------------------------------------------
+%files devel
+
+#---------------------------------------------------
+%files perf
+
+#---------------------------------------------------
+%files mcore-libs
+
+
+
+
+
+
+
+Requires: __DEPENDENT_PACKAGES__

--- a/configs/14.0/specs/monolithic.spec
+++ b/configs/14.0/specs/monolithic.spec
@@ -15,7 +15,7 @@
 %description
 The advance toolchain is a self contained toolchain which provides preview
 toolchain functionality in GCC, binutils and GLIBC, as well as the debug and
-profile tools GDB, Valgrind and OProfile.
+profile tools GDB and Valgrind.
 It also provides a group of optimized threading libraries as well.
 
 ####################################################
@@ -38,7 +38,7 @@ BuildRequires: systemd
 
 %description runtime
 The advance toolchain is a self contained toolchain which provides preview
-toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
 
 
 ####################################################
@@ -51,7 +51,7 @@ Provides: advance-toolchain-devel = %{at_major_version}-%{at_revision_number}
 
 %description devel
 The advance toolchain is a self contained toolchain which provides preview
-toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
 This package provides the packages necessary to build applications that use the
 features provided by the Advance Toolchain.
 
@@ -66,7 +66,7 @@ Provides: advance-toolchain-mcore-libs = %{at_major_version}-%{at_revision_numbe
 
 %description mcore-libs
 The advance toolchain is a self contained toolchain which provides preview
-toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
 This package provides the necessary libraries to build multi-threaded applications
 using the specialized multi-threaded libraries Amino-CBB, URCU and Threading
 Building Blocks.
@@ -82,9 +82,9 @@ Provides: advance-toolchain-perf = %{at_major_version}-%{at_revision_number}
 
 %description perf
 The advance toolchain is a self contained toolchain which provides preview
-toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
 This package 'perf' package contains the performance library install targets
-for Valgrind and OProfile.
+for Valgrind.
 
 
 ####################################################
@@ -97,7 +97,7 @@ Provides: advance-toolchain-libnxz = %{at_major_version}-%{at_revision_number}
 
 %description libnxz
 The advance toolchain is a self contained toolchain which provides preview
-toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
 This package provides the NX GZIP Library.
 
 
@@ -111,7 +111,7 @@ Group: Development/Libraries
 
 %description selinux
 The advance toolchain is a self contained toolchain which provides preview
-toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
 The 'selinux' package contains the required labels for a system
 running SElinux.
 
@@ -252,15 +252,6 @@ if [[ ${GLIBC_ABS} -gt %{at_glibc_ver} ]]; then
     echo "Your current glibc version ${GLIBC_VER} is higher than the one provided by the advance toolchain glibc."
     echo "Please, consider the possibility of installing a newer version of advance toolchain."
 fi
-
-#---------------------------------------------------
-%pre perf
-# We need to create this special user for OProfile
-getent group oprofile >/dev/null || groupadd -r oprofile
-getent passwd oprofile >/dev/null || \
-useradd -r -g oprofile -d /home/oprofile -s /sbin/nologin \
--c "Special user account to be used by OProfile" oprofile
-exit 0
 
 ####################################################
 %post runtime

--- a/configs/14.0/specs/monolithic_at-compat.spec
+++ b/configs/14.0/specs/monolithic_at-compat.spec
@@ -1,1 +1,81 @@
-../../13.0/specs/monolithic_at-compat.spec
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+%description
+The advance toolchain is a self contained toolchain which provides preview
+toolchain functionality in GCC, binutils and GLIBC, as well as the debug and
+profile tools GDB, and Valgrind.
+It also provides a group of optimized threading libraries as well.
+
+####################################################
+%package runtime-at__AT_OLD_VER__-compat
+Summary: Advance Toolchain
+Conflicts: advance-toolchain-at__AT_OLD_VER__-runtime
+Requires: advance-toolchain-%{at_major}-runtime = %{at_major_version}-%{at_revision_number}
+Requires(post): /sbin/chkconfig
+Requires(preun): /sbin/chkconfig
+Requires(preun): /sbin/service
+Requires(postun): /sbin/service
+Group: Development/Libraries
+
+%description runtime-at__AT_OLD_VER__-compat
+The advance toolchain is a self contained toolchain which provides preview
+toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
+This package provides a runtime compatibility mode for programs compiled with
+version __AT_OLD_VER__ of the Advance Toolchain.
+
+####################################################
+# On newer rpm versions, it's common to strip debug info and to compile python
+# files. We only want to compress man pages.
+%define __os_install_post /usr/lib/rpm/brp-compress
+
+%prep
+
+%build
+
+%install
+# Prepare a new build sandbox area
+mkdir -p ${RPM_BUILD_ROOT}$(dirname %{_prefix})
+# Prepare the required directories for install
+if [[ ! -d "${RPM_BUILD_ROOT}/etc/rc.d/init.d" ]]; then
+    mkdir -p ${RPM_BUILD_ROOT}/etc/rc.d/init.d
+fi
+mv %{_rpmdir}/%{at_major}-runtime-at__AT_OLD_VER__-compat \
+   ${RPM_BUILD_ROOT}/etc/rc.d/init.d/
+chmod +x ${RPM_BUILD_ROOT}/etc/rc.d/init.d/%{at_major}-runtime-at__AT_OLD_VER__-compat
+mkdir -p ${RPM_BUILD_ROOT}__AT_OLD_DEST__/lib \
+         ${RPM_BUILD_ROOT}__AT_OLD_DEST__/lib64
+
+%post runtime-at__AT_OLD_VER__-compat
+/sbin/chkconfig --add %{at_major}-runtime-at__AT_OLD_VER__-compat
+
+%preun runtime-at__AT_OLD_VER__-compat
+if [ $1 -eq 0 ] ; then
+    /sbin/service %{at_major}-runtime-at__AT_OLD_VER__-compat stop \
+        >/dev/null 2>&1
+    /sbin/chkconfig --del %{at_major}-runtime-at__AT_OLD_VER__-compat
+fi
+
+%postun runtime-at__AT_OLD_VER__-compat
+if [ "$1" -ge "1" ] ; then
+    /sbin/service %{at_major}-runtime-at__AT_OLD_VER__-compat condrestart \
+        >/dev/null 2>&1 || :
+fi
+
+####################################################
+%files runtime-at__AT_OLD_VER__-compat
+%defattr(-,root,root)
+/etc/rc.d/init.d/%{at_major}-runtime-at__AT_OLD_VER__-compat
+__AT_OLD_DEST__/lib
+__AT_OLD_DEST__/lib64

--- a/configs/14.0/specs/monolithic_compat.spec
+++ b/configs/14.0/specs/monolithic_compat.spec
@@ -1,1 +1,105 @@
-../../13.0/specs/monolithic_compat.spec
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+%description
+The advance toolchain is a self contained toolchain which provides preview
+toolchain functionality in GCC, binutils and GLIBC, as well as the debug and
+profile tools GDB and Valgrind.
+It also provides a group of optimized threading libraries as well.
+
+####################################################
+%package runtime-compat
+Summary: Advance Toolchain
+Requires: __COMPAT_REQ__
+Conflicts: advance-toolchain-%{at_major}-runtime
+Group: Development/Libraries
+AutoReqProv: no
+
+%description runtime-compat
+The advance toolchain is a self contained toolchain which provides preview
+toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
+
+
+####################################################
+# On newer rpm versions, it's common to strip debug info and to compile python
+# files. We only want to compress man pages.
+%define __os_install_post /usr/lib/rpm/brp-compress
+
+# These have been known to be different on different distributions
+%define _bindir %{_prefix}/bin
+%define _sbindir %{_prefix}/sbin
+%define _scriptdir %{_prefix}/scripts
+%define _libexecdir %{_prefix}/libexec
+# Some distributions set this to 'lib64' by default
+%define _libdir %{_prefix}/lib
+
+# Compat packages may use different variables with same values.
+%define _compatprefix %{_prefix}
+%define _compatbindir %{_prefix}/bin
+%define _compatdatadir %{_datadir}
+%define _compatlibdir %{_prefix}/lib
+%define _compatlibexecdir %{_prefix}/libexec
+%define _compatsbindir %{_prefix}/sbin
+
+%prep
+
+%build
+
+%install
+mkdir -p ${RPM_BUILD_ROOT}/$(dirname %{_prefix})
+# Make compat the root dir.
+cp -af %{_prefix}/compat ${RPM_BUILD_ROOT}/%{_prefix}
+# Remove loader temporary files from rpm build install tree
+rm -rf ${RPM_BUILD_ROOT}/%{_prefix}/etc/ld.so.cache \
+       ${RPM_BUILD_ROOT}/%{_prefix}/etc/ldconfig.log
+# Ensure runtime-compat won't distribute header files (usually kernel headers,
+# necessary for building glibc).
+rm -rf ${RPM_BUILD_ROOT}/%{_prefix}/include/
+
+####################################################
+%pre runtime-compat
+_host_power_arch=$(LD_SHOW_AUXV=1 /bin/true | grep AT_PLATFORM | grep -i power | sed 's/.*power//')
+if [[ "${_host_power_arch}" != "" && "${_host_power_arch}" < "%{_min_power_arch}" ]]; then
+    echo "The system is power${_host_power_arch} but must be at least power%{_min_power_arch} to install this RPM."
+    exit 1
+fi
+
+####################################################
+%post runtime-compat
+# Do this in every .spec file because they may only install a subset.
+%{_prefix}/sbin/ldconfig
+
+
+
+####################################################
+%postun runtime-compat
+# Remove the directory only when uninstalling
+if [[ "${1}" -eq "0" ]]; then
+    if [[ -d %{_prefix} ]]; then
+        rm -rf %{_prefix}
+    fi
+fi
+# Only remove ldconfig if it's' a bash script file
+if file /usr/sbin/ldconfig | grep "bash script" > /dev/null; then
+    at_installs=$(find /opt/ -maxdepth 1 -type d -name 'at[0-9].[0-9]*' \
+        2>/dev/null | wc -l)
+    if [[ "${at_installs}" -eq "0" ]]; then
+        rm -f /usr/sbin/ldconfig
+    fi
+fi
+
+
+####################################################
+%files runtime-compat -f %{at_work}/compat.list
+%defattr(-,root,root)

--- a/configs/14.0/specs/monolithic_cross.spec
+++ b/configs/14.0/specs/monolithic_cross.spec
@@ -63,7 +63,7 @@ Provides: advance-toolchain-mcore-libs = %{at_major_version}-%{at_revision_numbe
 
 %description mcore-libs
 The advance toolchain is a self contained toolchain which provides preview
-toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
 This package provides the necessary libraries to build multi-threaded applications
 using the specialized multi-threaded libraries Boost, SPHDE, URCU and Threading
 Building Blocks.
@@ -78,7 +78,7 @@ Provides: advance-toolchain-libnxz = %{at_major_version}-%{at_revision_number}
 
 %description libnxz
 The advance toolchain is a self contained toolchain which provides preview
-toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
 This package provides the NX GZIP Library.
 
 ####################################################


### PR DESCRIPTION
OProfile has been removed from AT14, but some mentions remain.
Remove those.
- Package descriptions (required replacement of symlinks with files)
- Release Notes license summary
- Creation of "oprofile" user at install time
- Removing the "binutils_3" target from `binutils.mk`, per the leading comment:
  ```
  # The 3rd binutils build is only necessary when targeting a 64-bit environment
  # and building OProfile for 32-bit.
  ```

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>