### PR TITLE
Update python on AT 13.0

### DIFF
--- a/configs/13.0/packages/python/sources
+++ b/configs/13.0/packages/python/sources
@@ -20,8 +20,8 @@
 #
 
 ATSRC_PACKAGE_NAME="Python"
-ATSRC_PACKAGE_VER=3.7.3
-ATSRC_PACKAGE_REV=ef4ec6ed12d6
+ATSRC_PACKAGE_VER=3.7.9
+ATSRC_PACKAGE_REV=13c94747c744
 ATSRC_PACKAGE_BRANCH=3.7
 ATSRC_PACKAGE_LICENSE="Python Software Foundation License 2"
 ATSRC_PACKAGE_DOCLINK="https://docs.python.org/3.7/"
@@ -44,8 +44,8 @@ ATSRC_PACKAGE_BUNDLE=toolchain_extra
 atsrc_get_patches ()
 {
 	at_get_patch \
-		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/master/Python%20Fixes/python-3.7-getlib64s2.patch' \
-		fdbf84e9eedfcfb2ef86c7807967f5a1 || return ${?}
+		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/36633f85101bb6bb8262b0078ee02d1f5f16c4ef/Python%20Fixes/python-3.7-getlib64s3.patch' \
+		d347d3019286bb4631b2285fe9e17060 || return ${?}
 
 	# Disable test_random_fork (test_ssl).
 	# See https://github.com/advancetoolchain/advance-toolchain/issues/201
@@ -68,7 +68,7 @@ atsrc_get_patches ()
 
 atsrc_apply_patches ()
 {
-	patch -p1 < python-3.7-getlib64s2.patch || return ${?}
+	patch -p1 < python-3.7-getlib64s3.patch || return ${?}
 	patch -p1 < python-3.7-disable-zlib-version-check.patch || return ${?}
 	patch -p1 < python-3.6.12-timeout-test_subprocess.patch || return ${?}
 	patch -p1 < python-3.6.3-skip_test_random_fork.patch || return ${?}


### PR DESCRIPTION
Bump to the tag v3.7.9.

Fixes #1889 and #1890.