### PR TITLE
Fix update_revision.sh to get updates from HEAD

### DIFF
--- a/scripts/utilities/update_revision.sh
+++ b/scripts/utilities/update_revision.sh
@@ -158,8 +158,6 @@ get_latest_revision ()
 		# relocated within the vendors directory.
 		if [[ $package == "gcc" ]] && [[ $configset != "next" ]]; then
 		    branch="refs/vendors/ibm/heads/${branch}"
-		else
-		    branch="refs/heads/${branch}"
 		fi
 		hash=$(git ls-remote ${url} ${branch} | cut -f1)
 		[[ -n "$hash" ]] && hash=$(git rev-parse --short=12 ${hash})


### PR DESCRIPTION
After commit 8607a59, the script wasn't able to get updates from HEAD branch
of packages because it tried to get refs/heads/HEAD instead of HEAD.

Fix #1897

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>