### PR TITLE
Build and package optimized libpython.so

### DIFF
--- a/configs/13.0/packages/python/stage_1
+++ b/configs/13.0/packages/python/stage_1
@@ -35,8 +35,8 @@ atcfg_configure() {
 	PATH=${at_dest}/bin:${PATH} \
 	CC="${at_dest}/bin/gcc -m${compiler}" \
 	CXX="${at_dest}/bin/g++ -m${compiler}" \
-	CFLAGS="-g -O2 -Wformat" \
-	CXXFLAGS="-g -O2" \
+	CFLAGS="-g -O3 -Wformat" \
+	CXXFLAGS="-g -O3" \
 	${ATSRC_PACKAGE_WORK}/configure \
 		--build=${target} \
 		--host=${target} \

--- a/configs/15.0/packages/python/stage_1
+++ b/configs/15.0/packages/python/stage_1
@@ -35,8 +35,8 @@ atcfg_configure() {
 	PATH=${at_dest}/bin:${PATH} \
 	CC="${at_dest}/bin/gcc -m${compiler}" \
 	CXX="${at_dest}/bin/g++ -m${compiler}" \
-	CFLAGS="-g -O2 -Wformat" \
-	CXXFLAGS="-g -O2" \
+	CFLAGS="-g -O3 -Wformat" \
+	CXXFLAGS="-g -O3" \
 	${ATSRC_PACKAGE_WORK}/configure \
 		--build=${target} \
 		--host=${target} \

--- a/configs/next/packages/python/python.mk
+++ b/configs/next/packages/python/python.mk
@@ -16,10 +16,18 @@
 #
 $(eval $(call set_provides,python_1,single,cross_no))
 
+python_tuned-deps := $(patsubst %,$(RCPTS)/%.rcpt,gcc_3 expat_1 openssl_1-64.b ldconfig_2 rsync_python)
+
+# Enable tuned targets
+$(eval $(call provide_tuneds,python))
+
 python_1: $(RCPTS)/python_1.rcpt
 
 $(RCPTS)/python_1.rcpt: $(python_1-archdeps)
 	@touch $@
 
 $(RCPTS)/python_1.a.rcpt: $(patsubst %,$(RCPTS)/%.rcpt,gcc_4 expat_1 openssl_1-64.b ldconfig_2 rsync_python)
+	@touch $@
+
+$(RCPTS)/python_tuned.rcpt: $(python_tuned-archdeps)
 	@touch $@

--- a/configs/next/packages/python/python.mk
+++ b/configs/next/packages/python/python.mk
@@ -1,1 +1,25 @@
-../../../15.0/packages/python/python.mk
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+#
+$(eval $(call set_provides,python_1,single,cross_no))
+
+python_1: $(RCPTS)/python_1.rcpt
+
+$(RCPTS)/python_1.rcpt: $(python_1-archdeps)
+	@touch $@
+
+$(RCPTS)/python_1.a.rcpt: $(patsubst %,$(RCPTS)/%.rcpt,gcc_4 expat_1 openssl_1-64.b ldconfig_2 rsync_python)
+	@touch $@

--- a/configs/next/packages/python/stage_optimized
+++ b/configs/next/packages/python/stage_optimized
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Copyright 2021 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Python build parameters for stage optimized
+# ===========================================
+#
+
+# Tell the build system to hold the temp install folder
+ATCFG_HOLD_TEMP_INSTALL='no'
+# Tell the build system to hold the temp build folder
+ATCFG_HOLD_TEMP_BUILD='no'
+# Build in a new directory
+ATCFG_BUILD_STAGE_T='dir'
+# Don't fail if stage final install place doesn't exist
+ATCFG_INSTALL_PEDANTIC=no
+
+atcfg_configure() {
+	PATH=${at_dest}/bin:${PATH} \
+	CC="${at_dest}/bin/gcc -m${compiler}" \
+	CXX="${at_dest}/bin/g++ -m${compiler}" \
+	CFLAGS="-g -Wformat" \
+	CXXFLAGS="-g" \
+	OPT="-O3 -mcpu=${AT_OPTIMIZE_CPU/ppc/}" \
+	${ATSRC_PACKAGE_WORK}/configure \
+		--build=${target} \
+		--host=${target} \
+		--target=${target} \
+		--prefix=${at_dest} \
+		--exec-prefix=${at_dest} \
+		--libdir="${at_dest}/lib${compiler##32}" \
+		--with-platlibdir="lib${compiler##32}" \
+		--enable-shared \
+		--enable-loadable-sqlite-extensions \
+		--with-openssl="${at_dest}" \
+		--with-ssl-default-suites=openssl \
+		--with-lto
+}
+
+atcfg_make() {
+	PATH=${at_dest}/bin:${PATH} ${SUB_MAKE} libpython3.so
+}
+
+atcfg_install() {
+	mkdir -p "${install_transfer}/lib64/glibc-hwcaps/$AT_OPTIMIZE_CPU"
+	cp -a libpython*.so* "${install_transfer}/lib64/glibc-hwcaps/$AT_OPTIMIZE_CPU/."
+}


### PR DESCRIPTION
~~This is not ready to merge.~~

~~For one thing, it exposes a bug in GCC [PR 102107](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=102107), which can result in Python crashing. The fix for this bug has only been committed to GCC trunk today.~~

~~Secondly, the results of the build would now be dependent on the system on which the build is performed.  On a Power9 system, a power9-optimized `libpython.so` is included in packages. On a Power10 system, a power9-optimized `libpython.so` and a power10-optmized `libpython.so` are included in packages. Preferably, "release-level" builds would be performed on a system with the latest processor, but failure to do so is silently ignored.~~

Also, the changes target "next". If deemed desirable, should they instead be targeted at "15.0"?