### PR TITLE
next: Fix regex to get current Python version

### DIFF
--- a/configs/next/packages/python/sources
+++ b/configs/next/packages/python/sources
@@ -41,7 +41,7 @@ ATSRC_PACKAGE_TARS=
 ATSRC_PACKAGE_MAKE_CHECK=
 ATSRC_PACKAGE_DISTRIB=no
 ATSRC_PACKAGE_BUNDLE=toolchain_extra
-ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://raw.githubusercontent.com/python/cpython/__REVISION__/README.rst" | head -n1 | grep "This is Python version " | sed "s/^.* \([0-9\.][0-9\.]*\).*$/\1/"'
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://raw.githubusercontent.com/python/cpython/__REVISION__/README.rst" | head -n1 | grep "This is Python version " | sed "s/^.* version \([0-9\.][0-9\.]*\).*$/\1/"'
 
 atsrc_get_patches ()
 {


### PR DESCRIPTION
The current regex passed to sed on ATSRC_PACKAGE_UPSTREAM for Python on AT next
is not handling beta/alpha versions correctly (see #2249). Change it so that it
ignores any beta/alpha information and only output the main version.

Signed-off-by: Matheus Castanho <msc@linux.ibm.com>
