### PR TITLE
Add f95 symbolic link to gfortran

### DIFF
--- a/configs/13.0/packages/gcc/stage_4
+++ b/configs/13.0/packages/gcc/stage_4
@@ -222,6 +222,7 @@ atcfg_post_install() {
 		popd
 	else
 		pushd ${install_place}/${at_dest}/bin
+		[[ -x gfortran && ! -e f95 ]] && ln -s gfortran f95
 		# This is necessary for some applications to work
 		if [[ ! -e "cc" ]]; then
 			ln -s "gcc" "cc"


### PR DESCRIPTION
Some programs prefer to use the command f95 instead of gfortran.
Adding the symlink /opt/atX.Y/bin/f95 to the gfortran binary (X >= 13).

Fix #2281

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>