### PR TITLE
fvtr: Ignore stderror from readelf

### DIFF
--- a/fvtr/ck_ldds/ck_ldds.exp
+++ b/fvtr/ck_ldds/ck_ldds.exp
@@ -62,7 +62,9 @@ set executables [ exec find $at_dir -type f -perm /111 | \
 			grep -Ev "\.debug$" ]
 foreach exe $executables {
 	if { [is_dynlink ${exe}] } {
-		set interp_info [exec ${at_dir}/bin/readelf -l ${exe}]
+		set interp_info [exec -ignorestderr \
+				     ${at_dir}/bin/readelf -l ${exe} \
+				     2>/dev/null]
 		if { [regexp -line "interpreter: (.*)\]$" ${interp_info} match \
 			  interpreter]} {
 			set interpreter2 [file normalize ${interpreter}]

--- a/fvtr/systemtap/systemtap.exp
+++ b/fvtr/systemtap/systemtap.exp
@@ -27,7 +27,8 @@ if { $env(AT_MAJOR_VERSION) < 11.0 } {
 proc check_systemtap {readelf lib} {
 	global WARNING
 	global ERROR
-	if {[catch {exec $readelf --notes $lib | grep stapsdt}]} {
+	if {[catch {exec -ignorestderr -- \
+			$readelf --notes $lib 2>/dev/null | grep stapsdt}]} {
 		printit "Could not find systemtap probes in $lib" $ERROR
 		return 1
 	} else {


### PR DESCRIPTION
The exec command in Tcl treats output in stderror as errors, causing
false positive failures when a warning is printed.