### PR TITLE
Update gcc on AT next and stop applying patch

### DIFF
--- a/configs/next/packages/gcc/sources
+++ b/configs/next/packages/gcc/sources
@@ -23,7 +23,7 @@ ATSRC_PACKAGE_NAME="GCC (GNU Compiler Collection)"
 ATSRC_PACKAGE_SUBPACKAGE_NAME_0="GNU Standard C++ Library v3 (Libstdc++-v3)"
 ATSRC_PACKAGE_SUBPACKAGE_NAME_1="GNU Libgomp"
 ATSRC_PACKAGE_VER=12.0.0
-ATSRC_PACKAGE_REV=6c5fffd127ec
+ATSRC_PACKAGE_REV=efb7c51024cc
 ATSRC_PACKAGE_LICENSE="GPL 3.0"
 ATSRC_PACKAGE_DOCLINK="https://gcc.gnu.org/onlinedocs/gcc/"
 ATSRC_PACKAGE_SUBPACKAGE_DOCLINK_0="https://gcc.gnu.org/libstdc++/"
@@ -67,10 +67,6 @@ atsrc_get_patches ()
 		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/master/GCC%20PowerPC%20Backport/11/Revert-Default-to-DWARF5.patch' \
 		0cc724faa8c2db5e686d70900b323365 || return ${?}
 
-	at_get_patch \
-		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/master/GCC%20PowerPC%20Backport/11/0001-powerpc-Remove-forced-runpath-from-with-advance-tool.patch' \
-		2a4d7864672f6227f33687a834e7dca4 || return ${?}
-
 	return 0
 }
 
@@ -86,9 +82,5 @@ atsrc_apply_patches ()
 
 	patch -p1 \
 	      < Revert-Default-to-DWARF5.patch \
-		|| return ${?}
-
-	patch -p1 \
-	      < 0001-powerpc-Remove-forced-runpath-from-with-advance-tool.patch \
 		|| return ${?}
 }


### PR DESCRIPTION
Bump to revision 2f3d43a35155.

The patch to remove the forced runpath when using --with-advance-toolchain has
been merged upstream as 9598134a055e9426fa283e51dac178d11af2c668, so we don't
need to apply it off-tree anymore.

Closes #2483 