### PR TITLE
Improve rules files

### DIFF
--- a/configs/13.0/deb/monolithic/rules
+++ b/configs/13.0/deb/monolithic/rules
@@ -38,7 +38,8 @@ ifeq (__USE_SYSTEMD__, yes)
 endif
 
 # Copy the packages' files.
-	dh_install --fail-missing
+	dh_install
+	dh_missing --fail-missing
 ifeq (__USE_SYSTEMD__, yes)
 	dh_systemd_start
 endif

--- a/configs/13.0/deb/monolithic_cross/rules
+++ b/configs/13.0/deb/monolithic_cross/rules
@@ -1,1 +1,66 @@
-../../../12.0/deb/monolithic_cross/rules
+#!/usr/bin/make -f
+#
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set the proper shell to use
+SHELL := /bin/bash
+
+# Get the package names to build
+PACKAGE=$(shell dh_listpackages)
+
+build:
+	dh_testdir
+	dh_testroot
+	dh_prep
+
+clean:
+	dh_testdir
+	dh_testroot
+	dh_clean -d
+
+binary-indep: build
+
+binary-arch: build binary-cp
+	dh_installdirs
+	dh_installdocs
+	dh_installchangelogs
+
+# Copy the packages' files.
+	dh_install --fail-missing
+
+	dh_compress
+# Avoid including PPC libraries as they could break system's objdump.
+	dh_makeshlibs --exclude=__DEST_CROSS__ \
+		--exclude=__AT_DEST__/__TARGET__
+	dh_installdeb
+# Avoid including PPC libraries as they could break system's ldd.
+	dh_shlibdeps --exclude=__DEST_CROSS__ \
+		--exclude=__AT_DEST__/__TARGET__
+	dh_gencontrol
+	dh_md5sums
+	dh_builddeb
+
+binary-cp: build
+	mkdir -p debian/tmp/__AT_DEST__
+	rsync -a --delete --delete-excluded \
+	      --exclude=share/info/dir --exclude=usr/share/info/dir \
+	      __AT_DEST__ debian/tmp/__AT_DEST__/../
+# Compress all of the info files.
+	gzip -9nvf debian/tmp/__AT_DEST__/share/info/*.info*
+	gzip -9nvf debian/tmp/__DEST_CROSS__/usr/share/info/*.info*
+
+binary: binary-indep binary-arch
+.PHONY: build clean binary-indep binary-arch binary

--- a/configs/13.0/deb/monolithic_cross/rules
+++ b/configs/13.0/deb/monolithic_cross/rules
@@ -1,6 +1,6 @@
 #!/usr/bin/make -f
 #
-# Copyright 2017 IBM Corporation
+# Copyright 2020 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,7 +39,8 @@ binary-arch: build binary-cp
 	dh_installchangelogs
 
 # Copy the packages' files.
-	dh_install --fail-missing
+	dh_install
+	dh_missing --fail-missing
 
 	dh_compress
 # Avoid including PPC libraries as they could break system's objdump.

--- a/configs/14.0/deb/monolithic/rules
+++ b/configs/14.0/deb/monolithic/rules
@@ -38,7 +38,8 @@ ifeq (__USE_SYSTEMD__, yes)
 endif
 
 # Copy the packages' files.
-	dh_install --fail-missing
+	dh_install
+	dh_missing --fail-missing
 ifeq (__USE_SYSTEMD__, yes)
 	dh_systemd_start
 endif


### PR DESCRIPTION
Added a call to `dh_missing --fail-missing` after `dh_install`.
This avoids warnings when generation deb packages as `dh_install --fail-missing` has been deprecated.

Fix #1599