### PR TITLE
fvtr: Increase timeout for Python test_eintr test

### DIFF
--- a/configs/11.0/packages/python/sources
+++ b/configs/11.0/packages/python/sources
@@ -62,6 +62,11 @@ atsrc_get_patches ()
 		https://raw.githubusercontent.com/powertechpreview/powertechpreview/1fa3a5896a6ce15e8b85fcf24109db5c1ea5548a/Python%20Fixes/python-3.7-disable-zlib-version-check.patch \
 		f52555a37aec6cb7f43eb052990e051b || return ${?}
 
+	# Increase a timeout in test_eintr
+	at_get_patch \
+	        https://raw.githubusercontent.com/powertechpreview/powertechpreview/eca78e1632b35e01a275c9d258dd1728a1bb6083/Python%20Fixes/0001-Increase-timeout-on-test_eintr.FNTLEINTRTest.patch \
+	        4ce5bbacd29438b372936a4ba37d1b30 || return ${?}
+
 	return 0
 }
 
@@ -71,6 +76,7 @@ atsrc_apply_patches ()
 	patch -p1 < python-3.6.3-skip_test_random_fork.patch || return ${?}
 	patch -p1 < python-3.6.12-timeout-test_subprocess.patch || return ${?}
 	patch -p1 < python-3.7-disable-zlib-version-check.patch || return ${?}
+	patch -p1 < 0001-Increase-timeout-on-test_eintr.FNTLEINTRTest.patch || return ${?}
 }
 
 atsrc_package_verify_make_log ()

--- a/configs/13.0/packages/python/sources
+++ b/configs/13.0/packages/python/sources
@@ -62,6 +62,11 @@ atsrc_get_patches ()
 		https://raw.githubusercontent.com/powertechpreview/powertechpreview/1fa3a5896a6ce15e8b85fcf24109db5c1ea5548a/Python%20Fixes/python-3.7-disable-zlib-version-check.patch \
 		f52555a37aec6cb7f43eb052990e051b || return ${?}
 
+	# Increase a timeout in test_eintr
+	at_get_patch \
+	        https://raw.githubusercontent.com/powertechpreview/powertechpreview/eca78e1632b35e01a275c9d258dd1728a1bb6083/Python%20Fixes/0001-Increase-timeout-on-test_eintr.FNTLEINTRTest.patch \
+	        4ce5bbacd29438b372936a4ba37d1b30 || return ${?}
+
 	return 0
 }
 
@@ -71,6 +76,7 @@ atsrc_apply_patches ()
 	patch -p1 < python-3.7-disable-zlib-version-check.patch || return ${?}
 	patch -p1 < python-3.6.12-timeout-test_subprocess.patch || return ${?}
 	patch -p1 < python-3.6.3-skip_test_random_fork.patch || return ${?}
+	patch -p1 < 0001-Increase-timeout-on-test_eintr.FNTLEINTRTest.patch || return ${?}
 }
 
 atsrc_package_verify_make_log ()

--- a/configs/14.0/packages/python/sources
+++ b/configs/14.0/packages/python/sources
@@ -64,6 +64,11 @@ atsrc_get_patches ()
 		https://raw.githubusercontent.com/powertechpreview/powertechpreview/1fa3a5896a6ce15e8b85fcf24109db5c1ea5548a/Python%20Fixes/python-3.7-disable-zlib-version-check.patch \
 		f52555a37aec6cb7f43eb052990e051b || return ${?}
 
+	# Increase a timeout in test_eintr
+	at_get_patch \
+	        https://raw.githubusercontent.com/powertechpreview/powertechpreview/eca78e1632b35e01a275c9d258dd1728a1bb6083/Python%20Fixes/0001-Increase-timeout-on-test_eintr.FNTLEINTRTest.patch \
+	        4ce5bbacd29438b372936a4ba37d1b30 || return ${?}
+
 	return 0
 }
 
@@ -73,6 +78,7 @@ atsrc_apply_patches ()
 	patch -p1 < python-3.7-disable-zlib-version-check.patch || return ${?}
 	patch -p1 < python-3.6.12-timeout-test_subprocess.patch || return ${?}
 	patch -p1 < python-3.6.3-skip_test_random_fork.patch || return ${?}
+	patch -p1 < 0001-Increase-timeout-on-test_eintr.FNTLEINTRTest.patch || return ${?}
 }
 
 atsrc_package_verify_make_log ()

--- a/configs/next/packages/python/sources
+++ b/configs/next/packages/python/sources
@@ -53,6 +53,11 @@ atsrc_get_patches ()
 		https://raw.githubusercontent.com/powertechpreview/powertechpreview/1fa3a5896a6ce15e8b85fcf24109db5c1ea5548a/Python%20Fixes/python-3.7-disable-zlib-version-check.patch \
 		f52555a37aec6cb7f43eb052990e051b || return ${?}
 
+	# Increase a timeout in test_eintr
+	at_get_patch \
+	        https://raw.githubusercontent.com/powertechpreview/powertechpreview/eca78e1632b35e01a275c9d258dd1728a1bb6083/Python%20Fixes/0001-Increase-timeout-on-test_eintr.FNTLEINTRTest.patch \
+	        4ce5bbacd29438b372936a4ba37d1b30 || return ${?}
+
 	return 0
 }
 
@@ -60,6 +65,7 @@ atsrc_apply_patches ()
 {
 	patch -p1 < python-3.9-timeout-test_subprocess.patch || return ${?}
 	patch -p1 < python-3.7-disable-zlib-version-check.patch || return ${?}
+	patch -p1 < 0001-Increase-timeout-on-test_eintr.FNTLEINTRTest.patch || return ${?}
 }
 
 atsrc_package_verify_make_log ()


### PR DESCRIPTION
This test has been failing intermittently on our FVTR Python tests when the
server is under heavy load (like when testing multiple PRs during the
weekend). So extend the tolerance to avoid these spurious failures.

(Hopefully)
Fixes #1873 