### PR TITLE
Fix installation fail of some packages in at-docker

### DIFF
--- a/configs/15.0/packages/glibc/stage_2
+++ b/configs/15.0/packages/glibc/stage_2
@@ -118,7 +118,14 @@ atcfg_configure() {
 
 # Make build command
 atcfg_make() {
-	PATH=${at_dest}/bin:${PATH} ${SUB_MAKE}
+	
+	if [[ ("${distro_fm}" == "ubuntu") || ("${distro_fm}" == "debian") ]]; then
+			user_defined_dir='user-defined-trusted-dirs=/lib/powerpc64le-linux-gnu:/usr/lib/powerpc64le-linux-gnu'			
+	else
+			user_defined_dir='user-defined-trusted-dirs=/lib64:/usr/lib64'          
+	fi
+
+	PATH=${at_dest}/bin:${PATH} ${SUB_MAKE} ${user_defined_dir}			
 }
 
 # Conditional install build command


### PR DESCRIPTION
Compile glibc with “user-defined-trusted-dirs” option to add
standard system libraries to paths that dynamic loader searchs for.
These paths will be the last in the order that dynamic loader will
look for( after  AT libraries paths )

Fixes issue #2888

Signed-off-by: Fabiane Watanabe <fabiane.watanabe@ibm.com>