### PR TITLE
Update speccpu2017 config files

### DIFF
--- a/fvtr/speccpu2017/at-sniff32.cfg
+++ b/fvtr/speccpu2017/at-sniff32.cfg
@@ -41,20 +41,24 @@ default:               # data model applies to all benchmarks
 
 500.perlbench_r,600.perlbench_s:
    PORTABILITY = -DSPEC_LINUX_PPC
-   EXTRA_OPTIMIZE = -fsigned-zeros -fno-strict-aliasing
+   EXTRA_COPTIMIZE = -fsigned-zeros -fno-strict-aliasing -fno-unsafe-math-optimizations -fno-finite-math-only
 
 521.wrf_r,621.wrf_s:
    CPORTABILITY = -DSPEC_CASE_FLAG
-   FPORTABILITY = -fconvert=big-endian
+   FPORTABILITY = -fconvert=big-endian -std=legacy
 
 523.xalancbmk_r,623.xalancbmk_s:
    PORTABILITY = -DSPEC_LINUX
+
+525.x264_r:
+   CPORTABILITY = -fcommon
 
 526.blender_r:
    PORTABILITY = -DSPEC_LINUX -funsigned-char
 
 527.cam4_r,627.cam4_s:
    PORTABILITY = -DSPEC_CASE_FLAG
+   FPORTABILITY = -std=legacy
 
 628.pop2_s:
    CPORTABILITY = -DSPEC_CASE_FLAG
@@ -70,4 +74,3 @@ default:               # data model applies to all benchmarks
 #
 default:
    OPTIMIZE       = -m32 -O3 -fpeel-loops -funroll-loops -ffast-math -mrecip
-   LDPORTABILITY  = -m32 -Wl,-q  -Wl,-rpath=%{BASE_DIR}/lib

--- a/fvtr/speccpu2017/at-sniff64.cfg
+++ b/fvtr/speccpu2017/at-sniff64.cfg
@@ -42,20 +42,24 @@ EXTRA_PORTABILITY = -DSPEC_LP64
 
 500.perlbench_r,600.perlbench_s:
    PORTABILITY = -DSPEC_LINUX_PPC_LE
-   EXTRA_OPTIMIZE = -fsigned-zeros -fno-strict-aliasing
+   EXTRA_COPTIMIZE = -fsigned-zeros -fno-strict-aliasing -fno-unsafe-math-optimizations -fno-finite-math-only
 
 521.wrf_r,621.wrf_s:
    CPORTABILITY = -DSPEC_CASE_FLAG
-   FPORTABILITY = -fconvert=big-endian
+   FPORTABILITY = -fconvert=big-endian -std=legacy
 
 523.xalancbmk_r,623.xalancbmk_s:
    PORTABILITY = -DSPEC_LINUX
+
+525.x264_r:
+   CPORTABILITY = -fcommon
 
 526.blender_r:
    PORTABILITY = -DSPEC_LINUX -funsigned-char
 
 527.cam4_r,627.cam4_s:
    PORTABILITY = -DSPEC_CASE_FLAG
+   FPORTABILITY = -std=legacy
 
 628.pop2_s:
    CPORTABILITY = -DSPEC_CASE_FLAG
@@ -72,4 +76,3 @@ EXTRA_PORTABILITY = -DSPEC_LP64
 #
 default:
    OPTIMIZE       = -m64 -O3 -fpeel-loops -funroll-loops -ffast-math -mrecip
-   LDPORTABILITY  = -m64 -Wl,-q  -Wl,-rpath=%{BASE_DIR}/lib64


### PR DESCRIPTION
Newer GCC versions started to cause build or runtime errors on SPEC
CPU2017, requiring extra flags.

Besides that, remove unnecessary linker parameters.