### PR TITLE
Remove array-bounds flag on AT next

### DIFF
--- a/configs/15.0/packages/glibc/stage_1
+++ b/configs/15.0/packages/glibc/stage_1
@@ -154,8 +154,7 @@ atcfg_configure()
 		AUTOCONF="${autoconf}" \
 		CC="${at_dest}/bin/gcc -m${AT_BIT_SIZE}" \
 		CFLAGS="-g -O2 ${secure_plt:+-msecure-plt} \
-			-Wno-error=maybe-uninitialized \
-			-Wno-error=array-bounds" \
+			-Wno-error=maybe-uninitialized" \
 		CXX="/bin/false" \
 		libc_cv_forced_unwind="yes" \
 		libc_cv_c_cleanup="yes" \
@@ -185,8 +184,7 @@ atcfg_configure()
 		AUTOCONF="${autoconf}" \
 		CC="${at_dest}/bin/${target64:-${target}}-gcc -m${AT_BIT_SIZE}" \
 		CFLAGS="-g -O2 \
-			-Wno-error=maybe-uninitialized \
-			-Wno-error=array-bounds" \
+			-Wno-error=maybe-uninitialized" \
 		CPPFLAGS="-isystem $(pwd)/systemtap" \
 		CXX="/bin/false" \
 		AR="${at_dest}/bin/${target}-ar" \

--- a/configs/15.0/packages/glibc/stage_2
+++ b/configs/15.0/packages/glibc/stage_2
@@ -95,8 +95,7 @@ atcfg_configure() {
 	CXX="${at_dest}/bin/g++ -m${AT_BIT_SIZE}" \
 	CFLAGS="-g -O3 \
 		${with_longdouble:+-mlong-double-128} \
-		-Wno-error=maybe-uninitialized \
-		-Wno-error=array-bounds" \
+		-Wno-error=maybe-uninitialized" \
 	CPPFLAGS="-isystem $(pwd)/systemtap" \
 	CXXFLAGS="-g -O3" \
 	${ATSRC_PACKAGE_WORK}/configure --build=${host} \

--- a/configs/15.0/packages/glibc/stage_optimized
+++ b/configs/15.0/packages/glibc/stage_optimized
@@ -84,8 +84,7 @@ atcfg_configure() {
 	CXX="${at_dest}/bin/g++ -m${AT_BIT_SIZE}" \
 	CFLAGS="-g -O3 \
 		${with_longdouble:+-mlong-double-128} \
-		-Wno-error=maybe-uninitialized \
-		-Wno-error=array-bounds" \
+		-Wno-error=maybe-uninitialized" \
 	CXXFLAGS="-g -O3" \
 	${ATSRC_PACKAGE_WORK}/configure --build=${target} \
 					--host=${base_target} \

--- a/configs/next/packages/binutils/stage_2
+++ b/configs/next/packages/binutils/stage_2
@@ -32,7 +32,7 @@ atcfg_configure() {
 		# Configure command for native builds
 		CC=${at_dest}/bin/gcc \
 		CXX=${at_dest}/bin/g++ \
-		CFLAGS="-g -O2 -Wno-error=array-bounds -Wno-error=address" \
+		CFLAGS="-g -O2 -Wno-error=address" \
 		CXXFLAGS="-g -O2" \
 		${ATSRC_PACKAGE_WORK}/configure --build=${host} \
 						--host=${target} \


### PR DESCRIPTION
b3ca16e and a46a9c8 added `-Wno-error=array-bounds` to glibc and binutils on AT next.
Removing it.

Fix #2243

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>