### PR TITLE
Improve script that updates revisions

### DIFF
--- a/scripts/utilities/update_revision.sh
+++ b/scripts/utilities/update_revision.sh
@@ -158,7 +158,7 @@ get_latest_revision ()
 		# When the revision is in HEAD we got a string like:
 		# master -> HEAD
 		# origin/master
-		if [[ $(expr index "${branch}" "HEAD") -ne 0 ]]; then
+		if [[ "${branch}" = *"HEAD"* ]]; then
 			branch="HEAD"
 		else
 		    if [[ $(echo "${branch}" | wc -w) -ne 1 ]]; then


### PR DESCRIPTION
A check about branch could lead to the master branch whereas the branch
to check isn't related to it.

This `expr index "${branch}" "HEAD"` checks that any chars in `"HEAD"` is found
in `"${branch}"`. And if so, set the reference branch to `"HEAD"`.
This means if `"${branch}"` is `"VALGRIND_3_16_BRANCH"`, the reference branch will
be `"HEAD"`, which is incorrect.

Updated the check to ensure the whole word `"HEAD"` is found or not in `"${branch}"`.

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>