### PR TITLE
Update zlib patch

### DIFF
--- a/configs/12.0/packages/zlib/sources
+++ b/configs/12.0/packages/zlib/sources
@@ -44,8 +44,8 @@ atsrc_get_patches ()
 {
 	# Patch to add optimized functions using vector instructions.
 	at_get_patch \
-		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/90d14be34444c4f724e1a68a2c51789786adb021/Zlib%20Patches/zlib-power-optimizations.patch' \
-		73bbced6a575fd585791370c460eefda || return ${?}
+		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/a5ca30f50ec9d97762aa87bcc6517e30fa273aae/Zlib%20Patches/zlib-power-optimizations.patch' \
+	        e4e94637f2df3fdc95b6b9a2ac21b4c5 || return ${?}
 
 	return 0
 }


### PR DESCRIPTION
The previous patch to add zlib optimizations was applying them also to 32-bit
targets, but some optimizations are only intended for 64 bits. The updated patch
makes sure optimizations are only applied to 64-bit targets.

This issue impacted AT12's 32-bit builds, which should be fixed now.

Signed-off-by: Matheus Castanho <msc@linux.ibm.com>