### PR TITLE
Add LZMA development package as a prerequisite

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -80,6 +80,7 @@ see it miserably fail, asking for these packages, we provide the list below for 
 	imake or xorg-x11-utils (for OpenSSL)
 	papi-devel - for oprofile
 	papi-devel-64bit - for oprofile
+	xz-devel/liblzma-dev - for GDB to decompress some debuginfo sections
 
   Special cases:
     RHEL 5 and SLES 10 only provide older versions of some

--- a/configs/13.0/distros/debian-10.mk
+++ b/configs/13.0/distros/debian-10.mk
@@ -66,7 +66,7 @@ ifndef AT_DISTRO_REQ_PKGS
     AT_CROSS_PKGS_REQ :=
     AT_NATIVE_PKGS_REQ := libxslt1.1 libpopt-dev libqt4-dev \
                           libc6-dev libbz2-dev xsltproc docbook-xsl \
-                          libsqlite3-dev
+                          libsqlite3-dev liblzma-dev
     AT_COMMON_PKGS_REQ := zlib1g-dev libncurses5-dev ncurses-term flex bison \
                           texinfo subversion gawk fakeroot debhelper \
                           autoconf rsync curl bc libxml2-utils automake \

--- a/configs/13.0/distros/redhat-8.mk
+++ b/configs/13.0/distros/redhat-8.mk
@@ -72,7 +72,7 @@ endef
 ifndef AT_DISTRO_REQ_PKGS
     AT_CROSS_PKGS_REQ :=
     AT_NATIVE_PKGS_REQ := libxslt docbook-style-xsl qt5-devel \
-                          autogen-libopts sqlite-devel
+                          autogen-libopts sqlite-devel xz-devel
     AT_COMMON_PKGS_REQ := zlib-devel ncurses-devel flex bison texinfo \
                           createrepo glibc-devel subversion gawk \
                           rsync curl bc automake libstdc\\+\\+-static \

--- a/configs/13.0/distros/suse-15.mk
+++ b/configs/13.0/distros/suse-15.mk
@@ -71,7 +71,7 @@ endef
 ifndef AT_DISTRO_REQ_PKGS
     AT_CROSS_PKGS_REQ :=
     AT_NATIVE_PKGS_REQ := libxslt popt-devel docbook-xsl-stylesheets \
-                          libbz2-devel sqlite3-devel
+                          libbz2-devel sqlite3-devel xz-devel
     AT_COMMON_PKGS_REQ := zlib-devel ncurses-devel flex bison texinfo \
                           createrepo_c subversion gawk autoconf rsync curl \
                           bc automake rpm-build gcc-c++ xorg-x11-util-devel \

--- a/configs/13.0/distros/ubuntu-18.mk
+++ b/configs/13.0/distros/ubuntu-18.mk
@@ -66,7 +66,7 @@ ifndef AT_DISTRO_REQ_PKGS
     AT_CROSS_PKGS_REQ :=
     AT_NATIVE_PKGS_REQ := libxslt libpopt-dev libqt4-dev \
                           libc6-dev libbz2-dev xsltproc docbook-xsl \
-                          libsqlite3-dev
+                          libsqlite3-dev liblzma-dev
     AT_COMMON_PKGS_REQ := zlib1g-dev libncurses5-dev ncurses-term flex bison \
                           texinfo subversion gawk fakeroot debhelper \
                           autoconf rsync curl bc libxml2-utils automake \

--- a/configs/14.0/distros/ubuntu-20.mk
+++ b/configs/14.0/distros/ubuntu-20.mk
@@ -67,7 +67,7 @@ ifndef AT_DISTRO_REQ_PKGS
     # TODO: add libqt4-dev or libqt5-dev when it will be available in Ubuntu 20.04.
     AT_NATIVE_PKGS_REQ := libxslt libpopt-dev \
                           libc6-dev libbz2-dev xsltproc docbook-xsl \
-                          libsqlite3-dev
+                          libsqlite3-dev liblzma-dev
     AT_COMMON_PKGS_REQ := zlib1g-dev libncurses5-dev ncurses-term flex bison \
                           texinfo subversion gawk fakeroot debhelper \
                           autoconf rsync curl bc libxml2-utils automake \


### PR DESCRIPTION
GDB needs LZMA development packages during build to support
LZ-compressed debuginfo sections.  Without this support built-in,
GDB can report warnings like:
```
$ /opt/at15.0/bin/gdb /usr/bin/python3
[...]
Reading symbols from /usr/bin/python3...

warning: Cannot parse .gnu_debugdata section; LZMA support was disabled at compile time
(No debugging symbols found in /usr/bin/python3)
```
...and presumably reduced capability as a result.

A GDB that includes such support will report:
```
$ ./at-next-16.0-0-alpha/bin/gdb /usr/bin/python3
[...]
Reading symbols from /usr/bin/python3...
Reading symbols from .gnu_debugdata for /usr/libexec/platform-python3.6...
(No debugging symbols found in .gnu_debugdata for /usr/libexec/platform-python3.6)
[...]
```
(slightly better, at least.)

Fixes #1950.

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>