### PR TITLE
Stop collecting logs by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -825,7 +825,6 @@ build_targets :=
 .PHONY: all test destclean cleanall clean collect clone edit pack
 
 all: package release
-	$(call collect_logs)
 
 test: fvtr tarball_test
 


### PR DESCRIPTION
Today Make builds a tar.gz file with all the build logs by default, but
this is not always necessary/useful. Users that want to keep the same
behavior can use 'make collect' in addition to the normal build + test
steps from now on.

Signed-off-by: Matheus Castanho <msc@linux.ibm.com>
