### PR TITLE
Add a third ldconfig stage

### DIFF
--- a/configs/12.0/packages/boost/boost.mk
+++ b/configs/12.0/packages/boost/boost.mk
@@ -23,7 +23,7 @@ boost: $(RCPTS)/boost_1.rcpt
 3rdparty_libs-reqs += $(RCPTS)/boost_1.rcpt
 
 ifeq ($(CROSS_BUILD),no)
-        boost-deps-64 := python_1.b
+        boost-deps-64 := python_1.b ldconfig_3
 endif
 
 $(RCPTS)/boost_1.rcpt: $(boost_1-archdeps)

--- a/configs/12.0/packages/gdb/gdb.mk
+++ b/configs/12.0/packages/gdb/gdb.mk
@@ -18,7 +18,7 @@ $(eval $(call set_provides,gdb_1,single,cross_yes))
 
 gdb-deps :=
 ifeq ($(CROSS_BUILD),no)
-    gdb-deps := python_1
+    gdb-deps := python_1 ldconfig_3
 endif
 
 gdb_1: $(RCPTS)/gdb_1.rcpt

--- a/scripts/helpers/utilities.mk
+++ b/scripts/helpers/utilities.mk
@@ -414,7 +414,7 @@ define prepare_loader_cache
             echo "/usr/local/lib64"           >> "$(DYNAMIC_LOAD)/sys64.ld.conf"; \
         fi; \
     fi; \
-    if [[ $1 -eq 2 ]]; then \
+    if [[ $1 -ge 2 ]]; then \
         for CPU in $(TUNED_PROCESSORS); do \
             if [[ -n "$(TARGET32)" ]]; then \
                 echo "$(AT_DEST)/lib/$${CPU}"       >> "$(DYNAMIC_LOAD)/at32.ld.conf"; \
@@ -458,7 +458,7 @@ define prepare_loader_cache
     "$(AT_DEST)/sbin/ldconfig"; \
     if [[ $1 -eq 1 ]]; then \
         touch "$(AT_DEST)/lib64/syslib-override"; \
-    else \
+    elif [[ $1 -eq 2 ]]; then \
         find "$(AT_DEST)/lib64/glibc-hwcaps" ! -type d \
              ! -newer "$(AT_DEST)/lib64/syslib-override" \
              -exec rm -f '{}' \;; \


### PR DESCRIPTION
Python build libraries that are expected to be used later when building
other packages. In order to run programs built with the new python
libraries, these libraries must be included in the loader cache,
requiring an extra stage for ldconfig.

Signed-off-by: Tulio Magno Quites Machado Filho <tuliom@linux.ibm.com>