### PR TITLE
Ignore test_tarfile Python test for older releases

### DIFF
--- a/fvtr/python/python.exp
+++ b/fvtr/python/python.exp
@@ -93,6 +93,12 @@ if { [lindex $pyverl 0] > 3
 }
 
 if { [lindex $pyverl 0] < 3
+     || ([lindex $pyverl 0] == 3 && [lindex $pyverl 1] <= 7) } {
+	# Fails if run on tmpfs.
+	append common_exclude_tests " test_tarfile"
+}
+
+if { [lindex $pyverl 0] < 3
      || ([lindex $pyverl 0] == 3 && [lindex $pyverl 1] <= 6) } {
 	# Fails if run from the install dir.
 	append common_exclude_tests " test_distutils"


### PR DESCRIPTION
This test is known to fail if run on tmpfs on ppc64 [1]. It was fixed
for Python 3.8, which maps to AT 14, so it will fail for any versions
prior to that when tmpfs is used (like inside a container).

[1] https://bugs.python.org/issue35772

Signed-off-by: Matheus Castanho <msc@linux.ibm.com>
