### PR TITLE
Remove -Wno-error flag from binutils stage2

### DIFF
--- a/configs/next/packages/binutils/stage_2
+++ b/configs/next/packages/binutils/stage_2
@@ -29,9 +29,7 @@ atcfg_configure() {
 		CC=${at_dest}/bin/gcc \
 		CXX=${at_dest}/bin/g++ \
 		CFLAGS="-g -O2 -Wno-error=stringop-truncation" \
-		CXXFLAGS="-g -O2 \
-			  -Wno-error=deprecated-declarations \
-			  -Wno-error=stringop-overflow" \
+		CXXFLAGS="-g -O2 -Wno-error=stringop-overflow" \
 		${ATSRC_PACKAGE_WORK}/configure --build=${host} \
 						--host=${target} \
 						--target=${target} \


### PR DESCRIPTION
[BZ26585](https://sourceware.org/bugzilla/show_bug.cgi?id=26585) has been fixed, preventing warnings to be thrown while building binutils.

Fix #1691

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>