### PR TITLE
Use git commit -s to sign auto-update commits

### DIFF
--- a/scripts/utilities/update_revision.sh
+++ b/scripts/utilities/update_revision.sh
@@ -95,8 +95,6 @@ if [[ "${service}" = "github" ]]; then
 			echo "Error: Git's user.name or user.email not configured."
 			exit 1
 		fi
-
-		GITHUB_SIGNATURE="${GIT_USER} <${GIT_EMAIL}>"
 	fi
 fi
 
@@ -522,9 +520,9 @@ exists!"
 	local msg="Update ${pkg} on AT ${cfg}\n\n\
 ${version_str}Bump to revision ${2}\n\n\
 \
-Signed-off-by: ${GITHUB_SIGNATURE}"
+${GITHUB_SIGNATURE:+Signed-off-by: ${GITHUB_SIGNATURE}}"
 
-	echo -e ${msg} | git commit -F -
+	echo -e ${msg} | git commit -s -F -
 
 	# Now we send the commit to GitHub
 	print_msg 2 "Sending commit to GitHub"


### PR DESCRIPTION
Use the '-s' parameter to include the 'Signed-off-by' line to auto-update
commits. If the user also specifies a GITHUB_SIGNATURE as the 5th argument to
update_revision.sh, the final commit will contain two separate signatures, the
one passed as argument and another for the Git user being used to create the
commit.

This allows us to create a commit that is both signed by our CI bot (Cherbot)
and another user, enabling auto-update PRs to properly pass the DCO check.

Signed-off-by: Matheus Castanho <msc@linux.ibm.com>
