### PR TITLE
Update GCC on AT 14 plus fixes

### DIFF
--- a/configs/14.0/packages/gcc/sources
+++ b/configs/14.0/packages/gcc/sources
@@ -23,7 +23,7 @@ ATSRC_PACKAGE_NAME="GCC (GNU Compiler Collection)"
 ATSRC_PACKAGE_SUBPACKAGE_NAME_0="GNU Standard C++ Library v3 (Libstdc++-v3)"
 ATSRC_PACKAGE_SUBPACKAGE_NAME_1="GNU Libgomp"
 ATSRC_PACKAGE_VER=10.2.1
-ATSRC_PACKAGE_REV=6c344e4ab655
+ATSRC_PACKAGE_REV=2093e873bb6c
 ATSRC_PACKAGE_BRANCH=gcc-10-branch
 ATSRC_PACKAGE_LICENSE="GPL 3.0"
 ATSRC_PACKAGE_DOCLINK="https://gcc.gnu.org/onlinedocs/gcc-${ATSRC_PACKAGE_VER%.*}.0/gcc/"
@@ -57,8 +57,8 @@ atsrc_get_patches ()
 
 	# Avoid a misconfiguration of tuned libraries as seen in issue #204.
 	at_get_patch \
-		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/a51115f619a5210d868819d41ba5f021327ba83/GCC%20PowerPC%20Backport/9/0001-libssp-Ignore-vsnprintf-test-when-ssp_have_usable_vs.patch' \
-		8ad129baf6f4a6f61572d5c36c57536b || return ${?}
+		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/fff3bbc86ac6308537b1f6365cc0b745d137308e/GCC%20PowerPC%20Backport/10/0001-libssp-Ignore-vsnprintf-test-when-ssp_have_usable_vs.patch' \
+		d033a657f2d2aaed471b8665ebe5c142 || return ${?}
 
 	# Avoid an error on libstdc++ when running msgfmt.
 	at_get_patch \

--- a/configs/14.0/packages/glibc/sources
+++ b/configs/14.0/packages/glibc/sources
@@ -43,8 +43,8 @@ atsrc_get_patches ()
 	# Fix TLS issues when PC-rel is enabled (POWER10).  Remove this later
 	# after merging it upstream.
 	at_get_patch \
-		'https://patchwork.sourceware.org/project/glibc/patch/20200930195512.724059-1-tuliom@linux.ibm.com/mbox/' \
-		14231edd3e971aa85c19bee7ea70ca6f tls.patch
+		'https://public-inbox.org/libc-alpha/20200930195512.724059-1-tuliom@linux.ibm.com/raw' \
+		c05d060a43cc78feea80a545734cd190 tls.patch
 }
 
 atsrc_apply_patches ()


### PR DESCRIPTION
This updates GCC on AT 14, fixes the libssp patch and also updates the URL to the glibc TLS patch to avoid md5sum mismatches if the file from patchwork gets changed (which just happened recently).

Closes #1900 