### PR TITLE
Update Python on AT 11.0 and 12.0

### DIFF
--- a/configs/11.0/packages/python/sources
+++ b/configs/11.0/packages/python/sources
@@ -20,8 +20,8 @@
 #
 
 ATSRC_PACKAGE_NAME="Python"
-ATSRC_PACKAGE_VER=3.6.6
-ATSRC_PACKAGE_REV=4cf1f54eb764
+ATSRC_PACKAGE_VER=3.6.12
+ATSRC_PACKAGE_REV=c0a9afe2ac18
 ATSRC_PACKAGE_LICENSE="Python Software Foundation License 2"
 ATSRC_PACKAGE_DOCLINK="https://docs.python.org/3.6/"
 ATSRC_PACKAGE_RELFIXES=
@@ -43,8 +43,8 @@ ATSRC_PACKAGE_BUNDLE=toolchain_extra
 atsrc_get_patches ()
 {
 	at_get_patch \
-		https://raw.githubusercontent.com/powertechpreview/powertechpreview/8494221d2bec8fd65deaab0d8f53117aa57a1ac3/Python%20Fixes/python-3.6-getlib64s1.patch \
-		76139c8832bb1b5846e215aa9cbe7c0f || return ${?}
+		https://raw.githubusercontent.com/powertechpreview/powertechpreview/6a26e58cd17487c9e56c2b19f6fc8a9cf7229028/Python%20Fixes/python-3.6-getlib64s2.patch \
+		eccb0c0c5c16ad0c63cf211150bc35f2 || return ${?}
 
 	# Disable test_random_fork (test_ssl).
 	# See https://github.com/advancetoolchain/advance-toolchain/issues/201
@@ -52,13 +52,19 @@ atsrc_get_patches ()
 		https://raw.githubusercontent.com/powertechpreview/powertechpreview/89d1d3cb24e43f8ec716e1047f8d94702b131fda/Python%20Fixes/python-3.6.3-skip_test_random_fork.patch \
 		b6713b5bea7d419b18b8f8319ba5a6f2 || return ${?}
 
+	# Disable zlib version check (test_zlib).
+	at_get_patch \
+		https://raw.githubusercontent.com/powertechpreview/powertechpreview/1fa3a5896a6ce15e8b85fcf24109db5c1ea5548a/Python%20Fixes/python-3.7-disable-zlib-version-check.patch \
+		f52555a37aec6cb7f43eb052990e051b || return ${?}
+
 	return 0
 }
 
 atsrc_apply_patches ()
 {
-	patch -p1 < python-3.6-getlib64s1.patch || return ${?}
+	patch -p1 < python-3.6-getlib64s2.patch || return ${?}
 	patch -p1 < python-3.6.3-skip_test_random_fork.patch || return ${?}
+	patch -p1 < python-3.7-disable-zlib-version-check.patch || return ${?}
 }
 
 atsrc_package_verify_make_log ()


### PR DESCRIPTION
Update to Python 3.6.12, from version 3.6.6.
This update requires changes to the lib64 patch and also requires a
patch that is used on earlier AT versions in order to ignore a test for
the zlib version.