### PR TITLE
Fix postinst scriptlet on AT >= 14.0

### DIFF
--- a/configs/14.0/specs/monolithic.spec
+++ b/configs/14.0/specs/monolithic.spec
@@ -313,6 +313,7 @@ for DIR in $(find %{_prefix}/lib/debug/%{_prefix}/*/ -type d \
     for FILE in $(ls -1 ${DIR}/*.debug 2>/dev/null); do
         ln -sf ${FILE} ${dest}/.debug/$(basename ${FILE} .debug)
     done
+done
 #---------------------------------------------------
 %post devel-debuginfo
 # Create symlinks to the debuginfo files in .debug subdirectories so valgrind,


### PR DESCRIPTION
The main loop of the postinst scriptlet of the runtime-debuginfo package
wasn't properly closed.

Added an end to the loop.

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>