### PR TITLE
Fix the content of the release package (SLES)

### DIFF
--- a/configs/13.0/base.mk
+++ b/configs/13.0/base.mk
@@ -51,3 +51,6 @@ AT_MAJOR_VERSION := 13.0
 AT_REVISION_NUMBER := 6
 AT_INTERNAL := none
 AT_PREVIOUS_VERSION := 12.0
+
+# Set the last day of support for this AT version.
+AT_END_OF_LIFE := 2022-08-31

--- a/configs/13.0/specs/release.spec
+++ b/configs/13.0/specs/release.spec
@@ -13,9 +13,12 @@
 # limitations under the License.
 #
 
-# Per convention the %%product name will be used a stem for the -release
-# package and the -prod file
-%define         product advance-toolchain-%{at_major}
+# The product is called 'ibm-power-advance-toolchain' in SCC.
+%define         product ibm-power-advance-toolchain
+
+# Per convention the %%package name will be used a stem for the -release
+# package.
+%define         package advance-toolchain-%{at_major}
 
 # Decide: The products version and release often follows the release package.
 # In this case use the -release packages %%{version} and %%{release}. But
@@ -27,15 +30,15 @@
 # The date when this Product goes out of support. A missing value indicates
 # that there will be no EOL, while an empty/invalid value indicates that
 # there will be an EOL date, but it's not yet known.
-%define         productendoflife ""
-%define         productendoflifel_pcescaped %{productendoflife}
+%define         productendoflife __AT_END_OF_LIFE__
+%define         productendoflife_pcescaped __AT_END_OF_LIFE_ESCAPED__
 
 %define         producturlbugtracker https://github.com/advancetoolchain/advance-toolchain/issues/
 %define         producturlbugtracker_pcescaped https%3A%2F%2Fgithub.com%2Fadvancetoolchain%2Fadvance%2Dtoolchain%2Fissues%2F
 
 # ----------------------------------------------------------------------
 
-Name:           %{product}-release
+Name:           %{package}-release
 Summary:        Advance Toolchain
 Version:        %{productversion}
 Release:        %{productrelease}
@@ -54,6 +57,7 @@ Provides:       product-url(bugtracker) = %{producturlbugtracker_pcescaped}
 # ----------------------------------------------------------------------
 
 Requires:       product(SUSE_SLE) >= __DISTRO_VERSION__
+Suggests:       %{package}-runtime
 AutoReqProv:    no
 
 %description
@@ -78,7 +82,7 @@ cat >$RPM_BUILD_ROOT/etc/products.d/%{product}.prod << EOF
   <patchlevel>0</patchlevel>
   <predecessor>sle-sdk</predecessor>
   <release>%{productrelease}</release>
-  <endoflife>%{productendoflife_pcescaped}</endoflife>
+  <endoflife>%{productendoflife}</endoflife>
   <arch>__TARGET_ARCH__</arch>
   <summary>Advance Toolchain</summary>
   <description>

--- a/configs/14.0/base.mk
+++ b/configs/14.0/base.mk
@@ -51,3 +51,6 @@ AT_MAJOR_VERSION := 14.0
 AT_REVISION_NUMBER := 5
 AT_INTERNAL := none
 AT_PREVIOUS_VERSION := 13.0
+
+# Set the last day of support for this AT version.
+AT_END_OF_LIFE := 2023-08-31

--- a/configs/15.0/base.mk
+++ b/configs/15.0/base.mk
@@ -56,3 +56,6 @@ AT_PREVIOUS_VERSION := 14.0
 # i.e. minimum kernel version required in order to run software linked to this
 # AT version.
 AT_KERNEL := 4.12.14
+
+# Set the last day of support for this AT version.
+AT_END_OF_LIFE := 2024-08-31

--- a/configs/16.0/base.mk
+++ b/configs/16.0/base.mk
@@ -56,3 +56,6 @@ AT_PREVIOUS_VERSION := 15.0
 # i.e. minimum kernel version required in order to run software linked to this
 # AT version.
 AT_KERNEL := 4.12.14
+
+# Set the last day of support for this AT version.
+AT_END_OF_LIFE := 2025-08-31

--- a/fvtr/package-check/package-check.exp
+++ b/fvtr/package-check/package-check.exp
@@ -315,14 +315,15 @@ proc test_debuginfo_pkgs { file_list } {
 proc test_release_pkg {{file_list {}}} {
 	global ERROR
 
-	set product_name [append_at_internal "advance-toolchain-$::env(AT_NAME)$::env(AT_MAJOR_VERSION)"]
+	set product_name "ibm-power-advance-toolchain"
 	if { [llength $file_list] > 0 } {
 		if { [regexp -all -line ".*/${product_name}.prod\$" $file_list] == 1 } {
 			printit "SUCCESS."
 			return 0
 		}
 	} else {
-		set package_name "${product_name}-release"
+		set package_name [append_at_internal "advance-toolchain-$::env(AT_NAME)$::env(AT_MAJOR_VERSION)"]
+		set package_name "${package_name}-release"
 		set error [catch {exec zypper product-info ${product_name}} product_info]
 		if { ${error} != 0 } {
 			printit "Problem found when looking for ${package_name} content..."

--- a/scripts/helpers/utilities.mk
+++ b/scripts/helpers/utilities.mk
@@ -140,6 +140,8 @@ define std_setenv
     export at_ver_rev_internal=$(AT_VER_REV_INTERNAL); \
     echo "  - Setting at_dir_name to $(AT_DIR_NAME)"; \
     export at_dir_name=$(AT_DIR_NAME); \
+    echo "  - Setting at_end_of_life to $(AT_END_OF_LIFE)"; \
+    export at_end_of_life=$(AT_END_OF_LIFE); \
     echo "  - Setting at_use_fedora_relnam to $(AT_USE_FEDORA_RELNAM)"; \
     export at_use_fedora_relnam=$(AT_USE_FEDORA_RELNAM); \
     echo "  - Setting kernel to $(AT_KERNEL)"; \

--- a/scripts/utilities/pkg_build_monolithic.sh
+++ b/scripts/utilities/pkg_build_monolithic.sh
@@ -224,6 +224,8 @@ function build_monolithic_spec()
 		        sed -e "$([[ -n ${build_rpm_vendor} ]] && \
 				echo "s|__RPM_VENDOR__|${build_rpm_vendor}|g" || \
 				echo "/__RPM_VENDOR__/d")" \
+			    -e "s|__AT_END_OF_LIFE__|${at_end_of_life}|g" \
+			    -e "s|__AT_END_OF_LIFE_ESCAPED__|$(echo "${at_end_of_life}" | sed "s/-/%2D/g")|g" \
 			    -e "s|__TARGET_ARCH__|${build_arch}|g" \
 			    -e "s|__DISTRO_VERSION__|$(echo "${distro_id}" | cut -d '-' -f 2)|g" \
 			    "${config_spec}/release.spec" > \


### PR DESCRIPTION
Updated the name of the product based on this comment[1].
The end of life in the spec file wasn't correct. Fixed this
and added an AT variable with the end of life for each AT version.

[1] https://bugzilla.linux.ibm.com/show_bug.cgi?id=193326#c11

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>