### PR TITLE
Fix next to work without RUNPATH on binaries

### DIFF
--- a/configs/next/deb/monolithic/rules
+++ b/configs/next/deb/monolithic/rules
@@ -1,1 +1,88 @@
-../../../14.0/deb/monolithic/rules
+#!/usr/bin/make -f
+#
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+PACKAGES=$(shell dh_listpackages)
+
+build:
+	dh_testdir
+	dh_testroot
+	dh_prep
+
+clean:
+	dh_testdir
+	dh_testroot
+	dh_clean -d
+
+binary-indep: build
+
+binary-arch: build binary-cp
+	dh_installdirs
+	dh_installdocs
+	dh_installchangelogs
+ifeq (__USE_SYSTEMD__, yes)
+	dh_systemd_enable
+endif
+
+# Copy the packages' files.
+	dh_install
+	dh_missing --fail-missing
+ifeq (__USE_SYSTEMD__, yes)
+	dh_systemd_start
+endif
+
+# Strip binaries
+	perl debian/dh_strip --dest=__AT_DEST__ --exclude=getconf --exclude=libgo. --exclude=ld- --dbg-package=advance-toolchain-__AT_MAJOR_INTERNAL__-runtime-dbg -p advance-toolchain-__AT_MAJOR_INTERNAL__-runtime
+	perl debian/dh_strip --dest=__AT_DEST__ --dbg-package=advance-toolchain-__AT_MAJOR_INTERNAL__-mcore-libs-dbg -p advance-toolchain-__AT_MAJOR_INTERNAL__-mcore-libs
+	perl debian/dh_strip --dest=__AT_DEST__ --exclude=getconf --dbg-package=advance-toolchain-__AT_MAJOR_INTERNAL__-devel-dbg -p advance-toolchain-__AT_MAJOR_INTERNAL__-devel
+	perl debian/dh_strip --dest=__AT_DEST__ --dbg-package=advance-toolchain-__AT_MAJOR_INTERNAL__-perf-dbg -p advance-toolchain-__AT_MAJOR_INTERNAL__-perf
+	perl debian/dh_strip --dest=__AT_DEST__ --dbg-package=advance-toolchain-__AT_MAJOR_INTERNAL__-libnxz-dbg -p advance-toolchain-__AT_MAJOR_INTERNAL__-libnxz
+
+	dh_compress
+	dh_makeshlibs --version-info
+	dh_installdeb
+	dh_shlibdeps --exclude=typedef --exclude=testdata
+	dh_gencontrol
+	dh_md5sums
+	dh_builddeb
+
+binary-cp: build
+	mkdir -p debian/tmp/__AT_DEST__
+	rsync -a --delete --delete-excluded \
+	      --exclude=etc/ld.so.cache \
+	      --exclude=compat/include \
+	      --exclude=share/info/dir \
+	      __AT_DEST__ debian/tmp/__AT_DEST__/../
+ifeq (__USE_SYSTEMD__, yes)
+	# Set a systemd service to run AT's ldconfig when the system's \
+	# ldconfig is executed.
+	mkdir -p debian/tmp/__SYSTEMD_UNIT__/
+	mv debian/cachemanager.service debian/tmp/__SYSTEMD_UNIT__/__AT_VER_ALTERNATIVE__-cachemanager.service
+	mkdir -p debian/tmp/__SYSTEMD_PRESET__/
+	echo "enable __AT_VER_ALTERNATIVE__-cachemanager.service" \
+		> debian/tmp/__SYSTEMD_PRESET__/90-__AT_VER_ALTERNATIVE__cachemanager.preset
+else
+	# Set a cronjob to run AT's ldconfig when the system's ldconfig is
+	# executed.
+	mkdir -p debian/tmp/etc/cron.d/
+	echo "@reboot root __AT_DEST__/bin/watch_ldconfig &" \
+	      > debian/tmp/etc/cron.d/__AT_VER_ALTERNATIVE___ldconfig
+	chmod 644 debian/tmp/etc/cron.d/__AT_VER_ALTERNATIVE___ldconfig
+endif
+	gzip -9nvf debian/tmp/__AT_DEST__/share/info/*.info*
+
+binary: binary-indep binary-arch
+.PHONY: build clean binary-indep binary-arch binary

--- a/configs/next/deb/monolithic/rules
+++ b/configs/next/deb/monolithic/rules
@@ -54,7 +54,7 @@ endif
 	dh_compress
 	dh_makeshlibs --version-info
 	dh_installdeb
-	dh_shlibdeps --exclude=typedef --exclude=testdata
+	dh_shlibdeps --exclude=typedef --exclude=testdata -l__AT_DEST__/lib -l__AT_DEST__/lib64
 	dh_gencontrol
 	dh_md5sums
 	dh_builddeb

--- a/configs/next/deb/monolithic_cross/rules
+++ b/configs/next/deb/monolithic_cross/rules
@@ -49,7 +49,9 @@ binary-arch: build binary-cp
 	dh_installdeb
 # Avoid including PPC libraries as they could break system's ldd.
 	dh_shlibdeps --exclude=__DEST_CROSS__ \
-		--exclude=__AT_DEST__/__TARGET__
+		--exclude=__AT_DEST__/__TARGET__ \
+		-l__AT_DEST__/lib64 \
+		-l__AT_DEST__/lib
 	dh_gencontrol
 	dh_md5sums
 	dh_builddeb

--- a/configs/next/deb/monolithic_cross/rules
+++ b/configs/next/deb/monolithic_cross/rules
@@ -1,1 +1,67 @@
-../../../14.0/deb/monolithic_cross/rules
+#!/usr/bin/make -f
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set the proper shell to use
+SHELL := /bin/bash
+
+# Get the package names to build
+PACKAGE=$(shell dh_listpackages)
+
+build:
+	dh_testdir
+	dh_testroot
+	dh_prep
+
+clean:
+	dh_testdir
+	dh_testroot
+	dh_clean -d
+
+binary-indep: build
+
+binary-arch: build binary-cp
+	dh_installdirs
+	dh_installdocs
+	dh_installchangelogs
+
+# Copy the packages' files.
+	dh_install
+	dh_missing --fail-missing
+
+	dh_compress
+# Avoid including PPC libraries as they could break system's objdump.
+	dh_makeshlibs --exclude=__DEST_CROSS__ \
+		--exclude=__AT_DEST__/__TARGET__
+	dh_installdeb
+# Avoid including PPC libraries as they could break system's ldd.
+	dh_shlibdeps --exclude=__DEST_CROSS__ \
+		--exclude=__AT_DEST__/__TARGET__
+	dh_gencontrol
+	dh_md5sums
+	dh_builddeb
+
+binary-cp: build
+	mkdir -p debian/tmp/__AT_DEST__
+	rsync -a --delete --delete-excluded \
+	      --exclude=share/info/dir --exclude=usr/share/info/dir \
+	      __AT_DEST__ debian/tmp/__AT_DEST__/../
+# Compress all of the info files.
+	gzip -9nvf debian/tmp/__AT_DEST__/share/info/*.info*
+	gzip -9nvf debian/tmp/__DEST_CROSS__/usr/share/info/*.info*
+
+binary: binary-indep binary-arch
+.PHONY: build clean binary-indep binary-arch binary

--- a/configs/next/packages/gcc/sources
+++ b/configs/next/packages/gcc/sources
@@ -66,6 +66,10 @@ atsrc_get_patches ()
 		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/master/GCC%20PowerPC%20Backport/11/Revert-Default-to-DWARF5.patch' \
 		0cc724faa8c2db5e686d70900b323365 || return ${?}
 
+	at_get_patch \
+		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/master/GCC%20PowerPC%20Backport/11/0001-powerpc-Remove-forced-runpath-from-with-advance-tool.patch' \
+		2a4d7864672f6227f33687a834e7dca4 || return ${?}
+
 	return 0
 }
 
@@ -81,5 +85,9 @@ atsrc_apply_patches ()
 
 	patch -p1 \
 	      < Revert-Default-to-DWARF5.patch \
+		|| return ${?}
+
+	patch -p1 \
+	      < 0001-powerpc-Remove-forced-runpath-from-with-advance-tool.patch \
 		|| return ${?}
 }

--- a/configs/next/packages/glibc/sources
+++ b/configs/next/packages/glibc/sources
@@ -37,17 +37,3 @@ ATSRC_PACKAGE_PORTS=
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=main_toolchain
 
-atsrc_get_patches ()
-{
-	# Patch that is applied to every ibm branch
-	at_get_patch \
-		https://raw.githubusercontent.com/powertechpreview/powertechpreview/93fef0c7170ccc1ee36a63fc25e4074e9e3b7e0c/GLIBC%20PowerPC%20Backport/master/0001-Remove-assert-if-DT_RUNPATH-and-DT_RPATH-flags-are-f.patch \
-		6cb72e98670c1c7671c9aa704f586d68 || return ${?}
-}
-
-atsrc_apply_patches ()
-{
-	patch -p1 < 0001-Remove-assert-if-DT_RUNPATH-and-DT_RPATH-flags-are-f.patch || return ${?}
-
-	return 0
-}

--- a/scripts/distributed/find_dependencies.sh
+++ b/scripts/distributed/find_dependencies.sh
@@ -82,13 +82,13 @@ for file in "${@}"; do
 		exit 1
 	fi;
 
-	# Get the RUNPATH.  The RUNPATH will tell us if this file was built
-	# using AT or not.
-	runpath=$(${readelf_path} -d ${file} \
-			| grep 'RUNPATH' \
-			| sed 's/^.*\: \[\(.*\)\]$/\1/')
-	at_path=${runpath%%/lib*}
-	if [[ ${is_cross} != "yes" && ${runpath} == /opt/at* ]]; then
+	# Get the interpreter.  The interpreter will tell us if this file was
+	# built using AT or not.
+	interpreter=$(${readelf_path} -e ${file} \
+			| grep 'interpreter' \
+			| sed 's/\[.*\: \(.*\)\]/\1/')
+	at_path=${interpreter%%/lib*}
+	if [[ ${is_cross} != "yes" && ${interpreter} == /opt/at* ]]; then
 		ldd_path=${at_path}/bin/ldd
 	else
 		ldd_path=$(which ldd)


### PR DESCRIPTION
This is still a draft

I still need to test this on RHEL and SUSE yet. Works on Debian.

For this to work we need to apply the patch bellow on gcc.

```
diff --git a/gcc/config.gcc b/gcc/config.gcc
index 17fea83b2e4..6827b799dc6 100644
--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -5071,16 +5071,6 @@ case "${target}" in
                        (at="/opt/$with_advance_toolchain"
                         echo "/* Use Advance Toolchain $at */"
                         echo
-                        echo "#undef  LINK_OS_EXTRA_SPEC32"
-                        echo "#define LINK_OS_EXTRA_SPEC32" \
-                             "\"%(link_os_new_dtags)" \
-                             "-rpath $prefix/lib -rpath $at/lib\""
-                        echo
-                        echo "#undef  LINK_OS_EXTRA_SPEC64"
-                        echo "#define LINK_OS_EXTRA_SPEC64" \
-                             "\"%(link_os_new_dtags)" \
-                             "-rpath $prefix/lib64 -rpath $at/lib64\""
-                        echo
                         echo "#undef  LINK_OS_NEW_DTAGS_SPEC"
                         echo "#define LINK_OS_NEW_DTAGS_SPEC" \
                              "\"--enable-new-dtags\""
```