### PR TITLE
Update GCC on AT next and remove out-of-tree patch

### DIFF
--- a/configs/next/packages/binutils/stage_2
+++ b/configs/next/packages/binutils/stage_2
@@ -28,8 +28,8 @@ atcfg_configure() {
 		# Configure command for native builds
 		CC=${at_dest}/bin/gcc \
 		CXX=${at_dest}/bin/g++ \
-		CFLAGS="-g -O2 -Wno-error=stringop-truncation" \
-		CXXFLAGS="-g -O2 -Wno-error=stringop-overflow" \
+		CFLAGS="-g -O2 -Wno-error=array-bounds" \
+		CXXFLAGS="-g -O2" \
 		${ATSRC_PACKAGE_WORK}/configure --build=${host} \
 						--host=${target} \
 						--target=${target} \

--- a/configs/next/packages/binutils/stage_2
+++ b/configs/next/packages/binutils/stage_2
@@ -1,1 +1,94 @@
-../../../15.0/packages/binutils/stage_2
+#!/usr/bin/env bash
+#
+# Copyright 2021 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+
+ATCFG_HOLD_TEMP_INSTALL='no'
+ATCFG_HOLD_TEMP_BUILD='no'
+# Build in a new directory
+ATCFG_BUILD_STAGE_T='dir'
+
+# Conditional configure command
+atcfg_configure() {
+	if [[ "${cross_build}" == "no" ]]; then
+		# Configure command for native builds
+		CC=${at_dest}/bin/gcc \
+		CXX=${at_dest}/bin/g++ \
+		CFLAGS="-g -O2 -Wno-error=stringop-truncation" \
+		CXXFLAGS="-g -O2 -Wno-error=stringop-overflow" \
+		${ATSRC_PACKAGE_WORK}/configure --build=${host} \
+						--host=${target} \
+						--target=${target} \
+						${alternate_target:+--enable-targets=${alternate_target}} \
+						--with-sysroot=/ \
+						--prefix=${at_dest} \
+						--libdir=${at_dest}/lib${compiler##32} \
+						--disable-gdb \
+						--disable-gdbserver \
+						--disable-readline \
+						--disable-libdecnumber \
+						--disable-sim \
+						--disable-nls \
+						--enable-shared \
+						--enable-plugins \
+						--enable-install-libiberty=./ \
+						--enable-gold \
+						--enable-follow-debug-links=no
+	else
+		# Configure command for cross builds
+		# TODO: Since Binutils 2.31, gold requires to build with
+		# -std=c++11.  Please review if it's possible to remove this
+		# later.
+		CC=${system_cc} \
+		CXX=${system_cxx} \
+		CFLAGS="-g -O" \
+		CXXFLAGS="-g -O -std=c++11" \
+		${ATSRC_PACKAGE_WORK}/configure --build=${host} \
+						--host=${host} \
+						--target=${target} \
+						${target64:+--enable-targets=${target64}} \
+						--with-sysroot=${dest_cross} \
+						--prefix=${at_dest} \
+						--disable-gdb \
+						--disable-gdbserver \
+						--disable-readline \
+						--disable-libdecnumber \
+						--disable-sim \
+						--disable-nls \
+						--enable-plugins \
+						--enable-gold \
+						--enable-follow-debug-links=no
+	fi
+}
+
+
+# Make command for build
+atcfg_make() {
+	${SUB_MAKE} all
+}
+
+# Make command for build
+atcfg_make_check() {
+	PATH=${at_dest}/bin:${PATH} \
+	${SUB_MAKE} check
+}
+
+
+# Install command for build
+atcfg_install() {
+	${SUB_MAKE} install DESTDIR=${install_place}
+}

--- a/configs/next/packages/gcc/sources
+++ b/configs/next/packages/gcc/sources
@@ -23,7 +23,7 @@ ATSRC_PACKAGE_NAME="GCC (GNU Compiler Collection)"
 ATSRC_PACKAGE_SUBPACKAGE_NAME_0="GNU Standard C++ Library v3 (Libstdc++-v3)"
 ATSRC_PACKAGE_SUBPACKAGE_NAME_1="GNU Libgomp"
 ATSRC_PACKAGE_VER=12.0.0
-ATSRC_PACKAGE_REV=4546f423ecff
+ATSRC_PACKAGE_REV=fcc7c6369f7f
 ATSRC_PACKAGE_LICENSE="GPL 3.0"
 ATSRC_PACKAGE_DOCLINK="https://gcc.gnu.org/onlinedocs/gcc/"
 ATSRC_PACKAGE_SUBPACKAGE_DOCLINK_0="https://gcc.gnu.org/libstdc++/"
@@ -75,10 +75,6 @@ atsrc_get_patches ()
 		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/25cc9095a4591a2cde8adc2a74f417e3ff667f3a/GCC%20PowerPC%20Backport/12/0001-Revert-Improve-global-state-for-options.patch' \
 		75484046f079e39a71545b391661ca08 || return ${?}
 
-        at_get_patch \
-		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/a68de5295ccdf27bdfd1bd7cca07cabdc013cf44/GCC%20libstdc%2B%2B%20PowerPC%20Patches/12/libstdcpp-check-gthreads.patch' \
-		ebf3bb59e8a586c1fb05a5715fa4f480 || return ${?}
-
 	return 0
 }
 
@@ -102,9 +98,5 @@ atsrc_apply_patches ()
 
 	patch -p1 \
 	      < 0001-Revert-Improve-global-state-for-options.patch \
-		|| return ${?}
-
-	patch  -p1 \
-	      < libstdcpp-check-gthreads.patch \
 		|| return ${?}
 }


### PR DESCRIPTION
Bump to revision 2e345e4ad6bb

The libstdc++ gthreads fix has been merged upstream (commit 2e345e4ad6bb), so we
don't need to apply it anymore.
