### PR TITLE
Fix installation of runtime rpm

### DIFF
--- a/configs/13.0/specs/monolithic.spec
+++ b/configs/13.0/specs/monolithic.spec
@@ -241,7 +241,7 @@ exit 0
 # Automatically set the timezone
 rm -f %{_prefix}/etc/localtime
 ln -s /etc/localtime %{_prefix}/etc/localtime
-systemctl --no-reload preset %{at_ver_alternative}-cachemanager.service \
+systemctl preset %{at_ver_alternative}-cachemanager.service \
     > /dev/null 2>&1 || :
 systemctl restart %{at_ver_alternative}-cachemanager.service
 

--- a/configs/14.0/specs/monolithic.spec
+++ b/configs/14.0/specs/monolithic.spec
@@ -259,7 +259,7 @@ fi
 # Automatically set the timezone
 rm -f %{_prefix}/etc/localtime
 ln -s /etc/localtime %{_prefix}/etc/localtime
-systemctl --no-reload preset %{at_ver_alternative}-cachemanager.service \
+systemctl preset %{at_ver_alternative}-cachemanager.service \
     > /dev/null 2>&1 || :
 systemctl restart %{at_ver_alternative}-cachemanager.service
 


### PR DESCRIPTION
Fixed usage of `systemctl` in postinstall scriptlet of `runtime` rpm by removing the option `--no-reload` when using the `preset` command.
Based on the [documentation](https://www.freedesktop.org/software/systemd/man/systemctl.html#--no-reload), `--no-reload` is not an option of the `preset` command.

Fix #2107 

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>