### PR TITLE
Update priority entry of deb packages

### DIFF
--- a/configs/12.0/deb/monolithic/control
+++ b/configs/12.0/deb/monolithic/control
@@ -1,4 +1,4 @@
-# Copyright 2017 IBM Corporation
+# Copyright 2020 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 #
 Source: advance-toolchain-__AT_MAJOR_INTERNAL__
 Section: devel
-Priority: extra
+Priority: optional
 Maintainer: Advance Toolchain
 
 Package: advance-toolchain-runtime

--- a/configs/12.0/deb/monolithic/control
+++ b/configs/12.0/deb/monolithic/control
@@ -1,1 +1,160 @@
-../../../11.0/deb/monolithic/control
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+Source: advance-toolchain-__AT_MAJOR_INTERNAL__
+Section: devel
+Priority: extra
+Maintainer: Advance Toolchain
+
+Package: advance-toolchain-runtime
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__)
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime
+Architecture: ppc64el
+Build-Depends: dh-systemd
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+
+Package: advance-toolchain-runtime-dbg
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime-dbg (= __AT_FULL_VER__)
+Description: Advance Toolchain
+ The advance toolchain debugging information.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime-dbg
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__)
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain debugging information.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime-compat
+Architecture: ppc64el
+Conflicts: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime
+Depends: ${shlibs:Depends}
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+
+Package: advance-toolchain-devel
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-devel (= __AT_FULL_VER__)
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ This package provides the packages necessary to build applications that use the
+ features provided by the Advance Toolchain.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-devel
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__)
+Depends: ${shlibs:Depends} ${misc:Depends}
+Suggests: environment-modules
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ This package provides the packages necessary to build applications that use the
+ features provided by the Advance Toolchain.
+
+Package: advance-toolchain-devel-dbg
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-devel-dbg (= __AT_FULL_VER__)
+Description: Advance Toolchain
+ The advance toolchain debugging information.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-devel-dbg
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-devel (= __AT_FULL_VER__)
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain debugging information.
+
+Package: advance-toolchain-mcore-libs
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-mcore-libs (= __AT_FULL_VER__)
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ This package provides the necessary libraries to build multi-threaded
+ applications.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-mcore-libs
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__)
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ This package provides the necessary libraries to build multi-threaded
+ applications.
+
+Package: advance-toolchain-mcore-libs-dbg
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-mcore-libs-dbg (= __AT_FULL_VER__)
+Description: Advance Toolchain
+ The advance toolchain debugging information.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-mcore-libs-dbg
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-mcore-libs (= __AT_FULL_VER__)
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain debugging information.
+
+Package: advance-toolchain-perf
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-perf (= __AT_FULL_VER__)
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ This package contains the performance library install targets for Valgrind
+ and OProfile.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-perf
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__)
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ This package contains the performance library install targets for Valgrind
+ and OProfile.
+
+Package: advance-toolchain-perf-dbg
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-perf-dbg (= __AT_FULL_VER__)
+Description: Advance Toolchain
+ The advance toolchain debugging information.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-perf-dbg
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-perf (= __AT_FULL_VER__)
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain debugging information.
+
+Package: advance-toolchain-golang-at
+Architecture: ppc64el
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ This package provides the Golang binaries for ppc64el.

--- a/configs/12.0/deb/monolithic_cross/control
+++ b/configs/12.0/deb/monolithic_cross/control
@@ -1,1 +1,90 @@
-../../../11.0/deb/monolithic_cross/control
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+Source: advance-toolchain-__AT_MAJOR_INTERNAL__-cross__BUILD_ARCH__
+Section: devel
+Priority: extra
+Maintainer: Advance Toolchain
+
+Package: advance-toolchain-cross__BUILD_ARCH__
+Architecture: any
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-cross__BUILD_ARCH__ (= __AT_FULL_VER__)
+Description: Advance Toolchain cross compiler
+ The Advance Toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, and GDB.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-cross__BUILD_ARCH__
+Architecture: any
+Depends: ${shlibs:Depends}, advance-toolchain-__AT_MAJOR_INTERNAL__-cross-common (= __AT_FULL_VER__)
+Description: Advance Toolchain cross compiler
+ The Advance Toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, and GDB.
+Multi-Arch: foreign
+
+Package: advance-toolchain-cross-common
+Architecture: any
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-cross-common (= __AT_FULL_VER__)
+Description: Advance Toolchain cross compiler common files
+ The Advance Toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, and GDB.
+ This package provides common files for the Advance Toolchain.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-cross-common
+Architecture: any
+Pre-Depends: info
+Depends: ${shlibs:Depends}, info
+Description: Advance Toolchain cross compiler common files
+ The Advance Toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, and GDB.
+ This package provides common files for the Advance Toolchain.
+Multi-Arch: foreign
+
+Package: advance-toolchain-cross__BUILD_ARCH__-runtime-extras
+Architecture: any
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-cross__BUILD_ARCH__-runtime-extras (= __AT_FULL_VER__)
+Description: Advance Toolchain cross compiler runtime extras files
+ The Advance Toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, and GDB.
+ This package contains the runtime libraries to run programs built with the
+ advance toolchain that are not present in the main cross compiler package.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-cross__BUILD_ARCH__-runtime-extras
+Architecture: any
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-cross__BUILD_ARCH__ (= __AT_FULL_VER__)
+Depends: ${shlibs:Depends}
+Description: Advance Toolchain cross compiler runtime extras files
+ The Advance Toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, and GDB.
+ This package contains the runtime libraries to run programs built with the
+ advance toolchain that are not present in the main cross compiler package.
+Multi-Arch: foreign
+
+Package: advance-toolchain-cross__BUILD_ARCH__-mcore-libs
+Architecture: any
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-cross__BUILD_ARCH__-mcore-libs (= __AT_FULL_VER__)
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ This package provides the necessary libraries to build multi-threaded
+ applications.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-cross__BUILD_ARCH__-mcore-libs
+Architecture: any
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-cross__BUILD_ARCH__ (= __AT_FULL_VER__)
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, Valgrind, and OProfile.
+ This package provides the necessary libraries to build multi-threaded
+ applications.

--- a/configs/12.0/deb/monolithic_cross/control
+++ b/configs/12.0/deb/monolithic_cross/control
@@ -1,4 +1,4 @@
-# Copyright 2017 IBM Corporation
+# Copyright 2020 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 #
 Source: advance-toolchain-__AT_MAJOR_INTERNAL__-cross__BUILD_ARCH__
 Section: devel
-Priority: extra
+Priority: optional
 Maintainer: Advance Toolchain
 
 Package: advance-toolchain-cross__BUILD_ARCH__

--- a/configs/13.0/deb/monolithic/control
+++ b/configs/13.0/deb/monolithic/control
@@ -14,7 +14,7 @@
 #
 Source: advance-toolchain-__AT_MAJOR_INTERNAL__
 Section: devel
-Priority: extra
+Priority: optional
 Maintainer: Advance Toolchain
 
 Package: advance-toolchain-runtime

--- a/configs/14.0/deb/monolithic/control
+++ b/configs/14.0/deb/monolithic/control
@@ -14,7 +14,7 @@
 #
 Source: advance-toolchain-__AT_MAJOR_INTERNAL__
 Section: devel
-Priority: extra
+Priority: optional
 Maintainer: Advance Toolchain
 
 Package: advance-toolchain-runtime

--- a/configs/14.0/deb/monolithic_cross/control
+++ b/configs/14.0/deb/monolithic_cross/control
@@ -14,7 +14,7 @@
 #
 Source: advance-toolchain-__AT_MAJOR_INTERNAL__-cross__BUILD_ARCH__
 Section: devel
-Priority: extra
+Priority: optional
 Maintainer: Advance Toolchain
 
 Package: advance-toolchain-cross__BUILD_ARCH__


### PR DESCRIPTION
Replaced deprecated value, `extra`, of the priority entry in control files.
According to [Debian Policy Manual](https://www.debian.org/doc/debian-policy/ch-archive.html#s-priorities), the `optional` value should be used instead of `extra`.

Fix #1564 