### PR TITLE
Follow Python 3.9 on AT next

### DIFF
--- a/configs/next/packages/python/sources
+++ b/configs/next/packages/python/sources
@@ -20,8 +20,8 @@
 #
 
 ATSRC_PACKAGE_NAME="Python"
-ATSRC_PACKAGE_VER=3.8.6
-ATSRC_PACKAGE_REV=a12f459ec2a3
+ATSRC_PACKAGE_VER=3.9.0
+ATSRC_PACKAGE_REV=7ae19ef5cf5d
 ATSRC_PACKAGE_LICENSE="Python Software Foundation License 2"
 ATSRC_PACKAGE_DOCLINK="https://docs.python.org/${ATSRC_PACKAGE_VER%\.*}/"
 ATSRC_PACKAGE_RELFIXES=
@@ -43,21 +43,10 @@ ATSRC_PACKAGE_BUNDLE=toolchain_extra
 
 atsrc_get_patches ()
 {
-    # Update python lib path to AT's
-	at_get_patch \
-		https://raw.githubusercontent.com/powertechpreview/powertechpreview/cd1a9a7bb398332641b05a45e12807ce6dabcc19/Python%20Fixes/python-3.8-getlib64.patch \
-		a8c6cab1ed2d9cabdb7369ae4b04a16a || return ${?}
-
-	# Disable test_random_fork (test_ssl).
-	# See https://github.com/advancetoolchain/advance-toolchain/issues/201
-	at_get_patch \
-		https://raw.githubusercontent.com/powertechpreview/powertechpreview/89d1d3cb24e43f8ec716e1047f8d94702b131fda/Python%20Fixes/python-3.6.3-skip_test_random_fork.patch \
-		b6713b5bea7d419b18b8f8319ba5a6f2 || return ${?}
-
 	# Increase a timeout in test_subprocess.
 	at_get_patch \
-		https://raw.githubusercontent.com/powertechpreview/powertechpreview/ec0f7202f72ca7b946525b29aca58ec50979906e/Python%20Fixes/python-3.6.12-timeout-test_subprocess.patch \
-		a50e89dca0c51249be26f027a0474a23 || return ${?}
+	        https://raw.githubusercontent.com/powertechpreview/powertechpreview/b9f88b42e734110e69873ea810272facc85b97c0/Python%20Fixes/python-3.9-timeout-test_subprocess.patch \
+	        92cfc34136fafb9420655b4bd3ef39d1 || return ${?}
 
 	# Disable zlib version check (test_zlib).
 	at_get_patch \
@@ -69,10 +58,8 @@ atsrc_get_patches ()
 
 atsrc_apply_patches ()
 {
-	patch -p1 < python-3.8-getlib64.patch || return ${?}
+	patch -p1 < python-3.9-timeout-test_subprocess.patch || return ${?}
 	patch -p1 < python-3.7-disable-zlib-version-check.patch || return ${?}
-	patch -p1 < python-3.6.12-timeout-test_subprocess.patch || return ${?}
-	patch -p1 < python-3.6.3-skip_test_random_fork.patch || return ${?}
 }
 
 atsrc_package_verify_make_log ()

--- a/configs/next/packages/python/stage_1
+++ b/configs/next/packages/python/stage_1
@@ -44,6 +44,7 @@ atcfg_configure() {
 		--prefix=${at_dest} \
 		--exec-prefix=${at_dest} \
 		--libdir="${at_dest}/lib${compiler##32}" \
+		--with-platlibdir="lib${compiler##32}" \
 		--enable-shared \
 		--enable-loadable-sqlite-extensions \
 		--with-openssl="${at_dest}" \

--- a/configs/next/packages/python/stage_1
+++ b/configs/next/packages/python/stage_1
@@ -1,1 +1,82 @@
-../../../14.0/packages/python/stage_1
+#!/usr/bin/env bash
+#
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Python build parameters for stage 1 32 bits
+# ===========================================
+#
+
+# Tell the build system to hold the temp install folder
+ATCFG_HOLD_TEMP_INSTALL='no'
+# Tell the build system to hold the temp build folder
+ATCFG_HOLD_TEMP_BUILD='no'
+# Build in a new directory
+ATCFG_BUILD_STAGE_T='dir'
+
+atcfg_post_hacks() {
+	rm -f ${install_transfer}/lib/libstdc++.so.6.0.*-gdb.py \
+	      ${install_transfer}/lib64/libstdc++.so.6.0.*-gdb.py
+}
+
+atcfg_configure() {
+	PATH=${at_dest}/bin:${PATH} \
+	CC="${at_dest}/bin/gcc -m${compiler}" \
+	CXX="${at_dest}/bin/g++ -m${compiler}" \
+	CFLAGS="-g -O2 -Wformat" \
+	CXXFLAGS="-g -O2" \
+	${ATSRC_PACKAGE_WORK}/configure \
+		--build=${target} \
+		--host=${target} \
+		--target=${target} \
+		--prefix=${at_dest} \
+		--exec-prefix=${at_dest} \
+		--libdir="${at_dest}/lib${compiler##32}" \
+		--enable-shared \
+		--enable-loadable-sqlite-extensions \
+		--with-openssl="${at_dest}" \
+		--with-ssl-default-suites=openssl \
+		--enable-optimizations \
+		--with-lto
+}
+
+atcfg_make() {
+	PATH=${at_dest}/bin:${PATH} ${SUB_MAKE}
+}
+
+atcfg_make_check() {
+	# Package testing not done on a cross build.
+
+	if [[ "${cross_build}" == 'no' ]]; then
+		PATH=${at_dest}/bin:${PATH} ${SUB_MAKE} test
+	fi
+}
+
+atcfg_install() {
+	PATH=${at_dest}/bin:${PATH} \
+		${SUB_MAKE} DESTDIR="${install_place}" install libainstall
+}
+
+atcfg_post_install() {
+	# Some projects (Boost) can't identify the Python headers directory
+	# when it's named pythonX.Ym.  So, it's necessary to create the
+	# symlink pythonX.Y -> pythonX.Ym.
+	if [ -d ${install_transfer}/include/python*m ]; then
+		pushd ${install_transfer}/include > /dev/null
+		local dir=$(ls -1d python*m | head -n 1)
+		ln -s ${dir} ${dir/%m/}
+		popd
+	fi
+}

--- a/fvtr/gdb/gdb.exp
+++ b/fvtr/gdb/gdb.exp
@@ -27,7 +27,7 @@ if { [array names env -exact "AT_GDB_VER"] == "" } {
 # AT 5.0 and 6.0 used to use development versions of GDB, instead of stable
 # versions like AT >= 7.0.  Which causes issues when trying to run this
 # testcase, like when testing for GDB version.
-if { [regexp "5\..*|6\..*" $env(AT_MAJOR_VERSION)] } {
+if { [regexp "\A5\..*|\A6\..*" $env(AT_MAJOR_VERSION)] } {
 	printit "This test doesn't work on AT 5.0 or 6.0." $WARNING
 	printit "Skipping..."
 	exit $ENOSYS

--- a/fvtr/python/python.exp
+++ b/fvtr/python/python.exp
@@ -45,7 +45,7 @@ if { [array names env -exact "AT_PYTHON_VER"] == "" } {
 
 # AT 5.0 and 6.0 doesn't have all the Python fixes implemented on AT >= 7.0,
 # which may cause Python expected failures on Python testcases.
-if { [regexp "5\..*|6\..*" $env(AT_MAJOR_VERSION)] } {
+if { [regexp "\A5\..*|\A6\..*" $env(AT_MAJOR_VERSION)] } {
 	printit "This test doesn't work on AT 5.0 or 6.0." $WARNING
 	printit "Skipping..."
 	exit $ENOSYS


### PR DESCRIPTION
This PR includes a fix for Python FVTR tests on AT next, an update to Python 3.9 on AT next and a few changes in the way we distribute Python. Copying the commit message of the most relevant commit:
    
    Python 3.9 has been recently released and is the version that should be
    followed by AT 15 (current AT next). While updating the revision, I took the
    time to fully revise all patches we have been applying to Python and actually
    found out we don't need two of them anymore (with a catch).
    
    1) Patch to skip test_ssl.test_random_fork:
    
        This was needed back in 2017 due to a bug in OpenSSL 1.1.1c (see discussion
        and linked Python issues in [0]). This has been fixed upstream a long time
        ago, and AT next currently follows OpenSSL 1.1.1h, which already includes
        the fix.
    
    2) Patch to update Python's lib path to AT's:
    
        Previous AT versions used to distribute all Python modules and packages
        under a python* directory on /opt/at<XX>/lib64. That is not default behavior
        upstream, so we needed this patch to force AT's Python to look for stuff in
        that subdir instead of the default ones under lib/.
    
        There are differences in the way distros approach this. The default scheme
        of installing everything to /usr/lib/ is used by Debian and Ubuntu. SLES and
        Fedora, on the other hand, split Python stuff into lib and lib64. All
        generic and pure-Python code is installed on lib and any platform-specific
        code goes to lib64. That behavior was not supported by Python upstream's
        install scripts, and these distros had to maintain off-tree patches (like
        ours) for a long time [1]. This changed in Python 3.9, which added the
        --with-platlibdir flag to help Fedora and SLES properly install stuff the
        way they need without needing off-tree patches.
    
        The split into the two different directories is specially useful for
        situations when one needs to install Python built for different targets on
        the same system. This way a 32- and a 64-bit installation can share the
        generic files and only install the platform-specific stuff in their
        corresponding directories. That obviously is not the case for AT, as we
        don't support 32-bit targets anymore.
    
        Still, I'd prefer if AT used an installation method that is supported
        upstream, so we can reduce the amount of off-tree patches we need to
        maintain, specially a big and complex one like this. They usually need
        updates now and then when a new version makes incompatible changes.
        Splitting the installation into lib and lib64 dirs as described above makes
        sense and should work well for AT.
    
        So instead of applying our off-tree patch, this commit configures Python
        with --with-platlibdir=lib64, which as a side-effect changes the way AT
        distributes Python modules and packages:
          Before: everything under /opt/at<XX>/lib64/
          After: generic and pure-Python modules /opt/at<XX>/lib and platform
          specific files in /opt/at<XX>/lib64.
    
        This change should be transparent to AT users as Python configured this way
        knows where it should look for stuff.
    
    [0] https://github.com/advancetoolchain/advance-toolchain/issues/201
    [1] https://bugs.python.org/issue1294959

Example of how Python stuff is distributed in AT 14:
``` bash
$ find /opt/at14.0/ -name '*python*' -type d
/opt/at14.0/lib/debug/opt/at14.0/lib64/python3.8
/opt/at14.0/lib64/python3.8
/opt/at14.0/lib64/cmake/boost_python-1.73.0
/opt/at14.0/share/gcc-10.2.1/python
/opt/at14.0/share/gdb/python
/opt/at14.0/include/python3.8
/opt/at14.0/include/python3.8/cpython
/opt/at14.0/include/boost/mpi/python
/opt/at14.0/include/boost/parameter/aux_/python
/opt/at14.0/include/boost/python
```

Now on AT next after this change:
```
$ find ./opt/at-next-15.0-0-alpha/ -name '*python*' -type d
./opt/at-next-15.0-0-alpha/lib64/cmake/boost_python-1.73.0
./opt/at-next-15.0-0-alpha/lib64/python3.9
./opt/at-next-15.0-0-alpha/include/python3.9
./opt/at-next-15.0-0-alpha/include/python3.9/cpython
./opt/at-next-15.0-0-alpha/include/boost/mpi/python
./opt/at-next-15.0-0-alpha/include/boost/parameter/aux_/python
./opt/at-next-15.0-0-alpha/include/boost/python
./opt/at-next-15.0-0-alpha/share/gcc-11.0.0/python
./opt/at-next-15.0-0-alpha/share/gdb/python
./opt/at-next-15.0-0-alpha/lib/python3.9
```

Closes #1763 
Closes #1818