### PR TITLE
Remove a -Wno-error flag from glibc's stage_optimized

### DIFF
--- a/configs/14.0/packages/glibc/stage_optimized
+++ b/configs/14.0/packages/glibc/stage_optimized
@@ -84,8 +84,7 @@ atcfg_configure() {
 	CXX="${at_dest}/bin/g++ -m${AT_BIT_SIZE}" \
 	CFLAGS="-g -O3 \
 		${with_longdouble:+-mlong-double-128} \
-		-fcommon \
-		-Wno-error=maybe-uninitialized" \
+		-fcommon" \
 	CXXFLAGS="-g -O3" \
 	${ATSRC_PACKAGE_WORK}/configure --build=${target} \
 					--host=${base_target} \


### PR DESCRIPTION
Removed -Wno-error=maybe-uninitialized from glibc's stage_optimized on AT 14.0. It's no longer useful to prevent warnings to be thrown while building glibc.

Fix #1635

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>