### PR TITLE
Fix FVTR tests being wrongly ignored on AT next

### DIFF
--- a/fvtr/ck_gold/ck_gold.exp
+++ b/fvtr/ck_gold/ck_gold.exp
@@ -23,10 +23,7 @@ set CFLAGS "-O2 -Wall"
 
 printit "Checking if binutils has been built with the gold linker..."
 
-if { [regexp "5\..*|6\..*|7\..|8\..*" $env(AT_MAJOR_VERSION)] } {
-	printit "gold linker is not built prior to AT 9.0."
-	exit $ENOSYS
-}
+check_minimum_version 9.0 "gold linker is not built prior to AT 9.0."
 
 #
 # Gold is enabled by passing the --enable-gold when building

--- a/fvtr/ck_lock_elision/ck_lock_elision.exp
+++ b/fvtr/ck_lock_elision/ck_lock_elision.exp
@@ -24,10 +24,7 @@ set CFLAGS "-O2 -Wall -pthread"
 
 printit "Checking if lock elision is enabled on libpthread..."
 
-if { [regexp "5\..*|6\..*|7\..*|8\..*" $env(AT_MAJOR_VERSION)] } {
-	printit "Lock elision is not supported prior to AT 9.0."
-	exit $ENOSYS
-}
+check_minimum_version 9.0 "Lock elision is not supported prior to AT 9.0."
 
 if { $env(AT_CROSS_BUILD) == "yes" } {
 	printit "Lock elision testing can only be performed on a supported host."

--- a/fvtr/ck_provides/ck_provides.exp
+++ b/fvtr/ck_provides/ck_provides.exp
@@ -152,7 +152,7 @@ proc check_rpms {packages} {
 	# AT 5.0 and 6.0 used to support devel and perf only.
 	set supported_pkgs {devel perf}
 	# AT 7.0 added the provides for runtime and mcore-libs.
-	if { ![regexp "5\..*|6\..*" $::env(AT_MAJOR_VERSION)] } {
+	if { ![regexp "^5\..*|^6\..*" $::env(AT_MAJOR_VERSION)] } {
 		lappend supported_pkgs runtime mcore-libs
 	}
 	foreach pkg ${supported_pkgs} {

--- a/fvtr/ck_tuned/ck_tuned.exp
+++ b/fvtr/ck_tuned/ck_tuned.exp
@@ -12,10 +12,7 @@ set libs {libc.so libcrypto.so libdfp.so libgcc_s.so libz.so}
 set rc 0
 set libs2 {}
 
-if { [regexp "5\..*|6\..*" $env(AT_MAJOR_VERSION)] } {
-	printit "Tuned libraries had different settings prior to AT 7.0."
-	exit $ENOSYS
-}
+check_minimum_version 7.0 "Tuned libraries had different settings prior to AT 7.0."
 
 if { $env(AT_CROSS_BUILD) == "yes" } {
 	printit "AT doesn't distribute tuned libraries in the cross compiler."

--- a/fvtr/gccgo/gccgo.exp
+++ b/fvtr/gccgo/gccgo.exp
@@ -25,10 +25,7 @@ source ./shared.exp
 set GCCGO [compiler_path gccgo]
 set CFLAGS "-O2 -Wall"
 
-if { [regexp "5\..*|6\..*|7.0" $env(AT_MAJOR_VERSION)] } {
-	printit "gccgo is not supported prior to AT 7.1\t\[SUCCESS\]"
-	exit $ENOSYS
-}
+check_minimum_version 7.1 "gccgo is not supported prior to AT 7.1\t\[SUCCESS\]"
 
 printit "Running gccgo tests..."
 
@@ -39,7 +36,7 @@ $at_dir/bin/$env(AT_TARGET)-gccgo is missing."
 }
 
 # GCC Go <= 5 do not support split-stack.
-if { ! [regexp "7\.1|8\.0|9\.0" $env(AT_MAJOR_VERSION)] } {
+if { ! [regexp "^7\.1|^8\.0|^9\.0" $env(AT_MAJOR_VERSION)] } {
 	printit "Test if libgo.so supports split-stack..."
 	set libs [ exec find ${at_dir} -type f -name libgo.so* ]
 	foreach f ${libs} {

--- a/fvtr/gdb/gdb.exp
+++ b/fvtr/gdb/gdb.exp
@@ -27,12 +27,7 @@ if { [array names env -exact "AT_GDB_VER"] == "" } {
 # AT 5.0 and 6.0 used to use development versions of GDB, instead of stable
 # versions like AT >= 7.0.  Which causes issues when trying to run this
 # testcase, like when testing for GDB version.
-if { [regexp "\A5\..*|\A6\..*" $env(AT_MAJOR_VERSION)] } {
-	printit "This test doesn't work on AT 5.0 or 6.0." $WARNING
-	printit "Skipping..."
-	exit $ENOSYS
-}
-
+check_minimum_version 7.0 "This test doesn't work prior to AT 7.0."
 
 # Get GDB version in the format: X.Y.Z
 set GDB [compiler_path gdb]

--- a/fvtr/oprofile/oprofile.exp
+++ b/fvtr/oprofile/oprofile.exp
@@ -67,11 +67,11 @@ if { [array names env -exact "AT_OPROFILE_VER"] == "" } {
 # Check if libjvmti_oprofile.so and libjvmpi_oprofile.so are available for 32
 # and 64 bits.
 switch -regexp $env(AT_MAJOR_VERSION) {
-	"5\..*" {
+	"^5\..*" {
 		# AT 5.0 supports jvmpi only (kernel limits?).
 		set java_libs {"libjvmpi_oprofile"}
 	}
-	"6\..*|7\.0" {
+	"^6\..*|^7\.0" {
 		# AT 6.0 and 7.0 support both jvmti and jvmpi.
 		set java_libs {"libjvmti_oprofile" "libjvmpi_oprofile"}
 	}

--- a/fvtr/python/python.exp
+++ b/fvtr/python/python.exp
@@ -102,6 +102,12 @@ if { [lindex $pyverl 0] < 3
 	append common_exclude_tests " test_distutils"
 }
 
+if { [lindex $pyverl 0] < 3
+     || ([lindex $pyverl 0] == 3 && [lindex $pyverl 1] <= 5) } {
+	# Fails on some systems depending on their timezone configuration.
+	append common_exclude_tests " test_strptime"
+}
+
 # The following sets up the python test command so that it excludes tests
 # which should not be run using FVTR.  The exclude test list is different
 # depending on the version of python being used, although some common tests

--- a/fvtr/python/python.exp
+++ b/fvtr/python/python.exp
@@ -45,11 +45,7 @@ if { [array names env -exact "AT_PYTHON_VER"] == "" } {
 
 # AT 5.0 and 6.0 doesn't have all the Python fixes implemented on AT >= 7.0,
 # which may cause Python expected failures on Python testcases.
-if { [regexp "\A5\..*|\A6\..*" $env(AT_MAJOR_VERSION)] } {
-	printit "This test doesn't work on AT 5.0 or 6.0." $WARNING
-	printit "Skipping..."
-	exit $ENOSYS
-}
+check_minimum_version 7.0 "This test doesn't work prior to AT 7.0."
 
 printit "Running Python tests..."
 

--- a/fvtr/shared.exp
+++ b/fvtr/shared.exp
@@ -531,6 +531,14 @@ ${pkg_name}."
 	return ${packages}
 }
 
+proc check_minimum_version {minversion errmsg} {
+    if { $::env(AT_MAJOR_VERSION) < $minversion } {
+	printit $errmsg $WARNING
+	printit "Skipping..."
+	exit $ENOSYS
+    }
+}
+
 # Variables used in most testcases
 set FULLPATH [pwd]
 set CURTEST [lindex $argv 0]

--- a/fvtr/speccpu2006/speccpu2006.exp
+++ b/fvtr/speccpu2006/speccpu2006.exp
@@ -65,10 +65,10 @@ if { $TARGET64 } {
 # Different versions of the compiler, requires different flags for specific
 # benchmarks.  A good example is what happened with 416.gamess on GCC 4.8.
 switch -regexp $env(AT_MAJOR_VERSION) {
-	5.0|6.0 {
+	"^5.0|^6.0" {
 		set cfg_set ""
 	}
-	7.0|7.1|8.0|9.0 {
+	"^7.0|^7.1|^8.0|^9.0" {
 		set cfg_set "7.0"
 	}
 	default {


### PR DESCRIPTION
This PR fixes almost all issues from #1813.  The only one missing is the perf setup on the build servers. It also skips `test_strptime` Python test on AT < 11. The test is broken prior to Python AT 3.6 and caused some failures on test builds.

Please check the commit messages for more info.

This is the FVTR output on the same host as in #1813, with this PR (+ proper perf setup):
```
2020-11-19_17.38.37 Running FVTR for at15.0-0-alpha...
amino                   power8:         ignored
boost                   power8:         passed
ck_binaries             power8:         passed
ck_gold                 power8:         passed
ck_ldconfig             power8:         passed
ck_ldds                 power8:         passed
ck_libbits              power8:         passed
ck_lock_elision         power8:         passed
ck_provides             power8:         passed
ck_requires             power8:         passed
ck_tuned                power8:         passed
dhrystone               power8:         ignored
gcc-builtins            power8:         passed
gccgo                   power8:         passed
gdb                     power8:         passed
gmp                     power8:         passed
golang                  power8:         ignored
gomp                    power8:         passed
gotools                 power8:         passed
libauxv                 power8:         ignored
libdfp                  power8:         passed
libexpat                power8:         passed
libhugetlbfs            power8:         passed
libnxz                  power8:         passed
libvecpf                power8:         passed
mpfr                    power8:         passed
openssl                 power8:         passed
oprofile                power8:         ignored
package-check           power8:         passed
paflib                  power8:         passed
perf                    power8:         passed
ppc476-workaround       power8:         ignored
pthreads                power8:         passed
pveclib                 power8:         passed
python                  power8:         passed
speccpu2006             power8:         ignored
speccpu2017             power8:         ignored
sphde                   power8:         passed
sysroot                 power8:         passed
systemtap               power8:         passed
tbb                     power8:         passed
tcmalloc                power8:         passed
timezone                power8:         ignored
urcu                    power8:         passed
valgrind                power8:         passed
xlc                     power8:         ignored
xlcdfp                  power8:         ignored
xlf                     power8:         ignored
zlib                    power8:         passed

**************** TEST SUMMARY *****************
Passed tests: 37
Skipped tests: 12
Failed tests: 0
***********************************************
```
The list of ignored tests looks more reasonable now.