### PR TITLE
Update zlib on AT next

### DIFF
--- a/configs/next/packages/zlib/sources
+++ b/configs/next/packages/zlib/sources
@@ -21,7 +21,7 @@
 
 ATSRC_PACKAGE_NAME="ZLIB Compression Library"
 ATSRC_PACKAGE_VER=master
-ATSRC_PACKAGE_REV=21767c654d31
+ATSRC_PACKAGE_REV=04f42ceca40f
 ATSRC_PACKAGE_LICENSE="Zlib License"
 ATSRC_PACKAGE_DOCLINK="http://www.zlib.net/manual.html"
 ATSRC_PACKAGE_RELFIXES=
@@ -47,36 +47,8 @@ atsrc_get_patches ()
 {
 	# Patch to add optimized functions using vector instructions.
 	at_get_patch \
-		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/4450368b03523e86204bc83a3291493f1698c5b4/Zlib%20Patches/zlib-power-optimizations.patch' \
-	        e2ef4fa0f220b710fc6df40839bd1939 || return ${?}
-
-	## The following 4 patches come from zlib's develop branch and address
-	## issues in the 1.2.12 release, they can be removed once the next version
-	## is released
-
-	# Fix CC detection
-	# https://github.com/madler/zlib/issues/608
-	at_get_patch \
-		'https://github.com/madler/zlib/commit/05796d3d8d5546cf1b4dfe2cd72ab746afae505d.patch' \
-		c60d18e80205fc2725a86a1562324681 fix-cc.patch || return ${?}
-
-	# Ignore high bits of crc32 on input
-	# https://github.com/madler/zlib/issues/613
-	at_get_patch \
-		'https://github.com/madler/zlib/commit/ec3df00224d4b396e2ac6586ab5d25f673caa4c2.patch' \
-		fa21ee3ab9eaeadf7221dfccc14577c4 fix-crc32-input.patch || return ${?}
-
-	# Fix CVE-2022-37434
-	# https://nvd.nist.gov/vuln/detail/CVE-2022-37434
-	at_get_patch \
-		'https://github.com/madler/zlib/commit/eff308af425b67093bab25f80f1ae950166bece1.patch' \
-		feec8c9885b84d5669ffc988977bad9e CVE-2022-37434.patch || return ${?}
-
-	# Fix segfault caused by the last patch
-	# https://github.com/curl/curl/issues/9271
-	at_get_patch \
-		'https://github.com/madler/zlib/commit/1eb7682f845ac9e9bf9ae35bbfb3bad5dacbd91d.patch' \
-		2d9085374e6978a8e95a1c48bfac68c0 fix-segfault.patch || return ${?}
+		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/5b6e39c5196917f21d3fce5f3ee9753bcb44887e/Zlib%20Patches/zlib-power-optimizations.patch' \
+		eafd5f61a8b6d2cb92c2061d5e3f974e || return ${?}
 
 	return 0
 }
@@ -84,12 +56,4 @@ atsrc_get_patches ()
 atsrc_apply_patches ()
 {
 	patch -p1 < zlib-power-optimizations.patch || return ${?}
-
-	patch -p1 < fix-cc.patch || return ${?}
-
-	patch -p1 < fix-crc32-input.patch || return ${?}
-
-	patch -p1 < CVE-2022-37434.patch || return ${?}
-
-	patch -p1 < fix-segfault.patch || return ${?}
 }


### PR DESCRIPTION
Bump to revision 04f42ceca40f

Got the power optimizations patches rebased on zlib 1.2.13. 
Removed the patches that were merged into zlib master branch.

Signed-off-by: Erwan Prioul <erwan@linux.ibm.com>