### PR TITLE
Update GCC and glibc on AT next

### DIFF
--- a/configs/15.0/packages/glibc/stage_1
+++ b/configs/15.0/packages/glibc/stage_1
@@ -154,8 +154,8 @@ atcfg_configure()
 		AUTOCONF="${autoconf}" \
 		CC="${at_dest}/bin/gcc -m${AT_BIT_SIZE}" \
 		CFLAGS="-g -O2 ${secure_plt:+-msecure-plt} \
-			-fcommon \
-			-Wno-error=stringop-overread" \
+			-Wno-error=maybe-uninitialized \
+			-Wno-error=array-bounds" \
 		CXX="/bin/false" \
 		libc_cv_forced_unwind="yes" \
 		libc_cv_c_cleanup="yes" \
@@ -185,7 +185,8 @@ atcfg_configure()
 		AUTOCONF="${autoconf}" \
 		CC="${at_dest}/bin/${target64:-${target}}-gcc -m${AT_BIT_SIZE}" \
 		CFLAGS="-g -O2 \
-			-Wno-error=stringop-overread" \
+			-Wno-error=maybe-uninitialized \
+			-Wno-error=array-bounds" \
 		CPPFLAGS="-isystem $(pwd)/systemtap" \
 		CXX="/bin/false" \
 		AR="${at_dest}/bin/${target}-ar" \

--- a/configs/15.0/packages/glibc/stage_2
+++ b/configs/15.0/packages/glibc/stage_2
@@ -95,8 +95,8 @@ atcfg_configure() {
 	CXX="${at_dest}/bin/g++ -m${AT_BIT_SIZE}" \
 	CFLAGS="-g -O3 \
 		${with_longdouble:+-mlong-double-128} \
-		-fcommon \
-		-Wno-error=stringop-overread" \
+		-Wno-error=maybe-uninitialized \
+		-Wno-error=array-bounds" \
 	CPPFLAGS="-isystem $(pwd)/systemtap" \
 	CXXFLAGS="-g -O3" \
 	${ATSRC_PACKAGE_WORK}/configure --build=${host} \

--- a/configs/15.0/packages/glibc/stage_optimized
+++ b/configs/15.0/packages/glibc/stage_optimized
@@ -84,9 +84,8 @@ atcfg_configure() {
 	CXX="${at_dest}/bin/g++ -m${AT_BIT_SIZE}" \
 	CFLAGS="-g -O3 \
 		${with_longdouble:+-mlong-double-128} \
-		-fcommon \
 		-Wno-error=maybe-uninitialized \
-		-Wno-error=stringop-overread" \
+		-Wno-error=array-bounds" \
 	CXXFLAGS="-g -O3" \
 	${ATSRC_PACKAGE_WORK}/configure --build=${target} \
 					--host=${base_target} \

--- a/configs/next/packages/gcc/sources
+++ b/configs/next/packages/gcc/sources
@@ -23,7 +23,7 @@ ATSRC_PACKAGE_NAME="GCC (GNU Compiler Collection)"
 ATSRC_PACKAGE_SUBPACKAGE_NAME_0="GNU Standard C++ Library v3 (Libstdc++-v3)"
 ATSRC_PACKAGE_SUBPACKAGE_NAME_1="GNU Libgomp"
 ATSRC_PACKAGE_VER=12.0.0
-ATSRC_PACKAGE_REV=fcc7c6369f7f
+ATSRC_PACKAGE_REV=f0fca213bc52
 ATSRC_PACKAGE_LICENSE="GPL 3.0"
 ATSRC_PACKAGE_DOCLINK="https://gcc.gnu.org/onlinedocs/gcc/"
 ATSRC_PACKAGE_SUBPACKAGE_DOCLINK_0="https://gcc.gnu.org/libstdc++/"
@@ -71,9 +71,15 @@ atsrc_get_patches ()
 		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/master/GCC%20PowerPC%20Backport/11/0001-powerpc-Remove-forced-runpath-from-with-advance-tool.patch' \
 		2a4d7864672f6227f33687a834e7dca4 || return ${?}
 
+	# The following 2 patches revert changes in libstdc++ that are causing
+	# issues while building Boost.
 	at_get_patch \
-		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/25cc9095a4591a2cde8adc2a74f417e3ff667f3a/GCC%20PowerPC%20Backport/12/0001-Revert-Improve-global-state-for-options.patch' \
-		75484046f079e39a71545b391661ca08 || return ${?}
+		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/969f5ad0cce09c1d95afb53c62525c627570ee78/GCC%20libstdc%2B%2B%20PowerPC%20Patches/12/0001-Revert-libstdc-Add-conditional-noexcept-to-std-excha.patch' \
+		3eec8e72318e25648084bbb992e7ebad || return ${?}
+
+	at_get_patch \
+		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/969f5ad0cce09c1d95afb53c62525c627570ee78/GCC%20libstdc%2B%2B%20PowerPC%20Patches/12/0001-Revert-libstdc-Reduce-header-dependencies-on-array-a.patch' \
+		5408b4d0cd5503e74782b2622caf8006 || return ${?}
 
 	return 0
 }
@@ -97,6 +103,10 @@ atsrc_apply_patches ()
 		|| return ${?}
 
 	patch -p1 \
-	      < 0001-Revert-Improve-global-state-for-options.patch \
+	      < 0001-Revert-libstdc-Add-conditional-noexcept-to-std-excha.patch \
+		|| return ${?}
+
+	patch -p1 \
+	      < 0001-Revert-libstdc-Reduce-header-dependencies-on-array-a.patch \
 		|| return ${?}
 }


### PR DESCRIPTION
A recent GCC update required further changes in GCC itself and in glibc.

One of the fix for a regression we caught a while ago has been merged, turning one of our patches obsolete. However, a new regression appeared and we need to revert 2 patches from upstream.

glibc requires 2 new `-Wno-error`. Luckily, 2 other parameters can be removed.

Close #2296.