### PR TITLE
[FVTR] Set GOPATH to avoid creating $HOME/go

### DIFF
--- a/fvtr/gotools/gotools.exp
+++ b/fvtr/gotools/gotools.exp
@@ -43,6 +43,7 @@ if { ![file exists $at_dir/bin/go] } {
 }
 
 set test_files {hello.go hello_cgo.go}
+set env(GOPATH) $FULLPATH
 
 foreach test $test_files {
 	spawn $GOTOOL run $FULLPATH/$test


### PR DESCRIPTION
Running the FVTR test for `gotools` leaves a `go` directory in $HOME
because `go` creates and uses a workspace based on the environment
variable `GOPATH` or `$HOME/go` by default.

Set `GOPATH` to the FVTR directory for `gotools` instead.

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>