### PR TITLE
Fix-ups in `remote-build.exp`

### DIFF
--- a/remote-build.exp
+++ b/remote-build.exp
@@ -227,6 +227,8 @@ foreach server $servers {
 			set host_destprefix $home/$host_destprefix
 		}
 	}
+	set host_trayprefix [string trimright "$host_trayprefix" /]
+	set host_destprefix [string trimright "$host_destprefix" /]
 
 	# Please note that using "set tray_dir" and "set destdir" implies that
 	# if you try to set those on your config file, they will be overridden
@@ -234,9 +236,9 @@ foreach server $servers {
 	# desired paths.
 
 	# Directory used by the script to save its files.
-	set tray_dir $host_trayprefix/$atdir
+	set tray_dir [string trimright "$host_trayprefix/$atdir" /]
 	# Directory where AT will be installed (aka DESTDIR).
-	set destdir $host_destprefix/$atdir
+	set destdir [string trimright "$host_destprefix/$atdir" /]
 
 	send "mkdir -p ${tray_dir}\n"
 	expect {
@@ -406,7 +408,7 @@ DESTDIR=${destdir}"
 	} else {
 		set tmux_parms "new -s at-build"
 		send_user "tmux ${tmux_parms} ${parent_cmd} make ${make_parms}\n"
-		send "tmux ${tmux_parms} ${parent_cmd} make ${make_parms} \\; pipe-pane 'cat > screen.log'\n"
+		send "tmux ${tmux_parms} ${parent_cmd} make ${make_parms} \\; pipe-pane 'cat >'${tray_dir}'/screen.log'\n"
 	}
 	expect {
 		"command not found" {

--- a/scripts/helpers/pack-exclude.lst
+++ b/scripts/helpers/pack-exclude.lst
@@ -29,7 +29,6 @@
 ./old_patches
 ./pack.txt
 ./patches
-./remote-build.exp
 ./scripts/.svn
 ./scripts/helpers/.svn
 ./scripts/skeletons/.svn


### PR DESCRIPTION
Commit 60c6a74bbd577012229ff50acc8db2d22b5661d6 subtlely changed the
`DESTDIR` used by `./remote_build.exp`, leaving a trailing `/` in some
cases, including the default case.  The results were mostly innocuous,
but the FVTR test `ck_ldds` failed, e.g.:
```
ck_ldds: power8:  The interpreter of /home/pc/opt/at14.0-0-alpha2/lib64/libpaf-dsc.so.0.0.3 is not  canonical: /home/pc/opt//at14.0-0-alpha2/lib64/ld64.so.2
```

Fix this by removing any trailing `/` characters from the associated
variables.

Note that the code before the above commit was using the Tcl command
`file canonicalize`, but that no longer works because the paths
being manipulated are from the target build system, and may not be
valid paths on the system running the `remote-build.exp` script.

Also, commit 1b03752eb1c531fb1804541af748d041f087de07 added support
for `tmux`, if `screen` is not available. This support is placing the
`screen.log` file in the user's HOME directory on the remote system.
When using `screen`, the equivalent file was placed in the "tray"
directory, so let's put the `tmux` log there as well.

Finally, removed `remote-build.exp` from the `pack-exclude.lst`, because
if you are working on bugs in `remote-build.exp`, it's nice to have that
be part of the build, so you know how the build was launched. ;-)

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>