### PR TITLE
Update libnxz on AT next

### DIFF
--- a/configs/next/packages/libnxz/sources
+++ b/configs/next/packages/libnxz/sources
@@ -21,7 +21,7 @@
 
 ATSRC_PACKAGE_NAME="NX GZIP library"
 ATSRC_PACKAGE_VER="v0.61"
-ATSRC_PACKAGE_REV=6fcbaac93c4f
+ATSRC_PACKAGE_REV=9fdc30c0cca8
 ATSRC_PACKAGE_BRANCH=develop
 ATSRC_PACKAGE_LICENSE="Apache License 2.0 and GPL 2.0"
 ATSRC_PACKAGE_DOCLINK="https://github.com/libnxz/power-gzip/wiki"

--- a/configs/next/packages/libnxz/stage_1
+++ b/configs/next/packages/libnxz/stage_1
@@ -1,1 +1,79 @@
-../../../15.0/packages/libnxz/stage_1
+#!/usr/bin/env bash
+#
+# Copyright 2020 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+source ${AT_BASE}/scripts/utilities/bitsize_selection.sh
+
+# NX GZIP library build parameters for stage 1  64 bits
+# ======================================================================
+#
+
+# Tell the build system to hold the temp install folder
+ATCFG_HOLD_TEMP_INSTALL='no'
+# Tell the build system to hold the temp build folder
+ATCFG_HOLD_TEMP_BUILD='no'
+# Build in the same directory
+ATCFG_BUILD_STAGE_T='link'
+
+atcfg_pre_configure() {
+	# The bin and lib directories depend on the word size, e.g.
+	# configure_bindir may be set to bin, bin32, or bin64.
+	configure_libdir=${configure_prefix}/$(find_build_libdir ${AT_BIT_SIZE})
+}
+
+atcfg_configure() {
+	# libnxz do not use autoconf
+	${SUB_MAKE} clean
+	# Hack to get the version outside the git repository.
+	cat lib/Makefile | \
+		sed "s/git describe --tags | cut -d - -f 1,2 | tr - ./echo ${ATSRC_PACKAGE_VER}/" \
+		> lib/Makefile.temp
+        [[ ${?} -eq 0 ]] && mv lib/Makefile.temp lib/Makefile || exit 1
+}
+
+atcfg_make() {
+	# In gcc10 the default is now -fno-common. In order to not have multiple
+	# definitions -fcommon is needed.
+	configure_cc="${at_dest}/bin/${target64:-${target}}-gcc"
+	PATH="${at_dest}/bin:${PATH}" \
+	${SUB_MAKE} \
+	CC="${configure_cc} -m${AT_BIT_SIZE}" \
+	FLG="-std=gnu11 -fcommon -g"
+}
+
+atcfg_make_check() {
+	# Package testing is not done on a cross build.
+	if [[ "${cross_build}" == 'no' ]]; then
+		PATH=${at_dest}/bin:${PATH} ${SUB_MAKE} check
+	fi
+}
+
+atcfg_pre_install() {
+	if [[ "${cross_build}" == "yes" ]]; then
+		install_dir="${install_transfer_cross}/usr"
+	else
+		install_dir="${install_transfer}"
+	fi
+}
+
+
+atcfg_install() {
+	PATH="${at_dest}/bin:${PATH}" \
+	PREFIX="${install_dir}" \
+	LIBDIR="${install_dir}/${configure_libdir}/" \
+	${SUB_MAKE} install
+}
+

--- a/configs/next/packages/libnxz/stage_1
+++ b/configs/next/packages/libnxz/stage_1
@@ -29,29 +29,45 @@ ATCFG_HOLD_TEMP_BUILD='no'
 ATCFG_BUILD_STAGE_T='link'
 
 atcfg_pre_configure() {
+	configure_host=$(find_build_target ${AT_BIT_SIZE})
+	if [[ "${cross_build}" == 'no' ]]; then
+		configure_build=${configure_host}
+	else
+		configure_build=${host}
+	fi
+
+	if [[ "${cross_build}" == "yes" ]]; then
+	    install_dir="${install_transfer_cross}/usr"
+	else
+	    install_dir="${install_transfer}"
+	fi
+
 	# The bin and lib directories depend on the word size, e.g.
 	# configure_bindir may be set to bin, bin32, or bin64.
-	configure_libdir=${configure_prefix}/$(find_build_libdir ${AT_BIT_SIZE})
+	configure_libdir=${install_dir}/$(find_build_libdir ${AT_BIT_SIZE})
 }
 
 atcfg_configure() {
-	# libnxz do not use autoconf
-	${SUB_MAKE} clean
-	# Hack to get the version outside the git repository.
-	cat lib/Makefile | \
-		sed "s/git describe --tags | cut -d - -f 1,2 | tr - ./echo ${ATSRC_PACKAGE_VER}/" \
-		> lib/Makefile.temp
-        [[ ${?} -eq 0 ]] && mv lib/Makefile.temp lib/Makefile || exit 1
+	if [[ "${cross_build}" == "yes" ]]; then
+		at_ar="${at_dest}/bin/${target}-ar"
+	else
+		at_ar="${at_dest}/bin/ar"
+	fi
+
+	# In gcc10 the default is now -fno-common. In order to not have multiple
+	# definitions -fcommon is needed.
+	AR="${at_ar}" \
+	CC="${at_dest}/bin/${target64:-${target}}-gcc" \
+	CFLAGS="-O3 -g -std=gnu11 -fcommon -m${AT_BIT_SIZE}" \
+	${ATSRC_PACKAGE_WORK}/configure --build="${configure_build}" \
+					--host="${configure_host}" \
+					--prefix="${install_dir}" \
+					--libdir="${configure_libdir}"
 }
 
 atcfg_make() {
-	# In gcc10 the default is now -fno-common. In order to not have multiple
-	# definitions -fcommon is needed.
-	configure_cc="${at_dest}/bin/${target64:-${target}}-gcc"
 	PATH="${at_dest}/bin:${PATH}" \
-	${SUB_MAKE} \
-	CC="${configure_cc} -m${AT_BIT_SIZE}" \
-	FLG="-std=gnu11 -fcommon -g"
+	${SUB_MAKE}
 }
 
 atcfg_make_check() {
@@ -61,19 +77,7 @@ atcfg_make_check() {
 	fi
 }
 
-atcfg_pre_install() {
-	if [[ "${cross_build}" == "yes" ]]; then
-		install_dir="${install_transfer_cross}/usr"
-	else
-		install_dir="${install_transfer}"
-	fi
-}
-
-
 atcfg_install() {
 	PATH="${at_dest}/bin:${PATH}" \
-	PREFIX="${install_dir}" \
-	LIBDIR="${install_dir}/${configure_libdir}/" \
 	${SUB_MAKE} install
 }
-


### PR DESCRIPTION
Bump to revision 9fdc30c0cca8

libnxz has recently started using autoconf, so build commands had to be changed
accordingly.

Closes #2533