### PR TITLE
Provide -release package for SLES

### DIFF
--- a/configs/13.0/specs/release.spec
+++ b/configs/13.0/specs/release.spec
@@ -1,0 +1,113 @@
+# Copyright 2021 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Per convention the %%product name will be used a stem for the -release
+# package and the -prod file
+%define         product advance-toolchain-%{at_major}
+
+# Decide: The products version and release often follows the release package.
+# In this case use the -release packages %%{version} and %%{release}. But
+# it is possible to maintain different v-r for product and -release package.
+# In this case the products v-r would be defined here.
+%define         productversion %{at_major_version}
+%define         productrelease %{at_revision_number}
+
+# The date when this Product goes out of support. A missing value indicates
+# that there will be no EOL, while an empty/invalid value indicates that
+# there will be an EOL date, but it's not yet known.
+%define         productendoflife ""
+%define         productendoflifel_pcescaped %{productendoflife}
+
+%define         producturlbugtracker https://github.com/advancetoolchain/advance-toolchain/issues/
+%define         producturlbugtracker_pcescaped https%3A%2F%2Fgithub.com%2Fadvancetoolchain%2Fadvance%2Dtoolchain%2Fissues%2F
+
+# ----------------------------------------------------------------------
+
+Name:           %{product}-release
+Summary:        Advance Toolchain
+Version:        %{productversion}
+Release:        %{productrelease}
+License:        GPL, LGPL
+Group:          Development/Libraries
+Vendor:         __RPM_VENDOR__
+
+Provides:       %name-%version
+# ======================================================================
+# Product indicator provides (mandatory and important):
+Provides:       product() = %{product}
+Provides:       product(%{product}) = %{productversion}-%{productrelease}
+# Additional product data exposed in the -release package:
+Provides:       product-endoflife() = %{productendoflife_pcescaped}
+Provides:       product-url(bugtracker) = %{producturlbugtracker_pcescaped}
+# ----------------------------------------------------------------------
+
+Requires:       product(SUSE_SLE) >= __DISTRO_VERSION__
+AutoReqProv:    no
+
+%description
+The Advance Toolchain for Linux on IBM Power is a self-contained toolchain that
+provides open-source compilers, runtime libraries, and development tools to take
+advantage of the latest IBM Power hardware features on Linux.
+
+%prep
+
+%build
+
+%install
+
+mkdir -p $RPM_BUILD_ROOT/etc/products.d
+cat >$RPM_BUILD_ROOT/etc/products.d/%{product}.prod << EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<product schemeversion="0">
+  <vendor>__RPM_VENDOR__</vendor>
+  <name>%{product}</name>
+  <version>%{productversion}</version>
+  <baseversion>__DISTRO_VERSION__</baseversion>
+  <patchlevel>0</patchlevel>
+  <predecessor>sle-sdk</predecessor>
+  <release>%{productrelease}</release>
+  <endoflife>%{productendoflife_pcescaped}</endoflife>
+  <arch>__TARGET_ARCH__</arch>
+  <summary>Advance Toolchain</summary>
+  <description>
+&lt;p&gt;The Advance Toolchain for Linux on IBM Power is a self-contained toolchain that 
+provides open-source compilers, runtime libraries, and development tools to take 
+advantage of the latest IBM Power hardware features on Linux.&lt;/p&gt;
+  </description>
+  <urls>
+    <url name="bugtracker">%{producturlbugtracker}</url>
+  </urls>
+  <buildconfig>
+    <producttheme>SLES</producttheme>
+  </buildconfig>
+  <installconfig>
+    <defaultlang>en_US</defaultlang>
+    <releasepackage name="%{name}" flag="EQ" version="%{version}" release="%{release}"/>
+    <distribution>SUSE_SLE</distribution>
+  </installconfig>
+  <runtimeconfig/>
+  <productdependency relationship="requires" name="SUSE_SLE" baseversion="__DISTRO_VERSION__" patchlevel="0" flag="GE"/>
+</product>
+
+EOF
+
+
+%files
+%defattr(644,root,root,755)
+%dir /etc/products.d
+/etc/products.d/*
+
+%changelog
+

--- a/configs/14.0/specs/release.spec
+++ b/configs/14.0/specs/release.spec
@@ -1,0 +1,1 @@
+../../13.0/specs/release.spec

--- a/configs/15.0/specs/release.spec
+++ b/configs/15.0/specs/release.spec
@@ -1,0 +1,1 @@
+../../14.0/specs/release.spec

--- a/configs/next/specs/release.spec
+++ b/configs/next/specs/release.spec
@@ -1,0 +1,1 @@
+../../15.0/specs/release.spec

--- a/fvtr/package-check/package-check.exp
+++ b/fvtr/package-check/package-check.exp
@@ -308,6 +308,44 @@ proc test_debuginfo_pkgs { file_list } {
 	return 1
 }
 
+# This function performs a simple check of the release package
+# to validate its contents were generated as expected.
+#
+# Parameters:
+# file_list             List of files
+#                       if empty, checking installed package
+#
+# Return:
+# 0 if success or 1 if the content is invalid.
+proc test_release_pkg {{file_list {}}} {
+	global ERROR
+
+	set product_name [append_at_internal "advance-toolchain-$::env(AT_NAME)$::env(AT_MAJOR_VERSION)"]
+	if { [llength $file_list] > 0 } {
+		if { [regexp -all -line ".*/${product_name}.prod\$" $file_list] == 1 } {
+			printit "SUCCESS."
+			return 0
+		}
+	} else {
+		set package_name "${product_name}-release"
+		set error [catch {exec zypper product-info ${product_name}} product_info]
+		if { ${error} != 0 } {
+			printit "Problem found when looking for ${package_name} content..."
+			exit $ERROR
+		}
+		if { [regexp -all -line ".* not found.\$" $product_info] == 1 } {
+			printit "Problem found when looking for ${package_name} content..."
+			exit $ERROR
+		}
+		if { [regexp -all -line "Information for product ${product_name}:\$" $product_info] == 1 } {
+			printit "SUCCESS."
+			return 0
+		}
+	}
+	printit "FAILED (Bad contents)."
+	return 1
+}
+
 # This function validates the content of all packages.
 #
 # Return:
@@ -346,6 +384,10 @@ proc test_all_packages {} {
 			if { [test_at_compat_pkg ${file_list}] } {
 				set rc 1
 			}
+		} elseif { [string match *release* "${package}"] } {
+			if { [test_release_pkg ${file_list}] } {
+				set rc 1
+			}
 		} elseif { [string match *-dbg_* "${package}"] \
 			|| [string match *-debuginfo-* "${package}"] } {
 			if { [test_debuginfo_pkgs ${file_list}] } {
@@ -373,10 +415,19 @@ if {[info exists env(AT_WD)]} {
 	}
 } else {
 	# By now, if the test is being run on an installed package system,
-	# just bypass it.
-	printit "Skipping: this test should be run on a compatible mode at the\
-			build system.\t\[SUCCESS\]"
-	exit $ENOSYS
+	# just bypass it. Except for the release package on SUSE.
+	set distro [get_distro]
+	if { $env(AT_MAJOR_VERSION) >= 13.0 && ${distro} == "suse" } {
+		set at_full_ver [append_at_internal "$::env(AT_NAME)$::env(AT_MAJOR_VERSION)"]
+		printitcont "Testing advance-toolchain-${at_full_ver}-release contents..."
+		if { [test_release_pkg] == 0 } {
+			exit 0
+		}
+	} else {
+		printit "Skipping: this test should be run on a compatible mode at the\
+				build system.\t\[SUCCESS\]"
+		exit $ENOSYS
+	}
 }
 
 exit 1

--- a/scripts/utilities/pkg_build_monolithic.sh
+++ b/scripts/utilities/pkg_build_monolithic.sh
@@ -218,6 +218,17 @@ function build_monolithic_spec()
 				mv "${rpmspecs}/advance-toolchain_compat.spec.tmp" \
 				   "${rpmspecs}/advance-toolchain_compat.spec" || exit 1
 		fi
+
+		if [[ "$(echo "${distro_id}" | cut -d '-' -f 1)" == "suse" && -e "${config_spec}/release.spec" ]]; then
+		        echo "Prepare the release spec (SUSE only)."
+		        sed -e "$([[ -n ${build_rpm_vendor} ]] && \
+				echo "s|__RPM_VENDOR__|${build_rpm_vendor}|g" || \
+				echo "/__RPM_VENDOR__/d")" \
+			    -e "s|__TARGET_ARCH__|${build_arch}|g" \
+			    -e "s|__DISTRO_VERSION__|$(echo "${distro_id}" | cut -d '-' -f 2)|g" \
+			    "${config_spec}/release.spec" > \
+				"${rpmspecs}/advance-toolchain-release.spec"
+		fi
 	else
 		echo "For cross package builds:"
 		sed -e "s|__CROSS__|${cross}|g" "${config_spec}/monolithic_cross.spec" \

--- a/utils/install_tools.sh
+++ b/utils/install_tools.sh
@@ -55,6 +55,9 @@ install_native ()
 		if [ -e advance-toolchain-*libnxz-${version}* ]; then
 			sudo rpm -${2}v advance-toolchain-*libnxz* || return ${?}
 		fi
+		if [ -e advance-toolchain-*-release* ]; then
+			sudo rpm -${2}v advance-toolchain-*-release* || return ${?}
+		fi
 	fi
 }
 


### PR DESCRIPTION
Added a spec file to build a -release package for SLES only.
This package provides information about a product, its repository, target distro, etc.

Fix #1372

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>