### PR TITLE
Update FVTR

### DIFF
--- a/fvtr/ck_provides/ck_provides.exp
+++ b/fvtr/ck_provides/ck_provides.exp
@@ -176,31 +176,15 @@ proc check_debs {packages} {
 	# This is needed to make sure not to get runtime-compat package.
 	# The files .deb has runtime_at_version in the name but the installed
 	# packages has only runtime.
-	if { ![info exists ::env(AT_WD)] } {
-		set package [lindex ${packages} [lsearch ${packages} \
-				"*runtime"]]
-	} else {
-		set package [lindex ${packages} [lsearch ${packages} \
-				"*runtime_$::env(AT_MAJOR_VERSION)*"]]
+	set criteria ""
+	if { [info exists ::env(AT_WD)] } {
+		set criteria "_$::env(AT_MAJOR_VERSION)*"
 	}
-	set newrc [process_deb ${package} \
-			    "advance-toolchain-runtime"]
-	set rc [set_new_rc ${rc} ${newrc}]
-
-	set package [lindex ${packages} [lsearch ${packages} "*devel*"]]
-	set newrc [process_deb ${package} \
-			    "advance-toolchain-devel"]
-	set rc [set_new_rc ${rc} ${newrc}]
-
-	set package [lindex ${packages} [lsearch ${packages} "*perf*"]]
-	set newrc [process_deb ${package} \
-			    "advance-toolchain-perf"]
-	set rc [set_new_rc ${rc} ${newrc}]
-
-	set package [lindex ${packages} [lsearch ${packages} "*mcore-libs*"]]
-	set newrc [process_deb ${package} \
-			    "advance-toolchain-mcore-libs"]
-	set rc [set_new_rc ${rc} ${newrc}]
+	foreach p [list runtime devel perf mcore-libs] {
+		set package [lsearch -inline ${packages} "*${p}${criteria}"]
+		set newrc [process_deb ${package} "advance-toolchain-${p}"]
+		set rc [set_new_rc ${rc} ${newrc}]
+	}
 
 	return ${rc}
 }

--- a/fvtr/python/python.exp
+++ b/fvtr/python/python.exp
@@ -80,17 +80,14 @@ set common_exclude_tests "test_doctest test_doctest2 test_asyncio \
 			  test_buffer test_tarball test_venv test_pty \
 			  test_epoll test_signal"
 
-if { [lindex $pyverl 0] > 3
-     || ([lindex $pyverl 0] == 3 && [lindex $pyverl 1] >= 6) } {
-	# The following tests take almost 1 hour to execute:
-	# test_multiprocessing_fork test_multiprocessing_forkserver
-	# test_multiprocessing_spawn
-	append common_exclude_tests " test_multiprocessing_fork \
-				      test_multiprocessing_forkserver \
-				      test_multiprocessing_spawn"
-	# test_dtrace tries to pass invalid parameters to dtrace.
-	append common_exclude_tests " test_dtrace"
-}
+# The following tests take almost 1 hour to execute:
+# test_multiprocessing_fork test_multiprocessing_forkserver
+# test_multiprocessing_spawn
+append common_exclude_tests " test_multiprocessing_fork \
+			      test_multiprocessing_forkserver \
+			      test_multiprocessing_spawn"
+# test_dtrace tries to pass invalid parameters to dtrace.
+append common_exclude_tests " test_dtrace"
 
 if { [lindex $pyverl 0] < 3
      || ([lindex $pyverl 0] == 3 && [lindex $pyverl 1] <= 7) } {
@@ -98,32 +95,11 @@ if { [lindex $pyverl 0] < 3
 	append common_exclude_tests " test_tarfile"
 }
 
-if { [lindex $pyverl 0] < 3
-     || ([lindex $pyverl 0] == 3 && [lindex $pyverl 1] <= 6) } {
-	# Fails if run from the install dir.
-	append common_exclude_tests " test_distutils"
-}
-
-if { [lindex $pyverl 0] < 3
-     || ([lindex $pyverl 0] == 3 && [lindex $pyverl 1] <= 5) } {
-	# Fails on some systems depending on their timezone configuration.
-	append common_exclude_tests " test_strptime"
-}
-
 # The following sets up the python test command so that it excludes tests
 # which should not be run using FVTR.  The exclude test list is different
 # depending on the version of python being used, although some common tests
 # are defined above separately.
-if { "$pyver" == "2.6" } {
-	# Fails if run from the install dir: test_lib2to3.
-	# Unexpected skip: test_tcl.
-	set spawn_cmd "spawn $env(AT_DEST)/bin/python $test_script \
-		-x $common_exclude_tests test_lib2to3 test_tcl"
-} elseif { "$pyver" == "2.7" } {
-	# Might fail if run from the install dir:  test_idle test_tools.
-	set spawn_cmd "spawn $env(AT_DEST)/bin/python $test_script \
-		-x $common_exclude_tests test_idle test_tools"
-} elseif { [string match 3.* $pyver] } {
+if { [string match 3.* $pyver] } {
 	# Python unit tests are "embarrassingly parallel", at least up to 6 cores
 	# it seems
 	set CORES [expr min(6, [exec grep -c "processor" /proc/cpuinfo ])]
@@ -137,28 +113,29 @@ if { "$pyver" == "2.6" } {
 
 	# The following tests fail intermittently when running the FVTR,
 	# making them unreliable for this kind of tests.
+        append common_exclude_tests " test_asyncgen \
+                                      test_compileall \
+                                      test_eintr \
+                                      test_faulthandler \
+                                      test_ftplib \
+                                      test_gdb \
+                                      test_httpservers \
+                                      test_imaplib \
+                                      test_logging \
+                                      test_os \
+                                      test_poplib \
+                                      test_posix \
+                                      test_selectors \
+                                      test_site \
+                                      test_smtplib \
+                                      test_socket \
+                                      test_ssl \
+                                      test_subprocess \
+                                      test_threading \
+                                      test_time"
+
 	set spawn_cmd "spawn $env(AT_DEST)/bin/python3 $test_script \
-		-j$CORES -x $common_exclude_tests \
-		test_asyncgen \
-		test_compileall \
-		test_eintr \
-		test_faulthandler \
-		test_ftplib \
-		test_gdb \
-		test_httpservers \
-		test_imaplib \
-		test_logging \
-		test_os \
-		test_poplib \
-		test_posix \
-		test_selectors \
-		test_site \
-		test_smtplib \
-		test_socket \
-		test_ssl \
-		test_subprocess \
-		test_threading \
-		test_time"
+		-j$CORES -x $common_exclude_tests"
 } else {
 	set spawn_cmd "spawn $env(AT_DEST)/bin/python $test_script"
 }

--- a/fvtr/python/python.exp
+++ b/fvtr/python/python.exp
@@ -95,6 +95,12 @@ if { [lindex $pyverl 0] < 3
 	append common_exclude_tests " test_tarfile"
 }
 
+# Temporary workaround to allow builds of AT 13.0 in a container.
+if { $::env(AT_MAJOR_VERSION) <= 13.0 } {
+        append common_exclude_tests " test_c_locale_coercion \
+                                      test_re"
+}
+
 # The following sets up the python test command so that it excludes tests
 # which should not be run using FVTR.  The exclude test list is different
 # depending on the version of python being used, although some common tests


### PR DESCRIPTION
Removed tests for unsupported versions of python.
Improved tests for deb packages.
Added a temporary workaround to build AT 13.0 in a container.