### PR TITLE
[next] Revert GCC 11 'Default to DWARF5'

### DIFF
--- a/configs/next/packages/gcc/sources
+++ b/configs/next/packages/gcc/sources
@@ -23,7 +23,7 @@ ATSRC_PACKAGE_NAME="GCC (GNU Compiler Collection)"
 ATSRC_PACKAGE_SUBPACKAGE_NAME_0="GNU Standard C++ Library v3 (Libstdc++-v3)"
 ATSRC_PACKAGE_SUBPACKAGE_NAME_1="GNU Libgomp"
 ATSRC_PACKAGE_VER=11.0.0
-ATSRC_PACKAGE_REV=2c356f221bba
+ATSRC_PACKAGE_REV=eb9883c1312c
 ATSRC_PACKAGE_LICENSE="GPL 3.0"
 ATSRC_PACKAGE_DOCLINK="https://gcc.gnu.org/onlinedocs/gcc/"
 ATSRC_PACKAGE_SUBPACKAGE_DOCLINK_0="https://gcc.gnu.org/libstdc++/"
@@ -62,6 +62,10 @@ atsrc_get_patches ()
 		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/master/GCC%20libstdc%2B%2B%20PowerPC%20Patches/9/0001-libstdc-Prevent-LD_LIBRARY_PATH-from-leaking-to-msgf.patch' \
 		9cba9a9b94ca9c1b8958c0d722a9c06b || return ${?}
 
+	at_get_patch \
+		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/master/GCC%20PowerPC%20Backport/11/Revert-Default-to-DWARF5.patch' \
+		0cc724faa8c2db5e686d70900b323365 || return ${?}
+
 	return 0
 }
 
@@ -73,5 +77,9 @@ atsrc_apply_patches ()
 
 	patch -p1 \
 	      < 0001-libstdc-Prevent-LD_LIBRARY_PATH-from-leaking-to-msgf.patch \
+		|| return ${?}
+
+	patch -p1 \
+	      < Revert-Default-to-DWARF5.patch \
 		|| return ${?}
 }


### PR DESCRIPTION
GCC 11 defaults to DWARF5. This causes problems with tools that are not
ready for it.  In particular, `perf` on SLES 15 SP2:
```
$rpm -qi perf
Name        : perf
Version     : 5.3.18
Release     : 23.24
```

Pull request #1928 hit this issue, seeing the FVTR test for `perf`
hang at the command:
```
$ perf probe -v -x /path/to/AT/at-next-15.0-0-alpha/bin/ld test_perf_debug=main argc
probe-definition(0): test_perf_debug=main argc
symbol:main file:(null) line:0 offset:0 return:0 lazy:(null)
parsing arg: argc into argc
1 arguments
Open Debuginfo file: /path/to/AT/at-next-15.0-0-alpha/bin/ld
Try to find probe point from debuginfo.
```

Revert the subject patch at least until these tools are ready.

Fixes #1951

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>