### PR TITLE
Disable cachemanager service setup on containers

### DIFF
--- a/configs/13.0/deb/monolithic/runtime.postinst
+++ b/configs/13.0/deb/monolithic/runtime.postinst
@@ -24,7 +24,8 @@ if [[ "${1}" == configure ]]; then
 	[[ -f __AT_DEST__/sbin/ldconfig ]] && __AT_DEST__/sbin/ldconfig
 fi
 
-if [[ "__USE_SYSTEMD__" == "yes" && -n "$(command -v systemctl)" ]]; then
+if [[ "__USE_SYSTEMD__" == "yes" && -n "$(command -v systemctl)"\
+	&& "$(systemctl is-system-running)" != "offline" ]]; then
 	systemctl --no-reload preset __AT_VER_ALTERNATIVE__-cachemanager.service \
 	    > /dev/null 2>&1 || :
 	systemctl restart __AT_VER_ALTERNATIVE__-cachemanager.service || \

--- a/configs/13.0/deb/monolithic/runtime.prerm
+++ b/configs/13.0/deb/monolithic/runtime.prerm
@@ -17,7 +17,8 @@
 
 if [[ "${1}" == remove ]]; then
 	# Stop and disable the cache manager service to remove symlinks.
-	if [[ "__USE_SYSTEMD__" == "yes" && -n "$(command -v systemctl)" ]]; then
+	if [[ "__USE_SYSTEMD__" == "yes" && -n "$(command -v systemctl)"\
+		&& "$(systemctl is-system-running)" != "offline" ]]; then
 		systemctl stop __AT_VER_ALTERNATIVE__-cachemanager.service
 		systemctl disable __AT_VER_ALTERNATIVE__-cachemanager.service
 	fi

--- a/configs/14.0/specs/monolithic.spec
+++ b/configs/14.0/specs/monolithic.spec
@@ -263,7 +263,7 @@ fi
 # Automatically set the timezone
 rm -f %{_prefix}/etc/localtime
 ln -s /etc/localtime %{_prefix}/etc/localtime
-if [[ -n "$(command -v systemctl)" ]]; then
+if [[ -n "$(command -v systemctl)" && "$(systemctl is-system-running)" != "offline" ]]; then
 	systemctl preset %{at_ver_alternative}-cachemanager.service \
 	    > /dev/null 2>&1 || :
 	systemctl restart %{at_ver_alternative}-cachemanager.service
@@ -433,9 +433,10 @@ fi
 
 #---------------------------------------------------
 %preun runtime
-command -v systemctl >/dev/null && systemctl --no-reload disable --now \
+if [[ -n "$(command -v systemctl)" && "$(systemctl is-system-running)" != "offline" ]]; then
+    systemctl --no-reload disable --now \
     %{at_ver_alternative}-cachemanager.service > /dev/null 2>&1 || :
-
+fi
 ####################################################
 %postun runtime
 # Remove the directory only when uninstalling
@@ -452,9 +453,11 @@ if file /usr/sbin/ldconfig | grep "bash script" > /dev/null; then
         rm -f /usr/sbin/ldconfig
     fi
 fi
-command -v systemctl >/dev/null &&  systemctl try-restart %{at_ver_alternative}-cachemanager.service >/dev/null \
-    2>&1 || :
 
+if [[ -n "$(command -v systemctl)" && "$(systemctl is-system-running)" != "offline" ]]; then
+    systemctl try-restart %{at_ver_alternative}-cachemanager.service >/dev/null \
+    2>&1 || :
+fi
 #---------------------------------------------------
 %postun devel
 if [ "$1" = 0 ]; then


### PR DESCRIPTION
Podman/docker containers don't necessarily have systemd enabled so
AT installation on such systems fails when trying to setup the cachemanager
service. Simply don't try to setup the service when inside a container for now.

Signed-off-by: Fabiane Watanabe <fabiane.watanabe@ibm.com>