### PR TITLE
Remove subversion from build requirement

### DIFF
--- a/configs/13.0/distros/debian-10.mk
+++ b/configs/13.0/distros/debian-10.mk
@@ -68,7 +68,7 @@ ifndef AT_DISTRO_REQ_PKGS
                           libc6-dev libbz2-dev xsltproc docbook-xsl \
                           libsqlite3-dev liblzma-dev
     AT_COMMON_PKGS_REQ := zlib1g-dev libncurses5-dev ncurses-term flex bison \
-                          texinfo subversion gawk fakeroot debhelper \
+                          texinfo gawk fakeroot debhelper \
                           autoconf rsync curl bc libxml2-utils automake \
                           dpkg-sig xutils-dev libtool wget dh-systemd \
                           docbook2x pkg-config autoconf-archive make \

--- a/configs/13.0/distros/redhat-8.mk
+++ b/configs/13.0/distros/redhat-8.mk
@@ -74,7 +74,7 @@ ifndef AT_DISTRO_REQ_PKGS
     AT_NATIVE_PKGS_REQ := libxslt docbook-style-xsl qt5-devel \
                           autogen-libopts sqlite-devel xz-devel
     AT_COMMON_PKGS_REQ := zlib-devel ncurses-devel flex bison texinfo \
-                          createrepo glibc-devel subversion gawk \
+                          createrepo glibc-devel gawk \
                           rsync curl bc automake libstdc\\+\\+-static \
                           redhat-lsb-core autoconf bzip2-[0-9] libtool-[0-9] \
                           gzip rpm-build-[0-9] rpm-sign gcc-c++ imake wget \

--- a/configs/13.0/distros/suse-15.mk
+++ b/configs/13.0/distros/suse-15.mk
@@ -73,7 +73,7 @@ ifndef AT_DISTRO_REQ_PKGS
     AT_NATIVE_PKGS_REQ := libxslt popt-devel docbook-xsl-stylesheets \
                           libbz2-devel sqlite3-devel xz-devel
     AT_COMMON_PKGS_REQ := zlib-devel ncurses-devel flex bison texinfo \
-                          createrepo_c subversion gawk autoconf rsync curl \
+                          createrepo_c gawk autoconf rsync curl \
                           bc automake rpm-build gcc-c++ xorg-x11-util-devel \
                           docbook2x wget autoconf-archive make git \
                           libffi-devel python3 systemtap-sdt-devel

--- a/configs/13.0/distros/ubuntu-18.mk
+++ b/configs/13.0/distros/ubuntu-18.mk
@@ -68,7 +68,7 @@ ifndef AT_DISTRO_REQ_PKGS
                           libc6-dev libbz2-dev xsltproc docbook-xsl \
                           libsqlite3-dev liblzma-dev
     AT_COMMON_PKGS_REQ := zlib1g-dev libncurses5-dev ncurses-term flex bison \
-                          texinfo subversion gawk fakeroot debhelper \
+                          texinfo gawk fakeroot debhelper \
                           autoconf rsync curl bc libxml2-utils automake \
                           dpkg-sig xutils-dev libtool wget dh-systemd \
                           docbook2x pkg-config autoconf-archive make \

--- a/configs/14.0/distros/ubuntu-20.mk
+++ b/configs/14.0/distros/ubuntu-20.mk
@@ -69,7 +69,7 @@ ifndef AT_DISTRO_REQ_PKGS
                           libc6-dev libbz2-dev xsltproc docbook-xsl \
                           libsqlite3-dev liblzma-dev
     AT_COMMON_PKGS_REQ := zlib1g-dev libncurses5-dev ncurses-term flex bison \
-                          texinfo subversion gawk fakeroot debhelper \
+                          texinfo gawk fakeroot debhelper \
                           autoconf rsync curl bc libxml2-utils automake \
                           dpkg-sig xutils-dev libtool wget dh-systemd \
                           docbook2x pkg-config autoconf-archive make \

--- a/configs/15.0/distros/debian-10.mk
+++ b/configs/15.0/distros/debian-10.mk
@@ -64,7 +64,7 @@ ifndef AT_DISTRO_REQ_PKGS
                           libc6-dev libbz2-dev xsltproc docbook-xsl \
                           libsqlite3-dev
     AT_COMMON_PKGS_REQ := zlib1g-dev libncurses5-dev ncurses-term flex bison \
-                          texinfo subversion gawk fakeroot debhelper \
+                          texinfo gawk fakeroot debhelper \
                           autoconf rsync curl bc libxml2-utils automake \
                           dpkg-sig xutils-dev libtool wget dh-systemd \
                           docbook2x pkg-config autoconf-archive make \

--- a/configs/15.0/distros/redhat-8.mk
+++ b/configs/15.0/distros/redhat-8.mk
@@ -70,7 +70,7 @@ ifndef AT_DISTRO_REQ_PKGS
     AT_NATIVE_PKGS_REQ := libxslt docbook-style-xsl qt5-devel \
                           autogen-libopts sqlite-devel
     AT_COMMON_PKGS_REQ := zlib-devel ncurses-devel flex bison texinfo \
-                          createrepo glibc-devel subversion gawk \
+                          createrepo glibc-devel gawk \
                           rsync curl bc automake libstdc\\+\\+-static \
                           redhat-lsb-core autoconf bzip2-[0-9] libtool-[0-9] \
                           gzip rpm-build-[0-9] rpm-sign gcc-c++ imake wget \

--- a/configs/15.0/distros/suse-15.mk
+++ b/configs/15.0/distros/suse-15.mk
@@ -69,7 +69,7 @@ ifndef AT_DISTRO_REQ_PKGS
     AT_NATIVE_PKGS_REQ := libxslt popt-devel docbook-xsl-stylesheets \
                           libbz2-devel sqlite3-devel
     AT_COMMON_PKGS_REQ := zlib-devel ncurses-devel flex bison texinfo \
-                          createrepo_c subversion gawk autoconf rsync curl \
+                          createrepo_c gawk autoconf rsync curl \
                           bc automake rpm-build gcc-c++ xorg-x11-util-devel \
                           docbook2x wget autoconf-archive make git \
                           libffi-devel python3 systemtap-sdt-devel

--- a/configs/15.0/distros/ubuntu-20.mk
+++ b/configs/15.0/distros/ubuntu-20.mk
@@ -65,7 +65,7 @@ ifndef AT_DISTRO_REQ_PKGS
                           libc6-dev libbz2-dev xsltproc docbook-xsl \
                           libsqlite3-dev
     AT_COMMON_PKGS_REQ := zlib1g-dev libncurses5-dev ncurses-term flex bison \
-                          texinfo subversion gawk fakeroot debhelper \
+                          texinfo gawk fakeroot debhelper \
                           autoconf rsync curl bc libxml2-utils automake \
                           dpkg-sig xutils-dev libtool wget dh-systemd \
                           docbook2x pkg-config autoconf-archive make \


### PR DESCRIPTION
Since fda478d, subversion is no longer required to build AT >= 13.0.
Fix #2442

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>