### PR TITLE
Update tbb on AT 15.0

### DIFF
--- a/configs/15.0/packages/tbb/sources
+++ b/configs/15.0/packages/tbb/sources
@@ -20,9 +20,9 @@
 #
 
 ATSRC_PACKAGE_NAME="Thread Building Blocks"
-ATSRC_PACKAGE_VER=2020
-ATSRC_PACKAGE_REV=eca91f16d749
-ATSRC_PACKAGE_BRANCH=tbb_2020
+ATSRC_PACKAGE_VER=2021.3.0
+ATSRC_PACKAGE_REV=261fe22630bd
+ATSRC_PACKAGE_BRANCH=onetbb_2021
 ATSRC_PACKAGE_LICENSE="GPL 2.0"
 ATSRC_PACKAGE_DOCLINK="https://www.threadingbuildingblocks.org/"
 ATSRC_PACKAGE_RELFIXES=
@@ -42,7 +42,7 @@ ATSRC_PACKAGE_TARS=""
 ATSRC_PACKAGE_MAKE_CHECK=none
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=mcore-libs
-ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://raw.githubusercontent.com/01org/tbb/__REVISION__/include/tbb/tbb_stddef.h" | grep "TBB_VERSION_M[AI]" | sort | sed "s/[^0-9]*//g" | tr "\n" "." | cut -d. -f1-2'
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://raw.githubusercontent.com/01org/tbb/__REVISION__/include/oneapi/tbb/version.h" | grep " TBB_VERSION_[MP][AI]" | sort | sed "s/[^0-9]*//g" | tr "\n" "." | cut -d. -f1-3'
 
 # This is a package function to verify the make_check log.
 # In some cases 'make check' will return 0 even though the log shows that
@@ -57,4 +57,47 @@ atsrc_package_verify_make_check_log ()
 		grep -i "error[: ]" "${1}" > /dev/null
 		return ${?}
 	fi
+}
+
+atsrc_get_patches ()
+{
+	# Remove arch macros, commit from the master branch
+	at_get_patch \
+		'https://github.com/oneapi-src/oneTBB/commit/fa944e19600500863507ed8e9b1f5a30037d9df6.patch' \
+		b4c510226c8d79d524166041c6750747 || return ${?}
+	# Remove some gcc 11 warnings, commits from the master branch
+	at_get_patch \
+		'https://github.com/oneapi-src/oneTBB/commit/81dd27c4f699d4c1a8f368b1f46bffc37a864da0.patch' \
+		1f3eea49cfbdcde34efca34234232bd4 || return ${?}
+	at_get_patch \
+		'https://github.com/oneapi-src/oneTBB/commit/ec505c7d5af7b3776b6732a8351107926b7b6461.patch' \
+		1fc2a4a34e8f38f53d19d5897a81a284 || return ${?}
+	at_get_patch \
+		'https://github.com/oneapi-src/oneTBB/commit/5a643c2360fb7684b6a88eccf4421f8c635668f5.patch' \
+		d9317888c2b46ce9000658ffd7cc7db2 || return ${?}
+	# Fix size of array, part of commit from the master branch
+        at_get_patch \
+		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/2da51fd320781ee9f5dd353b681258f13b04d66b/TBB%20PowerPC%20Patches/2021.3/tbb_fix_array_size.patch' \
+		baed2e1078e200d0314947ef8911c78a || return ${?}
+
+	return 0
+}
+
+atsrc_apply_patches ()
+{
+	patch -p1 \
+	     < fa944e19600500863507ed8e9b1f5a30037d9df6.patch \
+		|| return ${?}
+	patch -p1 \
+	     < 81dd27c4f699d4c1a8f368b1f46bffc37a864da0.patch \
+		|| return ${?}
+	patch -p1 \
+	     < ec505c7d5af7b3776b6732a8351107926b7b6461.patch \
+		|| return ${?}
+	patch -p1 \
+	     < 5a643c2360fb7684b6a88eccf4421f8c635668f5.patch \
+		|| return ${?}
+	patch -p1 \
+	     < tbb_fix_array_size.patch \
+		|| return ${?}
 }

--- a/configs/15.0/packages/tbb/stage_1
+++ b/configs/15.0/packages/tbb/stage_1
@@ -1,1 +1,116 @@
-../../../14.0/packages/tbb/stage_1
+#!/usr/bin/env bash
+#
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# TBB build parameters for stage 1 32/64 bits
+# ==============================================
+#
+
+# Include some standard functions
+source ${utilities}/bitsize_selection.sh
+
+# Tell the build system to hold the temp install folder
+ATCFG_HOLD_TEMP_INSTALL='no'
+# Tell the build system to hold the temp build folder
+ATCFG_HOLD_TEMP_BUILD='no'
+# Build in the source code directory
+ATCFG_BUILD_STAGE_T='link'
+
+atcfg_configure ()
+{
+	# No configure required for Thread Building Blocks
+	echo "No configure to run."
+}
+
+atcfg_pre_make ()
+{
+	# Thread Building Blocks has some env var name clash with our
+	# scripts.  Unset them now before build
+	unset compiler
+	unset target
+}
+
+atcfg_make ()
+{
+	local base_target=$(find_build_target ${AT_BIT_SIZE})
+
+	# Set the AT's GCC as compiler.
+	if [[ "${cross_build}" == 'yes' ]]; then
+		local cc_path="${at_dest}/bin/${target64:-${target}}-gcc"
+		local ccx_path="${at_dest}/bin/${target64:-${target}}-g++"
+	else
+		local cc_path="${at_dest}/bin/gcc"
+		local ccx_path="${at_dest}/bin/g++"
+	fi
+
+	PATH=${at_dest}/bin:${PATH} \
+	CONLY=${cc_path} \
+	CPLUS=${ccx_path} \
+	LDFLAGS="-m${AT_BIT_SIZE}" \
+	CXXFLAGS="-m${AT_BIT_SIZE}" \
+		${SUB_MAKE} arch=${base_target}
+}
+
+atcfg_make_check ()
+{
+	# Package testing not done on cross build
+	if [[ "${cross_build}" == 'no' ]]; then
+		PATH=${at_dest}/bin:${PATH} \
+		LDFLAGS="-m${AT_BIT_SIZE}" \
+		CXXFLAGS="-m${AT_BIT_SIZE}" \
+			${SUB_MAKE} test
+	fi
+}
+
+atcfg_pre_install ()
+{
+	if [[ "${cross_build}" == "yes" ]]; then
+		install_dir="${install_transfer_cross}/usr"
+	else
+		install_dir="${install_transfer}"
+	fi
+	local libdir=$(find_build_libdir ${AT_BIT_SIZE})
+
+	# Prepare the install folders for manual installation
+	mkdir -p ${install_dir}/${libdir} \
+		 ${install_dir}/include/tbb \
+		 ${install_dir}/include/tbb/compat \
+		 ${install_dir}/include/tbb/internal \
+		 ${install_dir}/include/tbb/machine
+}
+
+atcfg_install ()
+{
+	local libdir=$(find_build_libdir ${AT_BIT_SIZE})
+
+	for LIB in $(ls build/linux_powerpc*/*.so.*); do
+		LIB_DEST=$(basename ${LIB} | sed "s/\.so\..*$/\.so/")
+		install -m 755 ${LIB} \
+			${install_dir}/${libdir}/$(basename ${LIB})
+		pushd ${install_dir}/${libdir} && \
+			ln -s $(basename ${LIB}) ${LIB_DEST} && popd
+	done
+
+	# Include files
+	install -m 644 include/tbb/*.h \
+		${install_dir}/include/tbb
+	install -m 644 include/tbb/compat/* \
+		${install_dir}/include/tbb/compat
+	install -m 644 include/tbb/internal/* \
+		${install_dir}/include/tbb/internal
+	install -m 644 include/tbb/machine/* \
+		${install_dir}/include/tbb/machine
+}

--- a/configs/15.0/packages/tbb/stage_1
+++ b/configs/15.0/packages/tbb/stage_1
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2017 IBM Corporation
+# Copyright 2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-# TBB build parameters for stage 1 32/64 bits
+# TBB build parameters for stage 1 64 bits
 # ==============================================
 #
 
@@ -31,8 +31,42 @@ ATCFG_BUILD_STAGE_T='link'
 
 atcfg_configure ()
 {
-	# No configure required for Thread Building Blocks
-	echo "No configure to run."
+	# Set the AT's GCC as compiler.
+	if [[ "${cross_build}" == 'yes' ]]; then
+		local cc_path="${at_dest}/bin/${target64:-${target}}-gcc"
+		local ccx_path="${at_dest}/bin/${target64:-${target}}-g++"
+	else
+		local cc_path="${at_dest}/bin/gcc"
+		local ccx_path="${at_dest}/bin/g++"
+	fi
+	local base_target=$(find_build_target ${AT_BIT_SIZE})
+
+	if [[ "${make_check}" == 'none' ]]; then
+		local tests="OFF"
+	else
+		local tests="ON"
+	fi
+
+	if [[ "${cross_build}" == "yes" ]]; then
+		install_dir="${dest_cross}/usr"
+	else
+		install_dir="${at_dest}"
+	fi
+
+
+	PATH=${at_dest}/bin:${PATH} \
+	CC=${cc_path} \
+	CXX=${ccx_path} \
+	CXXFLAGS="-m${AT_BIT_SIZE}" \
+	LDFLAGS="-m${AT_BIT_SIZE}" \
+	VERBOSE=1 \
+	cmake \
+		-DCMAKE_BUILD_TYPE=Release \
+		-DCMAKE_SYSTEM_NAME=Linux \
+		-DCMAKE_SYSTEM_PROCESSOR=${base_target} \
+		-DTBB_TEST=${tests} \
+		-DCMAKE_INSTALL_PREFIX="${install_dir}" \
+		.
 }
 
 atcfg_pre_make ()
@@ -45,23 +79,9 @@ atcfg_pre_make ()
 
 atcfg_make ()
 {
-	local base_target=$(find_build_target ${AT_BIT_SIZE})
-
-	# Set the AT's GCC as compiler.
-	if [[ "${cross_build}" == 'yes' ]]; then
-		local cc_path="${at_dest}/bin/${target64:-${target}}-gcc"
-		local ccx_path="${at_dest}/bin/${target64:-${target}}-g++"
-	else
-		local cc_path="${at_dest}/bin/gcc"
-		local ccx_path="${at_dest}/bin/g++"
-	fi
-
 	PATH=${at_dest}/bin:${PATH} \
-	CONLY=${cc_path} \
-	CPLUS=${ccx_path} \
-	LDFLAGS="-m${AT_BIT_SIZE}" \
-	CXXFLAGS="-m${AT_BIT_SIZE}" \
-		${SUB_MAKE} arch=${base_target}
+	VERBOSE=1 \
+		cmake --build .
 }
 
 atcfg_make_check ()
@@ -69,48 +89,27 @@ atcfg_make_check ()
 	# Package testing not done on cross build
 	if [[ "${cross_build}" == 'no' ]]; then
 		PATH=${at_dest}/bin:${PATH} \
-		LDFLAGS="-m${AT_BIT_SIZE}" \
-		CXXFLAGS="-m${AT_BIT_SIZE}" \
-			${SUB_MAKE} test
+		VERBOSE=1 \
+			cmake --build . --target test
 	fi
-}
-
-atcfg_pre_install ()
-{
-	if [[ "${cross_build}" == "yes" ]]; then
-		install_dir="${install_transfer_cross}/usr"
-	else
-		install_dir="${install_transfer}"
-	fi
-	local libdir=$(find_build_libdir ${AT_BIT_SIZE})
-
-	# Prepare the install folders for manual installation
-	mkdir -p ${install_dir}/${libdir} \
-		 ${install_dir}/include/tbb \
-		 ${install_dir}/include/tbb/compat \
-		 ${install_dir}/include/tbb/internal \
-		 ${install_dir}/include/tbb/machine
 }
 
 atcfg_install ()
 {
 	local libdir=$(find_build_libdir ${AT_BIT_SIZE})
 
-	for LIB in $(ls build/linux_powerpc*/*.so.*); do
-		LIB_DEST=$(basename ${LIB} | sed "s/\.so\..*$/\.so/")
-		install -m 755 ${LIB} \
-			${install_dir}/${libdir}/$(basename ${LIB})
-		pushd ${install_dir}/${libdir} && \
-			ln -s $(basename ${LIB}) ${LIB_DEST} && popd
-	done
+	DESTDIR="${install_place}" \
+	VERBOSE=1 \
+	cmake -P cmake_install.cmake
+	ret=${?}
+	if [[ ${ret} -ne 0 ]]; then
+		return ${ret}
+	fi
 
-	# Include files
-	install -m 644 include/tbb/*.h \
-		${install_dir}/include/tbb
-	install -m 644 include/tbb/compat/* \
-		${install_dir}/include/tbb/compat
-	install -m 644 include/tbb/internal/* \
-		${install_dir}/include/tbb/internal
-	install -m 644 include/tbb/machine/* \
-		${install_dir}/include/tbb/machine
+	# TBB always installs libraries under lib/.  Workaround it when using
+	# another directory, e.g. lib64/.
+	if [[ "${libdir}" != "lib" ]]; then
+		mv "${install_place}${install_dir}/lib" \
+		   "${install_place}${install_dir}/${libdir}/"
+	fi
 }

--- a/fvtr/tbb/par-test.cpp
+++ b/fvtr/tbb/par-test.cpp
@@ -21,20 +21,7 @@
 #include <err.h>
 /* These are public headers which uses the internal ones.  */
 #include <tbb/tbb.h>
-#include <tbb/flow_graph.h>
-#include <tbb/parallel_while.h>
-#include <tbb/tbbmalloc_proxy.h>
-#include <tbb/tbb_config.h>
-#include <tbb/tbb_machine.h>
-#include <tbb/tbb_profiling.h>
-#include <tbb/blocked_range.h>
 #include <tbb/parallel_for.h>
-#include <tbb/task_scheduler_init.h>
-#include <tbb/internal/_aggregator_impl.h>
-/* These are not included in the public ones.  */
-#define __TBB_tbb_windef_H
-#define _MT
-#include <tbb/internal/_tbb_windef.h>
 
 /* Struct that does the computation.  */
 struct
@@ -74,7 +61,11 @@ int main()
   free(block);
 
   /* Tests the function using 18 threads.  */
+#ifdef ONETBB_SPEC_VERSION
+  oneapi::tbb::task_arena arena(18);
+#else
   tbb::task_scheduler_init init(18);
+#endif
   execute job;
   struct trigger trig(job);
   tbb::parallel_for(tbb::blocked_range<size_t>(0,1000),trig);

--- a/scripts/helpers/utilities.mk
+++ b/scripts/helpers/utilities.mk
@@ -256,6 +256,8 @@ define build_setenv
     export build_old_at_install=$(BUILD_OLD_AT_INSTALL); \
     echo "  - Setting distro suppoted java versions to '$(AT_JAVA_VERSIONS)'"; \
     export java_versions="$(AT_JAVA_VERSIONS)"; \
+    echo "  - Setting make check to '$(AT_MAKE_CHECK)'"; \
+    export make_check="$(AT_MAKE_CHECK)"; \
     echo "* Finished build env variables."
 endef
 


### PR DESCRIPTION
Bump to version 2021.3.0
Bump to revision 261fe22630bd

It diverges from AT 14.0 which tracks the branch tbb_2020.
AT next follows AT 15.0 until the creation of the 2022 branch.

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>