### PR TITLE
Fix the test for minimum processor during RPM installation

### DIFF
--- a/configs/11.0/specs/monolithic.spec
+++ b/configs/11.0/specs/monolithic.spec
@@ -214,7 +214,8 @@ echo "enable %{at_ver_alternative}-cachemanager.service" \
 ####################################################
 %pre runtime
 _host_power_arch=$(LD_SHOW_AUXV=1 /bin/true | grep AT_PLATFORM | grep -i power | sed 's/.*power//')
-if [[ "${_host_power_arch}" != "" && "${_host_power_arch}" < "%{_min_power_arch}" ]]; then
+if [[ "${_host_power_arch}" != "" \
+      && "%{_min_power_arch}" != $(echo -e "%{_min_power_arch}\n${_host_power_arch}" | sort -V | head -n 1) ]]; then
     echo "The system is power${_host_power_arch} but must be at least power%{_min_power_arch} to install this RPM."
     exit 1
 fi

--- a/configs/14.0/specs/monolithic.spec
+++ b/configs/14.0/specs/monolithic.spec
@@ -241,7 +241,8 @@ echo "enable %{at_ver_alternative}-cachemanager.service" \
 ####################################################
 %pre runtime
 _host_power_arch=$(LD_SHOW_AUXV=1 /bin/true | grep AT_PLATFORM | grep -i power | sed 's/.*power//')
-if [[ "${_host_power_arch}" != "" && "${_host_power_arch}" < "%{_min_power_arch}" ]]; then
+if [[ "${_host_power_arch}" != "" \
+      && "%{_min_power_arch}" != $(echo -e "%{_min_power_arch}\n${_host_power_arch}" | sort -V | head -n 1) ]]; then
     echo "The system is power${_host_power_arch} but must be at least power%{_min_power_arch} to install this RPM."
     exit 1
 fi

--- a/configs/14.0/specs/monolithic_compat.spec
+++ b/configs/14.0/specs/monolithic_compat.spec
@@ -70,7 +70,8 @@ rm -rf ${RPM_BUILD_ROOT}/%{_prefix}/include/
 ####################################################
 %pre runtime-compat
 _host_power_arch=$(LD_SHOW_AUXV=1 /bin/true | grep AT_PLATFORM | grep -i power | sed 's/.*power//')
-if [[ "${_host_power_arch}" != "" && "${_host_power_arch}" < "%{_min_power_arch}" ]]; then
+if [[ "${_host_power_arch}" != "" \
+	      && "%{_min_power_arch}" != $(echo -e "%{_min_power_arch}\n${_host_power_arch}" | sort -V | head -n 1) ]]; then
     echo "The system is power${_host_power_arch} but must be at least power%{_min_power_arch} to install this RPM."
     exit 1
 fi


### PR DESCRIPTION
With POWER10, string comparisons do not work as expected between POWER
processors anymore, e.g. "10" < "8".
This patch replaces simple string comparisons with `sort -V`.

Closes issue #1670 .