### PR TITLE
Fixes glibc_1 build for AT 12.0 on SLES 12

### DIFF
--- a/configs/11.0/packages/glibc/stage_1
+++ b/configs/11.0/packages/glibc/stage_1
@@ -153,7 +153,7 @@ atcfg_configure()
 	if [[ "${cross_build}" == "no" ]]; then
 		AUTOCONF="${autoconf}" \
 		CC="${at_dest}/bin/gcc -m${AT_BIT_SIZE}" \
-		CFLAGS="-g -O2 ${secure_plt:+-msecure-plt}" \
+		CFLAGS="-g -O2 ${secure_plt:+-msecure-plt} -Wno-error=attribute-alias" \
 		CXX="/bin/false" \
 		libc_cv_forced_unwind="yes" \
 		libc_cv_c_cleanup="yes" \


### PR DESCRIPTION
Ignore errors that the SLES 12 compiler started to report.