### PR TITLE
Update tbb on AT 15.0

### DIFF
--- a/configs/15.0/packages/tbb/sources
+++ b/configs/15.0/packages/tbb/sources
@@ -20,8 +20,8 @@
 #
 
 ATSRC_PACKAGE_NAME="Thread Building Blocks"
-ATSRC_PACKAGE_VER=2021.4.0
-ATSRC_PACKAGE_REV=4e021eafc035
+ATSRC_PACKAGE_VER=2021.5.0
+ATSRC_PACKAGE_REV=5a5c793a6c9b
 ATSRC_PACKAGE_BRANCH=onetbb_2021
 ATSRC_PACKAGE_LICENSE="GPL 2.0"
 ATSRC_PACKAGE_DOCLINK="https://www.threadingbuildingblocks.org/"
@@ -57,21 +57,4 @@ atsrc_package_verify_make_check_log ()
 		grep -i "error[: ]" "${1}" > /dev/null
 		return ${?}
 	fi
-}
-
-atsrc_get_patches ()
-{
-	# Remove some gcc 11 warnings, commits from the master branch
-	at_get_patch \
-		'https://github.com/oneapi-src/oneTBB/commit/5a643c2360fb7684b6a88eccf4421f8c635668f5.patch' \
-		d9317888c2b46ce9000658ffd7cc7db2 || return ${?}
-
-	return 0
-}
-
-atsrc_apply_patches ()
-{
-	patch -p1 \
-	     < 5a643c2360fb7684b6a88eccf4421f8c635668f5.patch \
-		|| return ${?}
 }


### PR DESCRIPTION
Bump to version 2021.5.0
Bump to revision 5a5c793a6c9b

Removed a patch that has been merged upstream.

Close #2436 

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>