### PR TITLE
Move AT 15.0 to binutils branch binutils-2_36-branch

### DIFF
--- a/configs/15.0/packages/binutils/sources
+++ b/configs/15.0/packages/binutils/sources
@@ -20,8 +20,9 @@
 #
 
 ATSRC_PACKAGE_NAME="GNU Binutils"
-ATSRC_PACKAGE_VER=2.36.50
-ATSRC_PACKAGE_REV=f006d9e205f7
+ATSRC_PACKAGE_VER=2.36.1
+ATSRC_PACKAGE_REV=0aa46dd891e6
+ATSRC_PACKAGE_BRANCH=binutils-2_36-branch
 ATSRC_PACKAGE_LICENSE="GPL 2.0"
 ATSRC_PACKAGE_DOCLINK="http://sourceware.org/binutils/docs/"
 ATSRC_PACKAGE_RELFIXES=
@@ -46,10 +47,14 @@ atsrc_get_patches ()
 	at_get_patch \
 		https://raw.githubusercontent.com/powertechpreview/powertechpreview/master/GNU%20Binutils%20Patches/workaround-to-build-with-gcc9.patch \
 		eaff715dac80052ff8181e4d6ae1f694 || return ${?}
+	at_get_patch \
+		https://raw.githubusercontent.com/powertechpreview/powertechpreview/80725ed8e224d2d73eb5452b3871304ffdbf05b1/GNU%20Binutils%20Patches/gold.patch \
+		ba52354a108b1c9199c17891e17f56c1 || return ${?}
 }
 
 atsrc_apply_patches ()
 {
 	patch -p1 < workaround-to-build-with-gcc9.patch \
 		|| return ${?}
+	patch -p1 < gold.patch || return ${?}
 }


### PR DESCRIPTION
AT 15.0 will track the binutils-2_36-branch, whereas AT next will track the main branch.

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>