### PR TITLE
Add missing GraphQL API call to update_revision.sh

### DIFF
--- a/scripts/utilities/update_revision.sh
+++ b/scripts/utilities/update_revision.sh
@@ -562,6 +562,8 @@ EOF
 }
 EOF
 
+				status=$(ghapi_gql_call ${out} 'payload.json')
+
 				if [[ ${status} -eq 200 ]]; then
 					pr_id="$(cat ${out} | jq -r '.data.repository.pullRequest.id')"
 					echo "PR ID: ${pr_id}"


### PR DESCRIPTION
Commit 465fed7 added support to mark our automated PRs as auto-mergeable, but missed 1 API
call. The code right after the changed line was still using the status code from
the previous REST API call to create the PR.

As a consequence, auto-merge was not being properly enabled on PRs.
