### PR TITLE
Disable follow-debug-links in binutils on AT next

### DIFF
--- a/configs/next/packages/binutils/stage_2
+++ b/configs/next/packages/binutils/stage_2
@@ -48,7 +48,8 @@ atcfg_configure() {
 						--enable-shared \
 						--enable-plugins \
 						--enable-install-libiberty=./ \
-						--enable-gold
+						--enable-gold \
+						--enable-follow-debug-links=no
 	else
 		# Configure command for cross builds
 		# TODO: Since Binutils 2.31, gold requires to build with
@@ -71,7 +72,8 @@ atcfg_configure() {
 						--disable-sim \
 						--disable-nls \
 						--enable-plugins \
-						--enable-gold
+						--enable-gold \
+						--enable-follow-debug-links=no
 	fi
 }
 


### PR DESCRIPTION
Since [c46b706620eb](https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=c46b706620eb), binutils has provided the option follow-debug-links (enabled by default).
This has been included in AT with commit c8efa1662541.

Since that, the tests `ck_ldds` and `systemtap` have failed when ran against the AT packages.

Disabling the option to allow the tests to pass.

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>