### PR TITLE
Move the definition of AT_KERNEL to base.mk on AT >= 15.0

### DIFF
--- a/configs/15.0/base.mk
+++ b/configs/15.0/base.mk
@@ -51,3 +51,8 @@ AT_MAJOR_VERSION := 15.0
 AT_REVISION_NUMBER := 0
 AT_INTERNAL := rc1
 AT_PREVIOUS_VERSION := 14.0
+
+# Minimum kernel version distributed on supported distros by this AT version,
+# i.e. minimum kernel version required in order to run software linked to this
+# AT version.
+AT_KERNEL := 4.12.14

--- a/configs/15.0/distros/debian-10.mk
+++ b/configs/15.0/distros/debian-10.mk
@@ -24,10 +24,6 @@ AT_SUPPORTED_ARCHS := ppc64le
 # You may force the BUILD_IGNORE_AT_COMPAT general condition by distro
 #BUILD_IGNORE_AT_COMPAT := yes
 
-# Kernel version to build toolchain against
-# - As this distro only supports one arch variation (ppc64le), there is no
-#   need to conditionally define these versions based on arch.
-AT_KERNEL := 4.19    # Current distro kernel version for runtime.
 # TODO: fill this when our packaging system starts supporting runtime-compat
 # on Debian.
 #AT_OLD_KERNEL :=  # Previous distro kernel version for runtime-compat.

--- a/configs/15.0/distros/debian-10.mk
+++ b/configs/15.0/distros/debian-10.mk
@@ -1,1 +1,87 @@
-../../14.0/distros/debian-10.mk
+# Copyright 2019 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Distro dependent basic definitions for Debian 10
+# =======================================================
+# This Makefile include contains the definitions for the distro being used
+# for the build process. It contains kernel version infos and distro specific
+# sanity checks.
+
+# Informs the distro supported power archs
+AT_SUPPORTED_ARCHS := ppc64le
+
+# You may force the BUILD_IGNORE_AT_COMPAT general condition by distro
+#BUILD_IGNORE_AT_COMPAT := yes
+
+# Kernel version to build toolchain against
+# - As this distro only supports one arch variation (ppc64le), there is no
+#   need to conditionally define these versions based on arch.
+AT_KERNEL := 4.19    # Current distro kernel version for runtime.
+# TODO: fill this when our packaging system starts supporting runtime-compat
+# on Debian.
+#AT_OLD_KERNEL :=  # Previous distro kernel version for runtime-compat.
+
+# Inform the mainly supported distros
+AT_SUPPORTED_DISTROS := buster
+
+# Inform the compatibility supported distros
+#AT_COMPAT_DISTROS :=
+
+# Sign the repository and packages
+#AT_SIGN_PKGS := yes
+#AT_SIGN_REPO := yes
+#AT_SIGN_PKGS_CROSS := no
+#AT_SIGN_REPO_CROSS := yes
+
+# ID of GNUPG key used to sign our packages (main/compat)
+AT_GPG_KEYID := 6976A827
+AT_GPG_KEYIDC := 3052930D
+# ID of GNUPG key used to sign our repositories (main/compat)
+AT_GPG_REPO_KEYID := 3052930D
+AT_GPG_REPO_KEYIDC := 3052930D
+
+# Options required by the command to update the repository metadata
+AT_REPOCMD_OPTS := -p -s sha1 --simple-md-filenames --no-database
+
+# As some distros have special requirements for configuration upon final
+# AT installation, put in this macro, the final configurations required
+# after the main build and prior to the rpm build
+define distro_final_config
+    echo "nothing to do."
+endef
+
+# Inform the list of packages to check
+ifndef AT_DISTRO_REQ_PKGS
+    AT_CROSS_PKGS_REQ :=
+    AT_NATIVE_PKGS_REQ := libxslt1.1 libpopt-dev libqt4-dev \
+                          libc6-dev libbz2-dev xsltproc docbook-xsl \
+                          libsqlite3-dev
+    AT_COMMON_PKGS_REQ := zlib1g-dev libncurses5-dev ncurses-term flex bison \
+                          texinfo subversion gawk fakeroot debhelper \
+                          autoconf rsync curl bc libxml2-utils automake \
+                          dpkg-sig xutils-dev libtool wget dh-systemd \
+                          docbook2x pkg-config autoconf-archive make \
+                          libffi-dev python3 git systemtap-sdt-dev
+    AT_CROSS_PGMS_REQ :=
+    AT_NATIVE_PGMS_REQ :=
+    AT_COMMON_PGMS_REQ :=
+endif
+
+# If needed, define the necessary distro related sanity checks.
+define distro_sanity
+    echo "nothing to test here"
+endef
+
+# Inform if the systemd service to monitor the loader cache should be used.
+USE_SYSTEMD := yes

--- a/configs/15.0/distros/redhat-8.mk
+++ b/configs/15.0/distros/redhat-8.mk
@@ -1,1 +1,97 @@
-../../14.0/distros/redhat-8.mk
+# Copyright 2019 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Distro dependent basic definitions for RedHat Enterprise Server 8
+# =================================================================
+# This Makefile include contains the definitions for the distro being used
+# for the build process. It contains kernel version infos and distro specific
+# sanity checks.
+
+# Informs the distro supported power archs
+AT_SUPPORTED_ARCHS := ppc64le
+
+# You may force the BUILD_IGNORE_AT_COMPAT general condition by distro
+#BUILD_IGNORE_AT_COMPAT := yes
+
+# Kernel version to build toolchain against
+# - As this distro only supports one arch variation (ppc64le), there is no
+#   need to conditionally define these versions based on arch.
+AT_KERNEL := 4.18    # Current distro kernel version for runtime.
+# Previous distro kernel version for runtime-compat.
+AT_OLD_KERNEL :=
+
+# Inform the mainly supported distros
+AT_SUPPORTED_DISTROS := RHEL8
+
+# Inform the compatibility supported distros
+AT_COMPAT_DISTROS :=
+
+# Sign the repository and packages
+AT_SIGN_PKGS := yes
+AT_SIGN_REPO := yes
+AT_SIGN_PKGS_CROSS := no
+AT_SIGN_REPO_CROSS := yes
+
+# ID of GNUPG key used to sign our packages (main/compat)
+AT_GPG_KEYID  := 6976A827
+AT_GPG_KEYIDC := 6976A827
+AT_GPG_KEYIDL := 6976A827
+# ID of GNUPG key used to sign our repositories (main/compat)
+AT_GPG_REPO_KEYID  := 6976A827
+AT_GPG_REPO_KEYIDC := 6976A827
+AT_GPG_REPO_KEYIDL := 6976A827
+
+# Options required by the command to update the repository metadata
+AT_REPOCMD_OPTS := -p -s sha1 --simple-md-filenames --no-database
+
+# Moved here from build.mk since the value for this variable
+# depends on the distro.
+# For a cross build the executables in the toolchain (gcc, ld, etc.)
+# should be built as 32 bit.
+BUILD_CROSS_32 := no
+
+# As some distros have special requirements for configuration upon final
+# AT installation, put in this macro, the final configurations required
+# after the main build and prior to the rpm build
+define distro_final_config
+    echo "nothing to do."
+endef
+
+# Inform the list of packages to check
+ifndef AT_DISTRO_REQ_PKGS
+    AT_CROSS_PKGS_REQ :=
+    AT_NATIVE_PKGS_REQ := libxslt docbook-style-xsl qt5-devel \
+                          autogen-libopts sqlite-devel
+    AT_COMMON_PKGS_REQ := zlib-devel ncurses-devel flex bison texinfo \
+                          createrepo glibc-devel subversion gawk \
+                          rsync curl bc automake libstdc\\+\\+-static \
+                          redhat-lsb-core autoconf bzip2-[0-9] libtool-[0-9] \
+                          gzip rpm-build-[0-9] rpm-sign gcc-c++ imake wget \
+                          docbook2X autoconf-archive libffi-devel python36 \
+                          systemtap-sdt-devel git make
+    AT_CROSS_PGMS_REQ :=
+    AT_NATIVE_PGMS_REQ :=
+    AT_COMMON_PGMS_REQ :=
+endif
+
+# Complete the list of packages to check that are based on arch being build
+AT_NATIVE_PKGS_REQ += glibc-devel bzip2-devel popt-devel
+
+# If needed, define the necessary distro related sanity checks.
+define distro_sanity
+    echo "nothing to test here"
+endef
+
+# Inform if the systemd service to monitor the loader cache should be used.
+USE_SYSTEMD := yes

--- a/configs/15.0/distros/redhat-8.mk
+++ b/configs/15.0/distros/redhat-8.mk
@@ -24,10 +24,6 @@ AT_SUPPORTED_ARCHS := ppc64le
 # You may force the BUILD_IGNORE_AT_COMPAT general condition by distro
 #BUILD_IGNORE_AT_COMPAT := yes
 
-# Kernel version to build toolchain against
-# - As this distro only supports one arch variation (ppc64le), there is no
-#   need to conditionally define these versions based on arch.
-AT_KERNEL := 4.18    # Current distro kernel version for runtime.
 # Previous distro kernel version for runtime-compat.
 AT_OLD_KERNEL :=
 

--- a/configs/15.0/distros/suse-15.mk
+++ b/configs/15.0/distros/suse-15.mk
@@ -24,10 +24,6 @@ AT_SUPPORTED_ARCHS := ppc64le
 # You may force the BUILD_IGNORE_AT_COMPAT general condition by distro
 #BUILD_IGNORE_AT_COMPAT := yes
 
-# Kernel version to build toolchain against
-# - As this distro only supports one arch variation (ppc64le), there is no
-#   need to conditionally define these versions based on arch.
-AT_KERNEL := 4.12.14     # Current distro kernel version for runtime.
 AT_OLD_KERNEL :=         # Previous distro kernel version for runtime-compat.
 
 # Inform the mainly supported distros

--- a/configs/15.0/distros/suse-15.mk
+++ b/configs/15.0/distros/suse-15.mk
@@ -1,1 +1,91 @@
-../../14.0/distros/suse-15.mk
+# Copyright 2019 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Distro dependent basic definitions for SuSE Enterprise Server 12
+# ================================================================
+# This Makefile include contains the definitions for the distro being used
+# for the build process. It contains kernel version infos and distro specific
+# sanity checks.
+
+# Informs the distro supported power archs
+AT_SUPPORTED_ARCHS := ppc64le
+
+# You may force the BUILD_IGNORE_AT_COMPAT general condition by distro
+#BUILD_IGNORE_AT_COMPAT := yes
+
+# Kernel version to build toolchain against
+# - As this distro only supports one arch variation (ppc64le), there is no
+#   need to conditionally define these versions based on arch.
+AT_KERNEL := 4.12.14     # Current distro kernel version for runtime.
+AT_OLD_KERNEL :=         # Previous distro kernel version for runtime-compat.
+
+# Inform the mainly supported distros
+AT_SUPPORTED_DISTROS := SLES_15
+
+# Inform the compatibility supported distros
+AT_COMPAT_DISTROS :=
+
+# Sign the repository and packages
+AT_SIGN_PKGS := yes
+AT_SIGN_REPO := yes
+AT_SIGN_PKGS_CROSS := no
+AT_SIGN_REPO_CROSS := yes
+
+# ID of GNUPG key used to sign our packages (main/compat)
+AT_GPG_KEYID  := 6976A827
+AT_GPG_KEYIDC := 6976A827
+AT_GPG_KEYIDL := 6976A827
+# ID of GNUPG key used to sign our repositories (main/compat)
+AT_GPG_REPO_KEYID  := 6976A827
+AT_GPG_REPO_KEYIDC := 6976A827
+AT_GPG_REPO_KEYIDL := 6976A827
+
+# Options required by the command to update the repository metadata
+AT_REPOCMD_OPTS := -p
+
+# Moved here from build.mk since the value for this variable
+# depends on the distro.
+# For a cross build the executables in the toolchain (gcc, ld, etc.)
+# should be built as 64 bit.
+BUILD_CROSS_32 := no
+
+# As some distros have special requirements for configuration upon final
+# AT installation, put in this macro, the final configurations required
+# after the main build and prior to the rpm build
+define distro_final_config
+    echo "nothing to do."
+endef
+
+# Inform the list of packages to check
+ifndef AT_DISTRO_REQ_PKGS
+    AT_CROSS_PKGS_REQ :=
+    AT_NATIVE_PKGS_REQ := libxslt popt-devel docbook-xsl-stylesheets \
+                          libbz2-devel sqlite3-devel
+    AT_COMMON_PKGS_REQ := zlib-devel ncurses-devel flex bison texinfo \
+                          createrepo_c subversion gawk autoconf rsync curl \
+                          bc automake rpm-build gcc-c++ xorg-x11-util-devel \
+                          docbook2x wget autoconf-archive make git \
+                          libffi-devel python3 systemtap-sdt-devel
+    AT_CROSS_PGMS_REQ :=
+    AT_NATIVE_PGMS_REQ :=
+    AT_COMMON_PGMS_REQ :=
+endif
+
+# If needed, define the necessary distro related sanity checks.
+define distro_sanity
+    echo "nothing to test here"
+endef
+
+# Inform if the systemd service to monitor the loader cache should be used.
+USE_SYSTEMD := yes

--- a/configs/15.0/distros/ubuntu-20.mk
+++ b/configs/15.0/distros/ubuntu-20.mk
@@ -1,1 +1,88 @@
-../../14.0/distros/ubuntu-20.mk
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Distro dependent basic definitions for Ubuntu 20.04 LTS
+# =======================================================
+# This Makefile include contains the definitions for the distro being used
+# for the build process. It contains kernel version infos and distro specific
+# sanity checks.
+
+# Informs the distro supported power archs
+AT_SUPPORTED_ARCHS := ppc64le
+
+# You may force the BUILD_IGNORE_AT_COMPAT general condition by distro
+#BUILD_IGNORE_AT_COMPAT := yes
+
+# Kernel version to build toolchain against
+# - As this distro only supports one arch variation (ppc64le), there is no
+#   need to conditionally define these versions based on arch.
+AT_KERNEL := 5.4   # Current distro kernel version for runtime.
+# TODO: fill this when our packaging system starts supporting runtime-compat
+# on Ubuntu.
+#AT_OLD_KERNEL :=  # Previous distro kernel version for runtime-compat.
+
+# Inform the mainly supported distros
+AT_SUPPORTED_DISTROS := focal
+
+# Inform the compatibility supported distros
+#AT_COMPAT_DISTROS :=
+
+# Sign the repository and packages
+#AT_SIGN_PKGS := yes
+#AT_SIGN_REPO := yes
+#AT_SIGN_PKGS_CROSS := no
+#AT_SIGN_REPO_CROSS := yes
+
+# ID of GNUPG key used to sign our packages (main/compat)
+AT_GPG_KEYID := 6976A827
+AT_GPG_KEYIDC := 3052930D
+# ID of GNUPG key used to sign our repositories (main/compat)
+AT_GPG_REPO_KEYID := 3052930D
+AT_GPG_REPO_KEYIDC := 3052930D
+
+# Options required by the command to update the repository metadata
+AT_REPOCMD_OPTS := -p -s sha256 --simple-md-filenames --no-database
+
+# As some distros have special requirements for configuration upon final
+# AT installation, put in this macro, the final configurations required
+# after the main build and prior to the rpm build
+define distro_final_config
+    echo "nothing to do."
+endef
+
+# Inform the list of packages to check
+ifndef AT_DISTRO_REQ_PKGS
+    AT_CROSS_PKGS_REQ :=
+    # TODO: add libqt4-dev or libqt5-dev when it will be available in Ubuntu 20.04.
+    AT_NATIVE_PKGS_REQ := libxslt libpopt-dev \
+                          libc6-dev libbz2-dev xsltproc docbook-xsl \
+                          libsqlite3-dev
+    AT_COMMON_PKGS_REQ := zlib1g-dev libncurses5-dev ncurses-term flex bison \
+                          texinfo subversion gawk fakeroot debhelper \
+                          autoconf rsync curl bc libxml2-utils automake \
+                          dpkg-sig xutils-dev libtool wget dh-systemd \
+                          docbook2x pkg-config autoconf-archive make \
+                          libffi-dev python3 git systemtap-sdt-dev
+    AT_CROSS_PGMS_REQ :=
+    AT_NATIVE_PGMS_REQ :=
+    AT_COMMON_PGMS_REQ :=
+endif
+
+# If needed, define the necessary distro related sanity checks.
+define distro_sanity
+    echo "nothing to test here"
+endef
+
+# Inform if the systemd service to monitor the loader cache should be used.
+USE_SYSTEMD := yes

--- a/configs/15.0/distros/ubuntu-20.mk
+++ b/configs/15.0/distros/ubuntu-20.mk
@@ -24,10 +24,6 @@ AT_SUPPORTED_ARCHS := ppc64le
 # You may force the BUILD_IGNORE_AT_COMPAT general condition by distro
 #BUILD_IGNORE_AT_COMPAT := yes
 
-# Kernel version to build toolchain against
-# - As this distro only supports one arch variation (ppc64le), there is no
-#   need to conditionally define these versions based on arch.
-AT_KERNEL := 5.4   # Current distro kernel version for runtime.
 # TODO: fill this when our packaging system starts supporting runtime-compat
 # on Ubuntu.
 #AT_OLD_KERNEL :=  # Previous distro kernel version for runtime-compat.

--- a/configs/next/base.mk
+++ b/configs/next/base.mk
@@ -52,3 +52,8 @@ AT_REVISION_NUMBER := 0
 AT_INTERNAL := alpha
 AT_PREVIOUS_VERSION := 15.0
 AT_DIR_NAME := at-next-$(AT_MAJOR_VERSION)-$(AT_REVISION_NUMBER)-$(AT_INTERNAL)
+
+# Minimum kernel version distributed on supported distros by this AT version,
+# i.e. minimum kernel version required in order to run software linked to this
+# AT version.
+AT_KERNEL := 4.12.14


### PR DESCRIPTION
Give a new interpretation to AT_KERNEL by moving it to base.mk.  Now,
it will be treated as the minimum kernel version supported by one AT
version.
    
This new interpretation will allow software built on a distro with a
newer kernel version to be executed on an older kernel version.
    
This is particularly more interesting when users start to run their
software inside containers whose host kernel may not be the same of the
distro inside the container.