### PR TITLE
Add prefix timestamps to build messages

### DIFF
--- a/scripts/skeletons/prefetch_target.mk
+++ b/scripts/skeletons/prefetch_target.mk
@@ -19,7 +19,7 @@ $(RCPTS)/fetch_%.rcpt: $(RCPTS)/fetch_%_patches.rcpt $(RCPTS)/fetch_%_source.rcp
 	@touch $@
 
 $(RCPTS)/fetch_%_source.rcpt: $(RCPTS)/bso_clearance.rcpt
-	@echo "Starting $* pristine source fetch for AT$(AT_CONFIGSET)...";
+	@echo "$$($(TIME)) Starting $* pristine source fetch for AT$(AT_CONFIGSET)...";
 	@{  echo "Setting required variables"; \
 	    export AT_STEPID=$(notdir $(basename $@)); \
 	    export AT_BASE=$(AT_BASE); \
@@ -40,11 +40,11 @@ $(RCPTS)/fetch_%_source.rcpt: $(RCPTS)/bso_clearance.rcpt
 	        done; \
 	    fi; \
 	} > $(LOGS)/_$(notdir $(basename $@)).log 2>&1
-	@echo "Completed $* pristine source fetch!";
+	@echo "$$($(TIME)) Completed $* pristine source fetch!";
 	@touch $@
 
 $(RCPTS)/fetch_%_patches.rcpt: $(RCPTS)/bso_clearance.rcpt
-	@echo "Starting $* patches fetch for AT$(AT_CONFIGSET)...";
+	@echo "$$($(TIME)) Starting $* patches fetch for AT$(AT_CONFIGSET)...";
 	@{ echo "Setting required variables"; \
 	    export AT_STEPID=$(notdir $(basename $@)); \
 	    export AT_BASE=$(AT_BASE); \
@@ -78,5 +78,5 @@ $(RCPTS)/fetch_%_patches.rcpt: $(RCPTS)/bso_clearance.rcpt
 	        done; \
 	    fi; \
 	} > $(LOGS)/_$(notdir $(basename $@)).log 2>&1
-	@echo "Completed $* patches fetch!";
+	@echo "$$($(TIME)) Completed $* patches fetch!";
 	@touch $@


### PR DESCRIPTION
This is a subjective change, but I believe messages for long-running
tasks should always be timestamped as a best practice. Timestamps can
be diagnotic as well, if a build takes extra time, the culprit phase
can be found quickly.

The chosen format of the timestamp matches that already chosen for
the collected logs.

Sample output:
```
2020-07-30_01.59.31 Completed binutils copy!
2020-07-30_01.59.31 Applying patches to binutils...
2020-07-30_01.59.31 Applied patches to binutils!
2020-07-30_01.59.31 Starting the build of binutils_1...
```

Also, sneaking in two tiny changes:
- Combine two lines which are, together, a single `find` command.
- Spell-o

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>