### PR TITLE
Diverge expat on AT 15.0 from AT next

### DIFF
--- a/configs/15.0/packages/expat/sources
+++ b/configs/15.0/packages/expat/sources
@@ -1,1 +1,43 @@
-../../../next/packages/expat/sources
+#!/usr/bin/env bash
+#
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# GLIBC source package and build info
+# ===================================
+#
+
+ATSRC_PACKAGE_NAME="Expat XML Parser"
+ATSRC_PACKAGE_VER=2.4.3
+ATSRC_PACKAGE_REV=1e1b52be2d9e
+ATSRC_PACKAGE_DOCLINK="https://libexpat.github.io/doc/"
+ATSRC_PACKAGE_RELFIXES=
+ATSRC_PACKAGE_STR_VER="${ATSRC_PACKAGE_NAME} ${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
+ATSRC_PACKAGE_VERID="${ATSRC_PACKAGE_VER}${ATSRC_PACKAGE_REV:+-${ATSRC_PACKAGE_REV}}"
+ATSRC_PACKAGE_LICENSE="MIT License"
+ATSRC_PACKAGE_PRE="test -d expat-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
+ATSRC_PACKAGE_CO=([0]="git clone https://github.com/libexpat/libexpat.git expat")
+ATSRC_PACKAGE_GIT="git checkout -b expat-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV} ${ATSRC_PACKAGE_REV}"
+ATSRC_PACKAGE_POST="mv expat expat-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}"
+ATSRC_PACKAGE_SRC=${AT_BASE}/sources/expat-${ATSRC_PACKAGE_VER}-${ATSRC_PACKAGE_REV}/expat
+ATSRC_PACKAGE_WORK=${AT_WORK_PATH}/expat
+ATSRC_PACKAGE_MLS=
+ATSRC_PACKAGE_PATCHES=
+ATSRC_PACKAGE_ALOC=
+ATSRC_PACKAGE_TARS=
+ATSRC_PACKAGE_MAKE_CHECK=
+ATSRC_PACKAGE_DISTRIB=no
+ATSRC_PACKAGE_BUNDLE=main_toolchain
+ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://raw.githubusercontent.com/libexpat/libexpat/__REVISION__/expat/lib/expat.h" | grep "XML_M.*_VERSION" | sed "s/^.*VERSION //" | paste -d "." - - -'


### PR DESCRIPTION
expat 2.4.3 has been released and will be distributed on AT 15.0.
AT next will continue to track expat master branch.

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>