### PR TITLE
Improve checking version of packages

### DIFF
--- a/configs/13.0/packages/binutils/sources
+++ b/configs/13.0/packages/binutils/sources
@@ -41,6 +41,7 @@ ATSRC_PACKAGE_PATCHES=
 ATSRC_PACKAGE_TARS=
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=main_toolchain
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://sourceware.org/git/?p=binutils-gdb.git;a=blob_plain;f=bfd/version.m4;hb=__REVISION__" | grep "^m4_define" | sed "s/^.*\[\([0-9\.][0-9\.]*\)].*$/\1/"'
 
 atsrc_get_patches ()
 {

--- a/configs/13.0/packages/gcc/sources
+++ b/configs/13.0/packages/gcc/sources
@@ -47,6 +47,7 @@ ATSRC_PACKAGE_TARS=
 ATSRC_PACKAGE_MAKE_CHECK=
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=main_toolchain
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://gcc.gnu.org/git/?p=gcc.git;a=blob_plain;f=gcc/BASE-VER;hb=__REVISION__"'
 
 atsrc_get_patches ()
 {

--- a/configs/13.0/packages/gdb/sources
+++ b/configs/13.0/packages/gdb/sources
@@ -39,3 +39,4 @@ ATSRC_PACKAGE_PATCHES=
 ATSRC_PACKAGE_MAKE_CHECK=""
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=devel
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://sourceware.org/git/?p=binutils-gdb.git;a=blob_plain;f=gdb/version.in;hb=__REVISION__" | cut -d. -f1-3'

--- a/configs/13.0/packages/glibc/sources
+++ b/configs/13.0/packages/glibc/sources
@@ -37,3 +37,4 @@ ATSRC_PACKAGE_MAKE_CHECK=
 ATSRC_PACKAGE_PORTS=
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=main_toolchain
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://sourceware.org/git/?p=glibc.git;a=blob_plain;f=version.h;hb=__REVISION__" | grep -w "VERSION" | sed "s/^.*\"\([0-9\.][0-9\.]*\)\".*$/\1/"'

--- a/configs/13.0/packages/liburcu/sources
+++ b/configs/13.0/packages/liburcu/sources
@@ -36,3 +36,4 @@ ATSRC_PACKAGE_WORK=${AT_WORK_PATH}/userspace-rcu
 ATSRC_PACKAGE_MAKE_CHECK=""
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=mcore-libs
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "http://git.liburcu.org/?p=userspace-rcu.git;a=blob_plain;f=configure.ac;hb=__REVISION__" | grep "AC_INIT" | sed "s/^.*\[\([0-9\.][0-9\.]*\)].*$/\1/"'

--- a/configs/13.0/packages/python/sources
+++ b/configs/13.0/packages/python/sources
@@ -40,6 +40,7 @@ ATSRC_PACKAGE_TARS=
 ATSRC_PACKAGE_MAKE_CHECK=
 ATSRC_PACKAGE_DISTRIB=no
 ATSRC_PACKAGE_BUNDLE=toolchain_extra
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://raw.githubusercontent.com/python/cpython/__REVISION__/README.rst" | head -n1 | grep "This is Python version " | sed "s/^.* \([0-9\.][0-9\.]*\).*$/\1/"'
 
 atsrc_get_patches ()
 {

--- a/configs/14.0/packages/binutils/sources
+++ b/configs/14.0/packages/binutils/sources
@@ -41,6 +41,7 @@ ATSRC_PACKAGE_PATCHES=
 ATSRC_PACKAGE_TARS=
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=main_toolchain
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://sourceware.org/git/?p=binutils-gdb.git;a=blob_plain;f=bfd/version.m4;hb=__REVISION__" | grep "^m4_define" | sed "s/^.*\[\([0-9\.][0-9\.]*\)].*$/\1/"'
 
 atsrc_get_patches ()
 {

--- a/configs/14.0/packages/expat/sources
+++ b/configs/14.0/packages/expat/sources
@@ -40,3 +40,4 @@ ATSRC_PACKAGE_TARS=
 ATSRC_PACKAGE_MAKE_CHECK=
 ATSRC_PACKAGE_DISTRIB=no
 ATSRC_PACKAGE_BUNDLE=main_toolchain
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://raw.githubusercontent.com/libexpat/libexpat/__REVISION__/expat/lib/expat.h" | grep "XML_M.*_VERSION" | sed "s/^.*VERSION //" | paste -d "." - - -'

--- a/configs/14.0/packages/gcc/sources
+++ b/configs/14.0/packages/gcc/sources
@@ -47,6 +47,7 @@ ATSRC_PACKAGE_TARS=
 ATSRC_PACKAGE_MAKE_CHECK=
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=main_toolchain
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://gcc.gnu.org/git/?p=gcc.git;a=blob_plain;f=gcc/BASE-VER;hb=__REVISION__"'
 
 atsrc_get_patches ()
 {

--- a/configs/14.0/packages/gdb/sources
+++ b/configs/14.0/packages/gdb/sources
@@ -39,3 +39,4 @@ ATSRC_PACKAGE_PATCHES=
 ATSRC_PACKAGE_MAKE_CHECK=""
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=devel
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://sourceware.org/git/?p=binutils-gdb.git;a=blob_plain;f=gdb/version.in;hb=__REVISION__" | cut -d. -f1-3'

--- a/configs/14.0/packages/glibc/sources
+++ b/configs/14.0/packages/glibc/sources
@@ -37,6 +37,7 @@ ATSRC_PACKAGE_MAKE_CHECK=
 ATSRC_PACKAGE_PORTS=
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=main_toolchain
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://sourceware.org/git/?p=glibc.git;a=blob_plain;f=version.h;hb=__REVISION__" | grep -w "VERSION" | sed "s/^.*\"\([0-9\.][0-9\.]*\)\".*$/\1/"'
 
 atsrc_get_patches ()
 {

--- a/configs/14.0/packages/libdfp/sources
+++ b/configs/14.0/packages/libdfp/sources
@@ -41,3 +41,4 @@ ATSRC_PACKAGE_TARS=""
 ATSRC_PACKAGE_MAKE_CHECK=""
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=toolchain_extra
+ATSRC_PACKAGE_UPSTREAM="wget -qO - \"https://raw.githubusercontent.com/libdfp/libdfp/__REVISION__/configure\" | grep \"PACKAGE_VERSION=\" | sed \"s/^.*'\([0-9\.][0-9\.]*\)'.*$/\1/\""

--- a/configs/14.0/packages/liburcu/sources
+++ b/configs/14.0/packages/liburcu/sources
@@ -36,3 +36,4 @@ ATSRC_PACKAGE_WORK=${AT_WORK_PATH}/userspace-rcu
 ATSRC_PACKAGE_MAKE_CHECK=""
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=mcore-libs
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "http://git.liburcu.org/?p=userspace-rcu.git;a=blob_plain;f=configure.ac;hb=__REVISION__" | grep "AC_INIT" | sed "s/^.*\[\([0-9\.][0-9\.]*\)].*$/\1/"'

--- a/configs/14.0/packages/openssl/sources
+++ b/configs/14.0/packages/openssl/sources
@@ -38,3 +38,4 @@ ATSRC_PACKAGE_MAKE_CHECK=
 ATSRC_PACKAGE_TARS=
 ATSRC_PACKAGE_DISTRIB=no
 ATSRC_PACKAGE_BUNDLE=toolchain_extra
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://raw.githubusercontent.com/openssl/openssl/__REVISION__/CHANGES" | grep -m1 "^ Changes between .*and .*xx XXX xxxx" | sed "s/^.* \([0-9\.][0-9\.]*[a-z]\) and .*$/\1/"'

--- a/configs/14.0/packages/python/sources
+++ b/configs/14.0/packages/python/sources
@@ -41,6 +41,7 @@ ATSRC_PACKAGE_TARS=
 ATSRC_PACKAGE_MAKE_CHECK=
 ATSRC_PACKAGE_DISTRIB=no
 ATSRC_PACKAGE_BUNDLE=toolchain_extra
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://raw.githubusercontent.com/python/cpython/__REVISION__/README.rst" | head -n1 | grep "This is Python version " | sed "s/^.* \([0-9\.][0-9\.]*\).*$/\1/"'
 
 atsrc_get_patches ()
 {

--- a/configs/14.0/packages/tbb/sources
+++ b/configs/14.0/packages/tbb/sources
@@ -42,6 +42,7 @@ ATSRC_PACKAGE_TARS=""
 ATSRC_PACKAGE_MAKE_CHECK=none
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=mcore-libs
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://raw.githubusercontent.com/01org/tbb/__REVISION__/include/tbb/tbb_stddef.h" | grep "TBB_VERSION_M[AI]" | sort | sed "s/[^0-9]*//g" | tr "\n" "." | cut -d. -f1-2'
 
 # This is a package function to verify the make_check log.
 # In some cases 'make check' will return 0 even though the log shows that

--- a/configs/14.0/packages/valgrind/sources
+++ b/configs/14.0/packages/valgrind/sources
@@ -41,6 +41,7 @@ ATSRC_PACKAGE_TARS=''
 ATSRC_PACKAGE_MAKE_CHECK=
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=profile
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://sourceware.org/git/?p=valgrind.git;a=blob_plain;f=configure.ac;hb=__REVISION__" | grep -m 1 "^AC_INIT" | sed "s/^.*\[\([0-9\.][0-9\.]*\)].*$/\1/"'
 
 atsrc_get_patches ()
 {

--- a/configs/15.0/packages/binutils/sources
+++ b/configs/15.0/packages/binutils/sources
@@ -41,6 +41,7 @@ ATSRC_PACKAGE_PATCHES=
 ATSRC_PACKAGE_TARS=
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=main_toolchain
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://sourceware.org/git/?p=binutils-gdb.git;a=blob_plain;f=bfd/version.m4;hb=__REVISION__" | grep "^m4_define" | sed "s/^.*\[\([0-9\.][0-9\.]*\)].*$/\1/"'
 
 atsrc_get_patches ()
 {

--- a/configs/15.0/packages/gcc/sources
+++ b/configs/15.0/packages/gcc/sources
@@ -47,6 +47,7 @@ ATSRC_PACKAGE_TARS=
 ATSRC_PACKAGE_MAKE_CHECK=
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=main_toolchain
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://gcc.gnu.org/git/?p=gcc.git;a=blob_plain;f=gcc/BASE-VER;hb=__REVISION__"'
 
 atsrc_get_patches ()
 {

--- a/configs/15.0/packages/gdb/sources
+++ b/configs/15.0/packages/gdb/sources
@@ -39,3 +39,4 @@ ATSRC_PACKAGE_PATCHES=
 ATSRC_PACKAGE_MAKE_CHECK=""
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=devel
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://sourceware.org/git/?p=binutils-gdb.git;a=blob_plain;f=gdb/version.in;hb=__REVISION__" | cut -d. -f1-3'

--- a/configs/15.0/packages/liburcu/sources
+++ b/configs/15.0/packages/liburcu/sources
@@ -36,3 +36,4 @@ ATSRC_PACKAGE_WORK=${AT_WORK_PATH}/userspace-rcu
 ATSRC_PACKAGE_MAKE_CHECK=""
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=mcore-libs
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "http://git.liburcu.org/?p=userspace-rcu.git;a=blob_plain;f=configure.ac;hb=__REVISION__" | grep "urcu_version_[mp][a-z]*]" | sort | sed "s/^.* \[\([0-9]*\)].*$/\1/" | tr "\n" "." | cut -d. -f1-3'

--- a/configs/15.0/packages/openssl/sources
+++ b/configs/15.0/packages/openssl/sources
@@ -38,3 +38,4 @@ ATSRC_PACKAGE_MAKE_CHECK=
 ATSRC_PACKAGE_TARS=
 ATSRC_PACKAGE_DISTRIB=no
 ATSRC_PACKAGE_BUNDLE=toolchain_extra
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://raw.githubusercontent.com/openssl/openssl/__REVISION__/CHANGES" | grep -m1 "^ Changes between .*and .*xx XXX xxxx" | sed "s/^.* \([0-9\.][0-9\.]*[a-z]\) and .*$/\1/"'

--- a/configs/15.0/packages/tbb/sources
+++ b/configs/15.0/packages/tbb/sources
@@ -42,6 +42,7 @@ ATSRC_PACKAGE_TARS=""
 ATSRC_PACKAGE_MAKE_CHECK=none
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=mcore-libs
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://raw.githubusercontent.com/01org/tbb/__REVISION__/include/tbb/tbb_stddef.h" | grep "TBB_VERSION_M[AI]" | sort | sed "s/[^0-9]*//g" | tr "\n" "." | cut -d. -f1-2'
 
 # This is a package function to verify the make_check log.
 # In some cases 'make check' will return 0 even though the log shows that

--- a/configs/15.0/packages/valgrind/sources
+++ b/configs/15.0/packages/valgrind/sources
@@ -40,6 +40,7 @@ ATSRC_PACKAGE_TARS=''
 ATSRC_PACKAGE_MAKE_CHECK=
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=profile
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://sourceware.org/git/?p=valgrind.git;a=blob_plain;f=configure.ac;hb=__REVISION__" | grep -m 1 "^AC_INIT" | sed "s/^.*\[\([0-9\.][0-9\.]*\)].*$/\1/"'
 
 atsrc_get_patches ()
 {

--- a/configs/next/packages/binutils/sources
+++ b/configs/next/packages/binutils/sources
@@ -40,6 +40,7 @@ ATSRC_PACKAGE_PATCHES=
 ATSRC_PACKAGE_TARS=
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=main_toolchain
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://sourceware.org/git/?p=binutils-gdb.git;a=blob_plain;f=bfd/version.m4;hb=__REVISION__" | grep "^m4_define" | sed "s/^.*\[\([0-9\.][0-9\.]*\)].*$/\1/"'
 
 atsrc_get_patches ()
 {

--- a/configs/next/packages/expat/sources
+++ b/configs/next/packages/expat/sources
@@ -40,3 +40,4 @@ ATSRC_PACKAGE_TARS=
 ATSRC_PACKAGE_MAKE_CHECK=
 ATSRC_PACKAGE_DISTRIB=no
 ATSRC_PACKAGE_BUNDLE=main_toolchain
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://raw.githubusercontent.com/libexpat/libexpat/__REVISION__/expat/lib/expat.h" | grep "XML_M.*_VERSION" | sed "s/^.*VERSION //" | paste -d "." - - -'

--- a/configs/next/packages/gcc/sources
+++ b/configs/next/packages/gcc/sources
@@ -44,6 +44,7 @@ ATSRC_PACKAGE_TARS=
 ATSRC_PACKAGE_MAKE_CHECK=
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=main_toolchain
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://gcc.gnu.org/git/?p=gcc.git;a=blob_plain;f=gcc/BASE-VER;hb=__REVISION__"'
 
 atsrc_get_patches ()
 {

--- a/configs/next/packages/gdb/sources
+++ b/configs/next/packages/gdb/sources
@@ -38,3 +38,4 @@ ATSRC_PACKAGE_PATCHES=
 ATSRC_PACKAGE_MAKE_CHECK=""
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=devel
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://sourceware.org/git/?p=binutils-gdb.git;a=blob_plain;f=gdb/version.in;hb=__REVISION__" | cut -d. -f1-3'

--- a/configs/next/packages/glibc/sources
+++ b/configs/next/packages/glibc/sources
@@ -36,4 +36,5 @@ ATSRC_PACKAGE_MAKE_CHECK=
 ATSRC_PACKAGE_PORTS=
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=main_toolchain
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://sourceware.org/git/?p=glibc.git;a=blob_plain;f=version.h;hb=__REVISION__" | grep -w "VERSION" | sed "s/^.*\"\([0-9\.][0-9\.]*\)\".*$/\1/"'
 

--- a/configs/next/packages/libhugetlbfs/sources
+++ b/configs/next/packages/libhugetlbfs/sources
@@ -38,3 +38,5 @@ ATSRC_PACKAGE_TARS=""
 ATSRC_PACKAGE_MAKE_CHECK=
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=toolchain_extra
+# Not needed because file follows master branch
+# ATSRC_PACKAGE_UPSTREAM=

--- a/configs/next/packages/liburcu/sources
+++ b/configs/next/packages/liburcu/sources
@@ -35,3 +35,5 @@ ATSRC_PACKAGE_WORK=${AT_WORK_PATH}/userspace-rcu
 ATSRC_PACKAGE_MAKE_CHECK=""
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=mcore-libs
+# Not needed because file follows master branch
+# ATSRC_PACKAGE_UPSTREAM=

--- a/configs/next/packages/python/sources
+++ b/configs/next/packages/python/sources
@@ -41,6 +41,7 @@ ATSRC_PACKAGE_TARS=
 ATSRC_PACKAGE_MAKE_CHECK=
 ATSRC_PACKAGE_DISTRIB=no
 ATSRC_PACKAGE_BUNDLE=toolchain_extra
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://raw.githubusercontent.com/python/cpython/__REVISION__/README.rst" | head -n1 | grep "This is Python version " | sed "s/^.* \([0-9\.][0-9\.]*\).*$/\1/"'
 
 atsrc_get_patches ()
 {

--- a/configs/next/packages/tcmalloc/sources
+++ b/configs/next/packages/tcmalloc/sources
@@ -40,3 +40,5 @@ ATSRC_PACKAGE_TARS=""
 ATSRC_PACKAGE_MAKE_CHECK=""
 ATSRC_PACKAGE_DISTRIB=no
 ATSRC_PACKAGE_BUNDLE=toolchain_extra
+# Not needed because file follows master branch
+# ATSRC_PACKAGE_UPSTREAM=

--- a/configs/next/packages/valgrind/sources
+++ b/configs/next/packages/valgrind/sources
@@ -40,6 +40,8 @@ ATSRC_PACKAGE_TARS=''
 ATSRC_PACKAGE_MAKE_CHECK=
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=profile
+# Not needed because file follows master branch
+# ATSRC_PACKAGE_UPSTREAM=
 
 atsrc_get_patches ()
 {

--- a/scripts/utilities/update_revision.sh
+++ b/scripts/utilities/update_revision.sh
@@ -226,54 +226,11 @@ get_version ()
 		echo ""
 		return 0
 	fi
-	case "$package" in
-	    binutils)
-		out=$(wget -qO - "https://sourceware.org/git/?p=binutils-gdb.git;a=blob_plain;f=bfd/version.m4;hb=${revision}" | grep "^m4_define" | sed "s/^.*\[\([0-9\.][0-9\.]*\)].*$/\1/")
-		;;
-	    expat)
-		out=$(wget -qO - "https://raw.githubusercontent.com/libexpat/libexpat/${revision}/expat/lib/expat.h" | grep "XML_M.*_VERSION" | sed "s/^.*VERSION //" | paste -d "." - - -)
-		;;
-	    gcc)
-		out=$(wget -qO - "https://gcc.gnu.org/git/?p=gcc.git;a=blob_plain;f=gcc/BASE-VER;hb=${revision}")
-		;;
-	    gdb)
-		out=$(wget -qO - "https://sourceware.org/git/?p=binutils-gdb.git;a=blob_plain;f=gdb/version.in;hb=${revision}" | cut -d. -f1-3)
-		;;
-	    glibc)
-		out=$(wget -qO - "https://sourceware.org/git/?p=glibc.git;a=blob_plain;f=version.h;hb=${revision}" | grep -w "VERSION" | sed "s/^.*\"\([0-9\.][0-9\.]*\)\".*$/\1/")
-		;;
-	    golang)
-		out=$(wget -qO - "https://raw.githubusercontent.com/powertechpreview/go/${revision}/VERSION" | head -n 1 | cut -c3-6)
-		;;
-	    libdfp)
-		out=$(wget -qO - "https://raw.githubusercontent.com/libdfp/libdfp/${revision}/configure" | grep "PACKAGE_VERSION=" | sed "s/^.*'\([0-9\.][0-9\.]*\)'.*$/\1/")
-		;;
-	    libhugetlbfs)
-		out=$(wget -qO - "https://raw.githubusercontent.com/libhugetlbfs/libhugetlbfs/${revision}/NEWS" | head -1 | sed "s/^.* \([0-9\.][0-9\.]*\) .*$/\1/")
-		;;
-	    libpfm)
-		out=$(wget -qO - "https://sourceforge.net/p/perfmon2/libpfm4/ci/${revision}/tree/debian/changelog?format=raw" | grep -m1 "libpfm4" | sed "s/^libpfm4 (\([0-9]*\)\.\([0-9]*\)).*$/4.\1.\2/")
-		;;
-	    liburcu)
-		out=$(wget -qO - "http://git.liburcu.org/?p=userspace-rcu.git;a=blob_plain;f=configure.ac;hb=${revision}" | grep "AC_INIT" | sed "s/^.*\[\([0-9\.][0-9\.]*\)].*$/\1/")
-		;;
-	    openssl)
-		out=$(wget -qO - "https://raw.githubusercontent.com/openssl/openssl/${revision}/CHANGES" | grep -m1 "^ Changes between .* and .*xx XXX xxxx" | sed "s/^.* \([0-9\.][0-9\.]*[a-z]\) and .*$/\1/")
-		;;
-	    python)
-		out=$(wget -qO - "https://raw.githubusercontent.com/python/cpython/${revision}/README.rst" | head -n1 | grep "This is Python version " | sed "s/^.* \([0-9\.][0-9\.]*\).*$/\1/")
-		;;
-	    tbb)
-		out=$(wget -qO - "https://raw.githubusercontent.com/01org/tbb/${revision}/include/tbb/tbb_stddef.h" | grep "TBB_VERSION_M[AI]" | sort | sed "s/[^0-9]*//g" | tr "\n" "." | cut -d. -f1-2)
-		;;
-	    valgrind)
-		out=$(wget -qO - "https://sourceware.org/git/?p=valgrind.git;a=blob_plain;f=configure.ac;hb=${revision}" | grep -m 1 "^AC_INIT" | sed "s/^.*\[\([0-9\.][0-9\.]*\)].*$/\1/")
-		;;
-	    *)
-		echo "Function get_version doesn't know the package $package"
-		return 1
-		;;
-	esac
+        if [[ -z "${ATSRC_PACKAGE_UPSTREAM}" ]]; then
+                echo "ATSRC_PACKAGE_UPSTREAM isn't defined for the package $package"
+                return 1
+        fi
+        out=$(eval $(echo "${ATSRC_PACKAGE_UPSTREAM}" | sed "s/__REVISION__/$revision/g"))
 	[[ "${ATSRC_PACKAGE_VER}" == "$out" ]] && out=""
 	echo "$out"
 }


### PR DESCRIPTION
Moved into the sources files the way to get the version of the package
upstream. This allows to follow changes between the branches of a package (like liburcu for example).

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>