### PR TITLE
Remove some -Wno-error from glibc stages

### DIFF
--- a/configs/next/packages/glibc/stage_1
+++ b/configs/next/packages/glibc/stage_1
@@ -155,9 +155,6 @@ atcfg_configure()
 		CC="${at_dest}/bin/gcc -m${AT_BIT_SIZE}" \
 		CFLAGS="-g -O2 ${secure_plt:+-msecure-plt} \
 			-fcommon \
-			-Wno-error=array-bounds \
-			-Wno-error=array-parameter \
-			-Wno-error=stringop-overflow \
 			-Wno-error=stringop-overread" \
 		CXX="/bin/false" \
 		libc_cv_forced_unwind="yes" \
@@ -188,9 +185,6 @@ atcfg_configure()
 		AUTOCONF="${autoconf}" \
 		CC="${at_dest}/bin/${target64:-${target}}-gcc -m${AT_BIT_SIZE}" \
 		CFLAGS="-g -O2 \
-			-Wno-error=array-bounds \
-			-Wno-error=array-parameter \
-			-Wno-error=stringop-overflow \
 			-Wno-error=stringop-overread" \
 		CPPFLAGS="-isystem $(pwd)/systemtap" \
 		CXX="/bin/false" \

--- a/configs/next/packages/glibc/stage_2
+++ b/configs/next/packages/glibc/stage_2
@@ -96,9 +96,6 @@ atcfg_configure() {
 	CFLAGS="-g -O3 \
 		${with_longdouble:+-mlong-double-128} \
 		-fcommon \
-		-Wno-error=array-bounds \
-		-Wno-error=array-parameter \
-		-Wno-error=stringop-overflow \
 		-Wno-error=stringop-overread" \
 	CPPFLAGS="-isystem $(pwd)/systemtap" \
 	CXXFLAGS="-g -O3" \

--- a/configs/next/packages/glibc/stage_optimized
+++ b/configs/next/packages/glibc/stage_optimized
@@ -86,9 +86,6 @@ atcfg_configure() {
 		${with_longdouble:+-mlong-double-128} \
 		-fcommon \
 		-Wno-error=maybe-uninitialized \
-		-Wno-error=array-bounds \
-		-Wno-error=array-parameter \
-		-Wno-error=stringop-overflow \
 		-Wno-error=stringop-overread" \
 	CXXFLAGS="-g -O3" \
 	${ATSRC_PACKAGE_WORK}/configure --build=${target} \


### PR DESCRIPTION
The following issues have been fixed, preventing warnings to be thrown while building glibc:
- https://sourceware.org/bugzilla/show_bug.cgi?id=26647
- https://sourceware.org/bugzilla/show_bug.cgi?id=26686
- https://sourceware.org/bugzilla/show_bug.cgi?id=26687

Fix #1699 

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>