### PR TITLE
Allow the installation tool to install AT next packages

### DIFF
--- a/utils/install_tools.sh
+++ b/utils/install_tools.sh
@@ -27,8 +27,10 @@ install_native ()
 {
 	local version=${1}
 
+	# Allowing AT next to be installed. AT next packages don't have 'next'
+	# in their name but a version number.
+	[[ "${version}" == "next" ]] && version=[0-9]
 	if [[ ${debian} == "yes" ]]; then
-		[[ "${version}" == "next" ]] && version=
 		sudo dpkg -i advance-toolchain-at*runtime_${version}* \
 			|| return ${?}
 		sudo dpkg -i advance-toolchain-at*devel_* \


### PR DESCRIPTION
Improve commit a2ac308a410b to install all AT next packages, not only `deb` files.

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>