### PR TITLE
Update GCC on AT next and apply patch to fix --disable-decimal-float

### DIFF
--- a/configs/next/packages/gcc/sources
+++ b/configs/next/packages/gcc/sources
@@ -22,8 +22,8 @@
 ATSRC_PACKAGE_NAME="GCC (GNU Compiler Collection)"
 ATSRC_PACKAGE_SUBPACKAGE_NAME_0="GNU Standard C++ Library v3 (Libstdc++-v3)"
 ATSRC_PACKAGE_SUBPACKAGE_NAME_1="GNU Libgomp"
-ATSRC_PACKAGE_VER=11.0.0
-ATSRC_PACKAGE_REV=93e8054406e8
+ATSRC_PACKAGE_VER=11.0.1
+ATSRC_PACKAGE_REV=3cb9e3aee98a
 ATSRC_PACKAGE_LICENSE="GPL 3.0"
 ATSRC_PACKAGE_DOCLINK="https://gcc.gnu.org/onlinedocs/gcc/"
 ATSRC_PACKAGE_SUBPACKAGE_DOCLINK_0="https://gcc.gnu.org/libstdc++/"
@@ -70,6 +70,10 @@ atsrc_get_patches ()
 		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/master/GCC%20PowerPC%20Backport/11/0001-powerpc-Remove-forced-runpath-from-with-advance-tool.patch' \
 		2a4d7864672f6227f33687a834e7dca4 || return ${?}
 
+	at_get_patch \
+		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/b1e3af97ffc725624c22a95897f888383287f3d5/GCC%20PowerPC%20Backport/11/0001-Honor-disable-decimal-float-on-PowerPC-Decimal-Float.patch' \
+		48de511bc467b2fc36214cb7adcc65c2 || return ${?}
+
 	return 0
 }
 
@@ -90,4 +94,9 @@ atsrc_apply_patches ()
 	patch -p1 \
 	      < 0001-powerpc-Remove-forced-runpath-from-with-advance-tool.patch \
 		|| return ${?}
+
+	patch -p1 \
+	      < 0001-Honor-disable-decimal-float-on-PowerPC-Decimal-Float.patch \
+		|| return ${?}
+
 }


### PR DESCRIPTION
Bump to version 11.0.1
Bump to revision 3cb9e3aee98a

Since GCC commit 781183595ac 'Add conversions between _Float128 and Decimal.',
cross builds started to fail during our first GCC build, caused by code to do
_Float128 to Decimal conversion. However, we explicitly disable
decimal-float-related code on that build by using `--disable-decimal-float`, so
this issue should not be happening. It was rather an error introduced by the
commit mentioned above. Here we apply a patch to GCC to honor that flag and stop
building decimal-float code on gcc_1, which gets past the error. That patch has
been proposed on gcc-patches [1], and is currently under review, but should be
harmless enough that we can apply it here beforehand until it is merged
upstream.

[1] https://gcc.gnu.org/pipermail/gcc-patches/2021-March/567453.html

Fixes #2017 
Closes #1990
