### PR TITLE
Fix gdb check on AT <= 12.0

### DIFF
--- a/fvtr/ck_binaries/ck_binaries.exp
+++ b/fvtr/ck_binaries/ck_binaries.exp
@@ -63,10 +63,10 @@ if { $env(AT_MAJOR_VERSION) >= 9.0 } {
 }
 
 # Binaries distributed with a different name on cross and non-cross
-set dif_exec {cpp elfedit embedspu gdb gprof readelf}
+set dif_exec {cpp elfedit embedspu gprof readelf}
 if { $env(AT_CROSS_BUILD) == "yes" } {
 	set alt_exec [concat ${alt_exec} ${dif_exec}]
-	set tgt_exec [concat ${tgt_exec} ${dif_exec}]
+	set tgt_exec [concat ${tgt_exec} ${dif_exec} gdb]
 } else {
 	set n_exec [concat ${n_exec} ${dif_exec} gdbserver]
 }
@@ -83,6 +83,7 @@ if { [string match no $env(AT_CROSS_BUILD)] } {
 }
 
 foreach exe $tgt_exec {
+	printitcont "Checking tgt file: $at_dir/bin/$env(AT_TARGET)-$exe"
 	if { ![file exists $at_dir/bin/$env(AT_TARGET)-$exe] } {
 		printitcont "Error:  File \
 $at_dir/bin/$env(AT_TARGET)-$exe is missing."
@@ -93,6 +94,7 @@ $at_dir/bin/$env(AT_TARGET)-$exe is missing."
 
 # Check architecture based executables
 foreach exe ${plt_exec} {
+	printitcont "Checking plt file: $at_dir/$env(AT_TARGET)/bin/$exe"
 	if { [file exists $at_dir/$env(AT_TARGET)/bin/$exe] == 0 } {
 		printitcont "Error: File $at_dir/$env(AT_TARGET)/bin/$exe is missing."
 		set rc 1


### PR DESCRIPTION
Older AT releases supported both ppc and ppc64.  For those releases,
some executables or symlinks were provided in order to simplify usage.
These executables used to have 2 different prefixes:
 - Target-based, e.g. powerpc64-linux-gnu-readelf;
 - Alternative, e.g. powerpc-linux-gnu-readelf.

However, not all executables available as target-based also had an
alternative-based prefix.  gdb is an exception and is only available as
a target-based prefix.

Futhermore, this issue is not reproduced on AT >= 13.0 because these
versions do not support big-endian targets anymore.

This commit is also improving verbosity of the test showing more
executables that were tested.

Fixes: 2781f58f58d545115ab40bddabcb6b5bbf82ae16
Signed-off-by: Tulio Magno Quites Machado Filho <tuliom@linux.ibm.com>