### PR TITLE
Remove most pre-dependencies on deb packages

### DIFF
--- a/configs/next/deb/monolithic/control
+++ b/configs/next/deb/monolithic/control
@@ -1,1 +1,180 @@
-../../../14.0/deb/monolithic/control
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+Source: advance-toolchain-__AT_MAJOR_INTERNAL__
+Section: devel
+Priority: optional
+Maintainer: Advance Toolchain
+
+Package: advance-toolchain-runtime
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__)
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime
+Architecture: ppc64el
+Build-Depends: dh-systemd
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
+
+Package: advance-toolchain-runtime-dbg
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime-dbg (= __AT_FULL_VER__)
+Description: Advance Toolchain
+ The advance toolchain debugging information.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime-dbg
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__)
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain debugging information.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime-compat
+Architecture: ppc64el
+Conflicts: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime
+Depends: ${shlibs:Depends}
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
+
+Package: advance-toolchain-devel
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-devel (= __AT_FULL_VER__)
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
+ This package provides the packages necessary to build applications that use the
+ features provided by the Advance Toolchain.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-devel
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__)
+Depends: ${shlibs:Depends} ${misc:Depends}
+Suggests: environment-modules
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
+ This package provides the packages necessary to build applications that use the
+ features provided by the Advance Toolchain.
+
+Package: advance-toolchain-devel-dbg
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-devel-dbg (= __AT_FULL_VER__)
+Description: Advance Toolchain
+ The advance toolchain debugging information.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-devel-dbg
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-devel (= __AT_FULL_VER__)
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain debugging information.
+
+Package: advance-toolchain-mcore-libs
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-mcore-libs (= __AT_FULL_VER__)
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
+ This package provides the necessary libraries to build multi-threaded
+ applications.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-mcore-libs
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__)
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
+ This package provides the necessary libraries to build multi-threaded
+ applications.
+
+Package: advance-toolchain-mcore-libs-dbg
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-mcore-libs-dbg (= __AT_FULL_VER__)
+Description: Advance Toolchain
+ The advance toolchain debugging information.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-mcore-libs-dbg
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-mcore-libs (= __AT_FULL_VER__)
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain debugging information.
+
+Package: advance-toolchain-perf
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-perf (= __AT_FULL_VER__)
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
+ This package contains the performance library install targets for Valgrind.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-perf
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__)
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
+ This package contains the performance library install targets for Valgrind.
+
+Package: advance-toolchain-perf-dbg
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-perf-dbg (= __AT_FULL_VER__)
+Description: Advance Toolchain
+ The advance toolchain debugging information.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-perf-dbg
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-perf (= __AT_FULL_VER__)
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain debugging information.
+
+Package: advance-toolchain-libnxz
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-libnxz (= __AT_FULL_VER__)
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
+ This package contains the NX GZIP Library.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-libnxz
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__)
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ The advance toolchain is a self contained toolchain which provides preview
+ toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
+ This package contains the NX GZIP Library.
+
+Package: advance-toolchain-libnxz-dbg
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-libnxz-dbg (= __AT_FULL_VER__)
+Description: Advance Toolchain
+ This package contains the NX GZIP Library debugging information.
+
+Package: advance-toolchain-__AT_MAJOR_INTERNAL__-libnxz-dbg
+Architecture: ppc64el
+Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-libnxz (= __AT_FULL_VER__)
+Depends: ${shlibs:Depends} ${misc:Depends}
+Description: Advance Toolchain
+ This package contains the NX GZIP Library debugging information.

--- a/configs/next/deb/monolithic/control
+++ b/configs/next/deb/monolithic/control
@@ -19,7 +19,7 @@ Maintainer: Advance Toolchain
 
 Package: advance-toolchain-runtime
 Architecture: ppc64el
-Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__)
+Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__)
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview
  toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
@@ -34,14 +34,14 @@ Description: Advance Toolchain
 
 Package: advance-toolchain-runtime-dbg
 Architecture: ppc64el
-Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime-dbg (= __AT_FULL_VER__)
+Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime-dbg (= __AT_FULL_VER__)
 Description: Advance Toolchain
  The advance toolchain debugging information.
 
 Package: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime-dbg
 Architecture: ppc64el
-Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__)
-Depends: ${shlibs:Depends} ${misc:Depends}
+Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__),
+         ${shlibs:Depends} ${misc:Depends}
 Description: Advance Toolchain
  The advance toolchain debugging information.
 
@@ -55,8 +55,8 @@ Description: Advance Toolchain
 
 Package: advance-toolchain-devel
 Architecture: ppc64el
-Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-devel (= __AT_FULL_VER__)
-Depends: ${shlibs:Depends} ${misc:Depends}
+Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-devel (= __AT_FULL_VER__),
+         ${shlibs:Depends} ${misc:Depends}
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview
  toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
@@ -65,8 +65,8 @@ Description: Advance Toolchain
 
 Package: advance-toolchain-__AT_MAJOR_INTERNAL__-devel
 Architecture: ppc64el
-Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__)
-Depends: ${shlibs:Depends} ${misc:Depends}
+Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__),
+         ${shlibs:Depends} ${misc:Depends}
 Suggests: environment-modules
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview
@@ -76,20 +76,20 @@ Description: Advance Toolchain
 
 Package: advance-toolchain-devel-dbg
 Architecture: ppc64el
-Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-devel-dbg (= __AT_FULL_VER__)
+Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-devel-dbg (= __AT_FULL_VER__)
 Description: Advance Toolchain
  The advance toolchain debugging information.
 
 Package: advance-toolchain-__AT_MAJOR_INTERNAL__-devel-dbg
 Architecture: ppc64el
-Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-devel (= __AT_FULL_VER__)
-Depends: ${shlibs:Depends} ${misc:Depends}
+Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-devel (= __AT_FULL_VER__),
+         ${shlibs:Depends} ${misc:Depends}
 Description: Advance Toolchain
  The advance toolchain debugging information.
 
 Package: advance-toolchain-mcore-libs
 Architecture: ppc64el
-Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-mcore-libs (= __AT_FULL_VER__)
+Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-mcore-libs (= __AT_FULL_VER__)
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview
  toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
@@ -98,8 +98,8 @@ Description: Advance Toolchain
 
 Package: advance-toolchain-__AT_MAJOR_INTERNAL__-mcore-libs
 Architecture: ppc64el
-Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__)
-Depends: ${shlibs:Depends} ${misc:Depends}
+Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__),
+         ${shlibs:Depends} ${misc:Depends}
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview
  toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
@@ -108,20 +108,20 @@ Description: Advance Toolchain
 
 Package: advance-toolchain-mcore-libs-dbg
 Architecture: ppc64el
-Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-mcore-libs-dbg (= __AT_FULL_VER__)
+Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-mcore-libs-dbg (= __AT_FULL_VER__)
 Description: Advance Toolchain
  The advance toolchain debugging information.
 
 Package: advance-toolchain-__AT_MAJOR_INTERNAL__-mcore-libs-dbg
 Architecture: ppc64el
-Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-mcore-libs (= __AT_FULL_VER__)
-Depends: ${shlibs:Depends} ${misc:Depends}
+Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-mcore-libs (= __AT_FULL_VER__),
+         ${shlibs:Depends} ${misc:Depends}
 Description: Advance Toolchain
  The advance toolchain debugging information.
 
 Package: advance-toolchain-perf
 Architecture: ppc64el
-Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-perf (= __AT_FULL_VER__)
+Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-perf (= __AT_FULL_VER__)
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview
  toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
@@ -129,8 +129,8 @@ Description: Advance Toolchain
 
 Package: advance-toolchain-__AT_MAJOR_INTERNAL__-perf
 Architecture: ppc64el
-Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__)
-Depends: ${shlibs:Depends} ${misc:Depends}
+Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__),
+         ${shlibs:Depends} ${misc:Depends}
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview
  toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
@@ -138,20 +138,20 @@ Description: Advance Toolchain
 
 Package: advance-toolchain-perf-dbg
 Architecture: ppc64el
-Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-perf-dbg (= __AT_FULL_VER__)
+Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-perf-dbg (= __AT_FULL_VER__)
 Description: Advance Toolchain
  The advance toolchain debugging information.
 
 Package: advance-toolchain-__AT_MAJOR_INTERNAL__-perf-dbg
 Architecture: ppc64el
-Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-perf (= __AT_FULL_VER__)
-Depends: ${shlibs:Depends} ${misc:Depends}
+Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-perf (= __AT_FULL_VER__),
+         ${shlibs:Depends} ${misc:Depends}
 Description: Advance Toolchain
  The advance toolchain debugging information.
 
 Package: advance-toolchain-libnxz
 Architecture: ppc64el
-Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-libnxz (= __AT_FULL_VER__)
+Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-libnxz (= __AT_FULL_VER__)
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview
  toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
@@ -159,8 +159,8 @@ Description: Advance Toolchain
 
 Package: advance-toolchain-__AT_MAJOR_INTERNAL__-libnxz
 Architecture: ppc64el
-Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__)
-Depends: ${shlibs:Depends} ${misc:Depends}
+Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-runtime (= __AT_FULL_VER__),
+         ${shlibs:Depends} ${misc:Depends}
 Description: Advance Toolchain
  The advance toolchain is a self contained toolchain which provides preview
  toolchain functionality in GCC, binutils, GLIBC, GDB, and Valgrind.
@@ -168,13 +168,13 @@ Description: Advance Toolchain
 
 Package: advance-toolchain-libnxz-dbg
 Architecture: ppc64el
-Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-libnxz-dbg (= __AT_FULL_VER__)
+Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-libnxz-dbg (= __AT_FULL_VER__)
 Description: Advance Toolchain
  This package contains the NX GZIP Library debugging information.
 
 Package: advance-toolchain-__AT_MAJOR_INTERNAL__-libnxz-dbg
 Architecture: ppc64el
-Pre-Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-libnxz (= __AT_FULL_VER__)
-Depends: ${shlibs:Depends} ${misc:Depends}
+Depends: advance-toolchain-__AT_MAJOR_INTERNAL__-libnxz (= __AT_FULL_VER__),
+         ${shlibs:Depends} ${misc:Depends}
 Description: Advance Toolchain
  This package contains the NX GZIP Library debugging information.

--- a/fvtr/ck_provides/ck_provides.exp
+++ b/fvtr/ck_provides/ck_provides.exp
@@ -68,6 +68,13 @@ proc process_deb {package expected} {
 	set at_full_ver [append_at_internal ${at_ver_rev}]
 	set version "(= ${at_full_ver})"
 
+	# On AT 15.0, all Pre-Depends have been replaced with Depends.
+	if { $::env(AT_MAJOR_VERSION) >= 15.0 } {
+		set depends_str "Depends"
+	} else {
+		set depends_str "Pre-Depends"
+	}
+
 	if { ![info exists ::env(AT_WD)] } {
 		if { [catch {exec dpkg-query --status ${expected}}] } {
 			printit "User didn't install package ${expected}.\
@@ -84,14 +91,15 @@ ${at_full_ver}. Can't run this test."
 			return ${ENOSYS}
 		}
 
-		# Parse the Pre-Depends field from the dummy package.
+		# Parse the Depends/Pre-Depends field from the dummy package.
 		# It must contain the actual package.
 		set depends [string trimleft \
 				    [exec dpkg-query --status ${expected} \
-					 | grep -E "Pre-Depends"] \
-				    "Pre-Depends: "]
+					 | grep -E "$depends_str"] \
+				    "$depends_str: "]
 
-		# Check if the Pre-Depends field references the actual package.
+		# Check if the Depends/Pre-Depends field references the actual
+		# package.
 		if { [string first "${package} ${version}" ${depends}] < 0 } {
 			printit "Package ${expected} doesn't depend on\
 \"${package} ${version}\"" ${ERROR}
@@ -108,15 +116,16 @@ ${at_full_ver}. Can't run this test."
 				 [string first "_" ${package}] \
 				 [string length ${package}]]
 
-		# Parse the Pre-Depends field from the dummy package.
+		# Parse the Depends/Pre-Depends field from the dummy package.
 		# It must contain the actual package.
 		set depends [string trimleft \
 				    [exec dpkg --info \
 				          ${deb_path}/${dpkg} \
-					 | grep -E "Pre-Depends"] \
-				    "Pre-Depends: "]
+					 | grep -E "$depends_str"] \
+				    "$depends_str: "]
 
-		# Check if the Pre-Depends field references the actual package.
+		# Check if the Depends/Pre-Depends field references the actual
+		# package.
 		if { [string first "${rpkg} ${version}" ${depends}] < 0 } {
 			printit "Package ${dpkg} doesn't depend on\
 \"${rpkg} ${version}\"" ${ERROR}
@@ -161,8 +170,8 @@ proc check_rpms {packages} {
 	return ${rc}
 }
 
-# Get each package that needs be checked and compare the string in Pre-Depends
-# of the correspondent DEB dummy package one by one.
+# Get each package that needs be checked and compare the string in Depends or
+# Pre-Depends of the correspondent DEB dummy package one by one.
 # packages - list of packages names.
 proc check_debs {packages} {
 	global at_ver_rev


### PR DESCRIPTION
5 of our deb packages have a Pre-Depends relationship because their
postinst(configure) execution depend on the availability of ldconfig.
However, many other packages had a Pre-Depends relationship without
having a pre-configure dependency.