### PR TITLE
Remove vestiges of Red Hat 6, Ubuntu 14.04, Ubuntu 14.10, and Debian 8

### DIFF
--- a/docs/advtool-compiler.html
+++ b/docs/advtool-compiler.html
@@ -129,8 +129,6 @@ pre {
 wget https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHEL7/gpg-pubkey-6976a827-5164221b
 rpm --import gpg-pubkey-6976a827-5164221b
 </pre>
-<p>Notes:</p>
-<ul><li>If you are installing on Red Hat 6, you must include two gpg public keys: <code>gpg-pubkey-6976a827-5164221b</code> and <code>gpg-pubkey-3052930d-5175955a</code>.</li></ul>
 <li>Create a configuration file for the Advance Toolchain repository configuration file: <code>/etc/yum.repos.d/<em>advance-toolchain.repo</em></code>. Add the following content:
 <pre>
 # Begin of configuration file
@@ -214,30 +212,31 @@ zypper addrepo https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/
 
 	<li>The gpg public key <code>gpg-pubkey-6976a827-5164221b</code> is provided in the repositories. This public key is used to verify the authenticity of both the Advance Toolchain packages and the repository contents. Download the gpg public key for your Linux distribution and import it using the following commands:
 <pre>
-wget https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/trusty/6976a827.gpg.key
+wget https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/focal/6976a827.gpg.key
 sudo apt-key add 6976a827.gpg.key
 </pre>
 </li>
 <li>Configure the Advance Toolchain repositories by adding the following line to <code>/etc/apt/sources.list</code>:
 <p>On ppc64el or amd64:</p>
 <pre>
-deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu trusty atX.X
+deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu focal atX.X
 </pre>
 
 <p>Notes:</p>
 
 <ul>
-	<li>When installing on Ubuntu 16.04 (xenial) or Ubuntu 14.10 (utopic), point to its respective repository:
+	<li>When installing on Ubuntu 18.04 (bionic) or Ubuntu 16.04 (xenial), point to its respective repository:
 <pre>
+deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu bionic atX.X
 deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu xenial atX.X
-deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu utopic atX.X
 </pre>
 	</li>
 
 
-    	<li>When installing on Debian 8 (jessie), point to its respective repository:
+    	<li>When installing on Debian 10 (buster) or Debian 9 (stretch), point to its respective repository:
 <pre>
-deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian jessie atX.X
+deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian buster atX.X
+deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/debian stretch atX.X
 </pre>
 	</li>
 </ul>

--- a/docs/advtool-installation.html
+++ b/docs/advtool-installation.html
@@ -156,6 +156,7 @@ pre {
         <p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#installUbuntu">Install Advance Toolchain</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/bionic/at14.0">Repository and release notes</a></p>
+      </td>
       <td>
         <p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#installUbuntu">Install Advance Toolchain</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
@@ -169,10 +170,10 @@ pre {
         <p class="ibm-ind-link"><a class="ibm-anchor-down-link" href="#installUbuntu">Install Advance Toolchain</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-forward-link" href="https://developer.ibm.com/linuxonpower/advance-toolchain/advtool-compiler">Install cross compiler</a></p><br />
         <p class="ibm-ind-link"><a class="ibm-btn-sec ibm-btn-gray-50 ibm-forward-link" href="https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/focal/at14.0">Repository and release notes</a></p>
+      </td>
       <td></td>
       <td></td>
     </tr>
-  </tbody>
   </tbody>
 </table>
 
@@ -221,10 +222,6 @@ pre {
 wget https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redhat/RHEL7/gpg-pubkey-6976a827-5164221b
 rpm --import gpg-pubkey-6976a827-5164221b
 </pre>
-      <p>Notes:</p>
-        <ul>
-          <li>If you are installing on Red Hat 6, you must include two gpg public keys: <code>gpg-pubkey-6976a827-5164221b</code> and <code>gpg-pubkey-3052930d-5175955a</code>.</li>
-        </ul>
     </li>
     <li>Create a configuration file for the Advance Toolchain repository configuration file: <code>/etc/yum.repos.d/<em>advance-toolchain.repo</em></code>. Add the following content:
 <pre>
@@ -240,7 +237,7 @@ gpgkey=https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/redha
 </pre>
       <p>Replace <em>RHELX</em> with the Red Hat release that you are using.</p>
     </li>
-    <li>Install the Advance Toolchain by running yum install. Replace <code>atX.X</code> with the Advance Toolchain release that you are installing. For example, <code>at13.0</code>.
+    <li>Install the Advance Toolchain by running yum install. Replace <code>atX.X</code> with the Advance Toolchain release that you are installing. For example, <code>at14.0</code>.
 <pre>
 yum install advance-toolchain-atX.X-runtime \
     advance-toolchain-atX.X-devel \
@@ -500,7 +497,7 @@ rpm -ivh ibm-power-repo-latest.noarch.rpm
 	      <li>
                 The gpg public key <code>gpg-pubkey-6976a827-5164221b</code> is provided in the repositories. This public key is used to verify the authenticity of both the Advance Toolchain packages and the repository contents. Download the gpg public key for your Linux distribution and import it using the following commands:
 <pre>
-wget https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/trusty/6976a827.gpg.key
+wget https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/focal/6976a827.gpg.key
 sudo apt-key add 6976a827.gpg.key
 </pre>
               </li>
@@ -508,16 +505,15 @@ sudo apt-key add 6976a827.gpg.key
                 Configure the Advance Toolchain repositories by adding the following line to <code>/etc/apt/sources.list</code>:
                 <p>On ppc64el or amd64:</p>
 <pre>
-deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu trusty atX.X
+deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu focal atX.X
 </pre>
                 <p>Notes:</p>
 
                 <ul>
-                  <li>When installing on Ubuntu 16.04 (xenial), Ubuntu 18.04 (bionic) or Ubuntu 20.04 (focal), point to its respective repository:
+                  <li>When installing on Ubuntu 18.04 (bionic) or Ubuntu 16.04 (xenial), point to its respective repository:
 <pre>
 deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu xenial atX.X
 deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu bionic atX.X
-deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu focal atX.X
 </pre>
                   </li>
 	          <li>
@@ -546,7 +542,7 @@ sudo aptitude install advance-toolchain-atX.X-runtime \
               </li>
             </ol>
 
-            <p>Aptitude supports package upgrades for new revision releases (for example, from 13.0-0 to 13.0-1). For new major releases (for example, from 12.0-1 to 13.0-0), please proceed as in a normal installation.</p>
+            <p>Aptitude supports package upgrades for new revision releases (for example, from 14.0-0 to 14.0-1). For new major releases (for example, from 13.0-1 to 14.0-0), please proceed as in a normal installation.</p>
           </div>
 
 <div id="ubuntutab2" class="ibm-tabs-content">
@@ -556,7 +552,7 @@ sudo aptitude install advance-toolchain-atX.X-runtime \
     <li>
       The gpg public key <code>gpg-pubkey-6976a827-5164221b</code> is provided in the repositories. This public key is used to verify the authenticity of both the Advance Toolchain packages and the repository contents. Download the gpg public key for your Linux distribution and import it using the following commands:
 <pre>
-wget https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/trusty/6976a827.gpg.key
+wget https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu/dists/focal/6976a827.gpg.key
 sudo apt-key add 6976a827.gpg.key
 </pre>
     </li>
@@ -564,15 +560,14 @@ sudo apt-key add 6976a827.gpg.key
       Configure the Advance Toolchain repositories by adding the following line to <code>/etc/apt/sources.list</code>:
       <p>On ppc64el or amd64:</p>
 <pre>
-deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu trusty atX.X
+deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu focal atX.X
 </pre>
       <p>Notes:</p>
       <ul>
-        <li>When installing on Ubuntu 16.04 (xenial), Ubuntu 18.04 (bionic) or Ubuntu 20.04 (focal), point to its respective repository:
+        <li>When installing on Ubuntu 18.04 (bionic) or Ubuntu 16.04 (xenial), point to its respective repository:
 <pre>
-deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu xenial atX.X
 deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu bionic atX.X
-deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu focal atX.X
+deb https://public.dhe.ibm.com/software/server/POWER/Linux/toolchain/at/ubuntu xenial atX.X
 </pre>
         </li>
         <li>
@@ -601,7 +596,7 @@ sudo apt-get install advance-toolchain-atX.X-runtime \
     </li>
   </ol>
 
-  <p>APT supports package upgrades for new revision releases (i.e. 13.0-0 to 13.0-1). For new major releases (i.e. 12.0-1 to 13.0-0), please proceed as in a normal installation.</p>
+  <p>APT supports package upgrades for new revision releases (i.e. 14.0-0 to 14.0-1). For new major releases (i.e. 13.0-1 to 14.0-0), please proceed as in a normal installation.</p>
 </div>
 
 


### PR DESCRIPTION
Commit d223471cf977202ec13faefee916d96b5a8ace79 "Remove references in the
website to unsupported distributions", including "Red Hat 6", but missed
a few notes.  Remove these, too.

Also, update the "current" Ubuntu release in the documentation, and
remove Debian 8.

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>