### PR TITLE
Enable follow-debug-link in binutils on AT => 15.0

### DIFF
--- a/configs/15.0/packages/binutils/stage_2
+++ b/configs/15.0/packages/binutils/stage_2
@@ -51,7 +51,6 @@ atcfg_configure() {
 						--enable-plugins \
 						--enable-install-libiberty=./ \
 						--enable-gold \
-						--enable-follow-debug-links=no \
 						${DEBUGINFOD}
 	else
 		# Configure command for cross builds
@@ -76,7 +75,6 @@ atcfg_configure() {
 						--disable-nls \
 						--enable-plugins \
 						--enable-gold \
-						--enable-follow-debug-links=no \
 						${DEBUGINFOD}
 	fi
 }

--- a/configs/next/packages/binutils/stage_2
+++ b/configs/next/packages/binutils/stage_2
@@ -51,7 +51,6 @@ atcfg_configure() {
 						--enable-plugins \
 						--enable-install-libiberty=./ \
 						--enable-gold \
-						--enable-follow-debug-links=no \
 						${DEBUGINFOD}
 	else
 		# Configure command for cross builds
@@ -76,7 +75,6 @@ atcfg_configure() {
 						--disable-nls \
 						--enable-plugins \
 						--enable-gold \
-						--enable-follow-debug-links=no \
 						${DEBUGINFOD}
 	fi
 }


### PR DESCRIPTION
The flag was disabled in 6ed6a47 to allow the tests `ck_ldds` and `systemtap` to pass.

Enabling back the flag.
Fix #2051

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>