### PR TITLE
Disable more Python tests on AT <= 12.0

### DIFF
--- a/fvtr/python/python.exp
+++ b/fvtr/python/python.exp
@@ -100,15 +100,21 @@ if { [lindex $pyverl 0] > 3
 	append common_exclude_tests " test_dtrace"
 }
 
+if { [lindex $pyverl 0] < 3
+     || ([lindex $pyverl 0] == 3 && [lindex $pyverl 1] <= 6) } {
+	# Fails if run from the install dir.
+	append common_exclude_tests " test_distutils"
+}
+
 # The following sets up the python test command so that it excludes tests
 # which should not be run using FVTR.  The exclude test list is different
 # depending on the version of python being used, although some common tests
 # are defined above separately.
 if { "$pyver" == "2.6" } {
-	# Fails if run from the install dir: test_lib2to3, test_distutils.
+	# Fails if run from the install dir: test_lib2to3.
 	# Unexpected skip: test_tcl.
 	set spawn_cmd "spawn $env(AT_DEST)/bin/python $test_script \
-		-x $common_exclude_tests test_lib2to3 test_tcl test_distutils"
+		-x $common_exclude_tests test_lib2to3 test_tcl"
 } elseif { "$pyver" == "2.7" } {
 	# Might fail if run from the install dir:  test_idle test_tools.
 	set spawn_cmd "spawn $env(AT_DEST)/bin/python $test_script \


### PR DESCRIPTION
Some Python tests have been unreliable on AT <= 12.0.

test_distutils is known to fail when run from the install directory.