### PR TITLE
Improve install_tools script

### DIFF
--- a/utils/install_tools.sh
+++ b/utils/install_tools.sh
@@ -275,6 +275,9 @@ testsuite ()
 		export DHRY_TEST_DIR="$HOME/dhrystone/"
 	fi
 
+	# Set AT_BASE if not defined.
+	# AT_BASE is needed by some FVTR scripts.
+	printenv AT_BASE >/dev/null || export AT_BASE=$(pwd)
 	cd fvtr
 	bash fvtr.sh -f ${config}
 }


### PR DESCRIPTION
`AT_BASE` is needed by some FVTR scripts, but `AT_BASE` is not defined when FVTR
scripts are called by the `install_tools.sh` script (with the `testsuite` command).

This patch set `AT_BASE` if it's not defined before running FVTR.

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>