### PR TITLE
Update binutils on AT 15.0

### DIFF
--- a/configs/15.0/packages/binutils/sources
+++ b/configs/15.0/packages/binutils/sources
@@ -21,7 +21,7 @@
 
 ATSRC_PACKAGE_NAME="GNU Binutils"
 ATSRC_PACKAGE_VER=2.37.0
-ATSRC_PACKAGE_REV=34223865b002
+ATSRC_PACKAGE_REV=2e62356d25e9
 ATSRC_PACKAGE_BRANCH=binutils-2_37-branch
 ATSRC_PACKAGE_LICENSE="GPL 2.0"
 ATSRC_PACKAGE_DOCLINK="http://sourceware.org/binutils/docs/"
@@ -42,51 +42,3 @@ ATSRC_PACKAGE_TARS=
 ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=main_toolchain
 ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://sourceware.org/git/?p=binutils-gdb.git;a=blob_plain;f=bfd/version.m4;hb=__REVISION__" | grep "^m4_define" | sed "s/^.*\[\([0-9\.][0-9\.]*\)].*$/\1/"'
-
-atsrc_get_patches ()
-{
-	at_get_patch \
-		'https://sourceware.org/git?p=binutils-gdb.git;a=patch;h=912697efc15768894c13a9370a2fcaa950f24558' \
-		12974f5f070e033a074a16a379e71b55 pr28192-1.patch || return ${?}
-
-	at_get_patch \
-		'https://sourceware.org/git?p=binutils-gdb.git;a=patch;h=973b2b402ebf660e2bbbac60e85469164d76ecfc' \
-		cf1432819ccef14fc02119aeebd1f4ec pr28192-2.patch || return ${?}
-
-	at_get_patch \
-		'https://sourceware.org/git?p=binutils-gdb.git;a=patch;h=54721a930e80a635d3cb47c0ad3899ed9680bd78' \
-		f91178978357b96d7f2cbe360e502066 pr28192-3.patch || return ${?}
-
-	at_get_patch \
-		'https://sourceware.org/git?p=binutils-gdb.git;a=patch;h=2cc9ed14fae1b288bbdbd9b102b2cbc9a29bf348' \
-		63edc3d59a553be5b6ed423a7a55eeff pr28192-4.patch || return ${?}
-
-	at_get_patch \
-		'https://sourceware.org/git?p=binutils-gdb.git;a=patch;h=e4d49a0f908415edb7a7e718ef2008a96dd43f9b' \
-		420967131774a9108c0d515c18e75694 pr28192-5.patch || return ${?}
-
-	at_get_patch \
-		'https://sourceware.org/git?p=binutils-gdb.git;a=patch;h=5cdb4f14426a99ec8fcba843fa503efdc55fa078' \
-		1d871681fc3982f25354a14e896a56a3 pr28192-6.patch || return ${?}
-}
-
-atsrc_apply_patches ()
-{
-	patch -p1 < pr28192-1.patch \
-		|| return ${?}
-
-	patch -p1 < pr28192-2.patch \
-		|| return ${?}
-
-	patch -p1 < pr28192-3.patch \
-		|| return ${?}
-
-	patch -p1 < pr28192-4.patch \
-		|| return ${?}
-
-	patch -p1 < pr28192-5.patch \
-		|| return ${?}
-
-	patch -p1 < pr28192-6.patch \
-		|| return ${?}
-}


### PR DESCRIPTION
Bump to revision 2e62356d25e9
Removed backported patches.

Close #2401 

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>