### PR TITLE
Verify `systemctl` is available before using it

### DIFF
--- a/configs/13.0/deb/monolithic/runtime.postinst
+++ b/configs/13.0/deb/monolithic/runtime.postinst
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2017 IBM Corporation
+# Copyright 2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ if [[ "${1}" == configure ]]; then
 	[[ -f __AT_DEST__/sbin/ldconfig ]] && __AT_DEST__/sbin/ldconfig
 fi
 
-if [[ "__USE_SYSTEMD__" == "yes" ]]; then
+if [[ "__USE_SYSTEMD__" == "yes" && -n "$(command -v systemctl)" ]]; then
 	systemctl --no-reload preset __AT_VER_ALTERNATIVE__-cachemanager.service \
 	    > /dev/null 2>&1 || :
 	systemctl restart __AT_VER_ALTERNATIVE__-cachemanager.service || \

--- a/configs/13.0/deb/monolithic/runtime.postinst
+++ b/configs/13.0/deb/monolithic/runtime.postinst
@@ -1,1 +1,36 @@
-../../../12.0/deb/monolithic/runtime.postinst
+#!/bin/bash
+#
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if [[ "${1}" == configure ]]; then
+	# Automatically set the timezone
+	rm -f "__AT_DEST__/etc/localtime"
+	ln -s /etc/localtime "__AT_DEST__/etc/localtime"
+
+	# Update ld.so.cache
+	[[ -f __AT_DEST__/sbin/ldconfig ]] && __AT_DEST__/sbin/ldconfig
+fi
+
+if [[ "__USE_SYSTEMD__" == "yes" ]]; then
+	systemctl --no-reload preset __AT_VER_ALTERNATIVE__-cachemanager.service \
+	    > /dev/null 2>&1 || :
+	systemctl restart __AT_VER_ALTERNATIVE__-cachemanager.service || \
+	    echo -e " Failed to start __AT_VER_ALTERNATIVE__-cachemanager.service.\n \
+AT's linker cache file is not automatically updated when a package is \
+installed or modified.\n \
+Please run __AT_DEST__/bin/watch_ldconfig if you want it to be."
+
+fi

--- a/configs/13.0/deb/monolithic/runtime.prerm
+++ b/configs/13.0/deb/monolithic/runtime.prerm
@@ -1,1 +1,24 @@
-../../../12.0/deb/monolithic/runtime.prerm
+#!/bin/bash
+#
+# Copyright 2018 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if [[ "${1}" == remove ]]; then
+	# Stop and disable the cache manager service to remove symlinks.
+	if [[ "__USE_SYSTEMD__" == "yes" ]]; then
+		systemctl stop __AT_VER_ALTERNATIVE__-cachemanager.service
+		systemctl disable __AT_VER_ALTERNATIVE__-cachemanager.service
+	fi
+fi

--- a/configs/13.0/deb/monolithic/runtime.prerm
+++ b/configs/13.0/deb/monolithic/runtime.prerm
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2018 IBM Corporation
+# Copyright 2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 
 if [[ "${1}" == remove ]]; then
 	# Stop and disable the cache manager service to remove symlinks.
-	if [[ "__USE_SYSTEMD__" == "yes" ]]; then
+	if [[ "__USE_SYSTEMD__" == "yes" && -n "$(command -v systemctl)" ]]; then
 		systemctl stop __AT_VER_ALTERNATIVE__-cachemanager.service
 		systemctl disable __AT_VER_ALTERNATIVE__-cachemanager.service
 	fi

--- a/configs/13.0/specs/monolithic.spec
+++ b/configs/13.0/specs/monolithic.spec
@@ -241,9 +241,11 @@ exit 0
 # Automatically set the timezone
 rm -f %{_prefix}/etc/localtime
 ln -s /etc/localtime %{_prefix}/etc/localtime
-systemctl preset %{at_ver_alternative}-cachemanager.service \
-    > /dev/null 2>&1 || :
-systemctl restart %{at_ver_alternative}-cachemanager.service
+if [[ -n "$(command -v systemctl)" ]]; then
+	systemctl preset %{at_ver_alternative}-cachemanager.service \
+	    > /dev/null 2>&1 || :
+	systemctl restart %{at_ver_alternative}-cachemanager.service
+fi
 
 #---------------------------------------------------
 %post devel
@@ -386,7 +388,7 @@ fi
 
 #---------------------------------------------------
 %preun runtime
-systemctl --no-reload disable --now \
+command -v systemctl >/dev/null && systemctl --no-reload disable --now \
     %{at_ver_alternative}-cachemanager.service > /dev/null 2>&1 || :
 
 ####################################################
@@ -405,7 +407,7 @@ if file /usr/sbin/ldconfig | grep "bash script" > /dev/null; then
         rm -f /usr/sbin/ldconfig
     fi
 fi
-systemctl try-restart %{at_ver_alternative}-cachemanager.service >/dev/null \
+command -v systemctl >/dev/null &&  systemctl try-restart %{at_ver_alternative}-cachemanager.service >/dev/null \
     2>&1 || :
 
 #---------------------------------------------------

--- a/configs/14.0/specs/monolithic.spec
+++ b/configs/14.0/specs/monolithic.spec
@@ -259,9 +259,11 @@ fi
 # Automatically set the timezone
 rm -f %{_prefix}/etc/localtime
 ln -s /etc/localtime %{_prefix}/etc/localtime
-systemctl preset %{at_ver_alternative}-cachemanager.service \
-    > /dev/null 2>&1 || :
-systemctl restart %{at_ver_alternative}-cachemanager.service
+if [[ -n "$(command -v systemctl)" ]]; then
+	systemctl preset %{at_ver_alternative}-cachemanager.service \
+	    > /dev/null 2>&1 || :
+	systemctl restart %{at_ver_alternative}-cachemanager.service
+fi
 
 #---------------------------------------------------
 %post devel
@@ -426,7 +428,7 @@ fi
 
 #---------------------------------------------------
 %preun runtime
-systemctl --no-reload disable --now \
+command -v systemctl >/dev/null && systemctl --no-reload disable --now \
     %{at_ver_alternative}-cachemanager.service > /dev/null 2>&1 || :
 
 ####################################################
@@ -445,7 +447,7 @@ if file /usr/sbin/ldconfig | grep "bash script" > /dev/null; then
         rm -f /usr/sbin/ldconfig
     fi
 fi
-systemctl try-restart %{at_ver_alternative}-cachemanager.service >/dev/null \
+command -v systemctl >/dev/null &&  systemctl try-restart %{at_ver_alternative}-cachemanager.service >/dev/null \
     2>&1 || :
 
 #---------------------------------------------------


### PR DESCRIPTION
In packages scriplets, check that `systemctl` is available before using it.
This will avoid error messages when installing AT packages.

Fix #2330

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>