### PR TITLE
Update golang bootstrap version on AT 12.0

### DIFF
--- a/configs/12.0/packages/golang/sources
+++ b/configs/12.0/packages/golang/sources
@@ -45,6 +45,6 @@ atsrc_get_patches ()
 	# Reuse the build from the community in order to bootstrap our own
 	# build.
 	at_get_patch \
-		https://storage.googleapis.com/golang/go1.8.1.linux-ppc64le.tar.gz \
-		8c74ee3647048c3e18802a901821e270 || return ${?}
+		https://go.dev/dl/go1.10.8.linux-ppc64le.tar.gz \
+		03c56f26066607d0bdaec59565761c17 || return ${?}
 }

--- a/configs/12.0/packages/golang/stage_1
+++ b/configs/12.0/packages/golang/stage_1
@@ -43,7 +43,7 @@ atcfg_configure ()
 {
 
 	mkdir -p ${bootstrap} && pushd $_
-	tar -zxf ${ATSRC_PACKAGE_WORK}/go1.8.1.linux-ppc64le.tar.gz --strip-components 1
+	tar -zxf ${ATSRC_PACKAGE_WORK}/go1.10.8.linux-ppc64le.tar.gz --strip-components 1
 	popd
 }
 


### PR DESCRIPTION
Start using golang 1.10.8 as the original compiler for building golang
on AT 12.0.
This fixes an issue that started to be reproduced on Linux 5.18 and was
fixed in golang 1.10.

Signed-off-by: Tulio Magno Quites Machado Filho <tuliom@linux.ibm.com>