### PR TITLE
fvtr: Skip perf test on cross builds

### DIFF
--- a/fvtr/perf/perf.exp
+++ b/fvtr/perf/perf.exp
@@ -17,6 +17,11 @@
 
 source ./shared.exp
 
+if { $env(AT_CROSS_BUILD) == "yes" } {
+	printit "This is a cross build. Skipping this test..."
+	exit $ENOSYS
+}
+
 set traced_events "/sys/kernel/debug/tracing/uprobe_events"
 
 if {![file writable $traced_events]} {


### PR DESCRIPTION
It doesn't make much sense to run the perf FVTR test on cross builds, since it
won't run on a Power machine using AT.

Signed-off-by: Matheus Castanho <msc@linux.ibm.com>
