### PR TITLE
Add a group for libnxz

### DIFF
--- a/configs/14.0/packages/groups
+++ b/configs/14.0/packages/groups
@@ -28,6 +28,7 @@
 #* devel: Development tools
 #* profile: Additional performance and debugging tools
 #* mcore-libs: Additional multi core support libraries
+#* libnxz: POWER NX zlib compliant library
 
 # This filters below are used to isolate toolchain devel and runtime files where
 # propriate. They are arrays of *Extended* Regular Expressions (ERE).

--- a/configs/14.0/packages/groups
+++ b/configs/14.0/packages/groups
@@ -1,1 +1,68 @@
-../../13.0/packages/groups
+#!/bin/bash
+#
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+#
+#
+#
+#
+
+# The following lines containintg #* at the beginning should remain as is, and
+# be replicated when this file is cloned, or new groups are added.
+
+#* main_toolchain: Base toolchain packages
+#* toolchain_extra: Additional support libraries, including some additional floating point support libraries
+#* devel: Development tools
+#* profile: Additional performance and debugging tools
+#* mcore-libs: Additional multi core support libraries
+
+# This filters below are used to isolate toolchain devel and runtime files where
+# propriate. They are arrays of *Extended* Regular Expressions (ERE).
+
+# Filters to use on runtime package file exclusion (sed ERE)
+runtime_exclude=('/^.*\.a$/d' \
+                 '/^.*\/bin\/([^epw]|p[^iy]|e[^a]).*$/d' \
+                 '/^.*\/sbin\/([^l]|l[^d]).*$/d' \
+                 '/^.*\/include\/.*$/d' \
+                 '/^.*\/share\/info\/.*$/d' \
+                 '/^.*\/share\/modules\/.*$/d' \
+                 '/^.*\/pkgconfig\/.*$/d'\
+                 '/^.*\.o$/d' \
+                 '/^.*\.la$/d' \
+                 '/^.*\.spec$/d' \
+                 '/^.*\.gox$/d' \
+                 '/^.*\/lib64\/python[0-9].[0-9]\/test\/.*$/d')
+
+# Filters to use on runtime package file inclusion (grep ERE)
+runtime_include=
+
+# Filters to use on devel package file exclusion (sed ERE)
+devel_exclude=('/^.*\/sbin\/ldconfig$/d' \
+               '/^.*\/bin\/watch_ldconfig$/d')
+
+# Filters to use on devel package file inclusion (grep ERE)
+devel_include=('^.*\.a$' \
+               '^.*\/bin\/([^ep]|p[^iy]|e[^a]).*$' \
+               '^.*\/sbin\/.*$' \
+               '^.*\/include\/.*$' \
+               '^.*\/share\/info\/.*$' \
+               '^.*\/share\/modules\/.*$' \
+               '^.*\/pkgconfig\/.*$'\
+               '^.*\.o$' \
+               '^.*\.la$' \
+               '^.*\.spec$' \
+               '^.*\.gox$' \
+               '^.*\/lib64\/python[0-9].[0-9]\/test\/.*$')


### PR DESCRIPTION
Created a group so `libnxz` will appear in the release notes.

Fix #2887 

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>