### PR TITLE
Fix SLES release package for AT next

### DIFF
--- a/configs/next/base.mk
+++ b/configs/next/base.mk
@@ -57,3 +57,7 @@ AT_DIR_NAME := at-next-$(AT_MAJOR_VERSION)-$(AT_REVISION_NUMBER)-$(AT_INTERNAL)
 # i.e. minimum kernel version required in order to run software linked to this
 # AT version.
 AT_KERNEL := 4.12.14
+
+# Set the last day of support for this AT version.
+# Update it every year for the new AT release.
+AT_END_OF_LIFE := 2026-08-31


### PR DESCRIPTION
In 6e82c00a, the end of life date for AT next was missing.
Added it in this patch.

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>