### PR TITLE
Fix the `release` package for Suse

### DIFF
--- a/configs/13.0/specs/release.spec
+++ b/configs/13.0/specs/release.spec
@@ -13,10 +13,11 @@
 # limitations under the License.
 #
 
-# The product is called 'ibm-power-advance-toolchain' in SCC.
-%define         product ibm-power-advance-toolchain
+%define         product advance-toolchain-%{at_major}
+# The former product name
+%define         oldproduct ibm-power-advance-toolchain
 
-# Per convention the %%package name will be used a stem for the -release
+# Per convention the %package name will be used a stem for the -release
 # package.
 %define         package advance-toolchain-%{at_major}
 
@@ -51,6 +52,8 @@ Provides:       %name-%version
 # Product indicator provides (mandatory and important):
 Provides:       product() = %{product}
 Provides:       product(%{product}) = %{productversion}-%{productrelease}
+# Keeping track of previous product name
+Obsoletes:      product:%{oldproduct} = %{productversion}
 # Additional product data exposed in the -release package:
 Provides:       product-endoflife() = %{productendoflife_pcescaped}
 Provides:       product-url(bugtracker) = %{producturlbugtracker_pcescaped}
@@ -111,7 +114,7 @@ EOF
 %files
 %defattr(644,root,root,755)
 %dir /etc/products.d
-/etc/products.d/*
+/etc/products.d/%{product}.prod
 
 %changelog
 

--- a/fvtr/package-check/package-check.exp
+++ b/fvtr/package-check/package-check.exp
@@ -315,7 +315,7 @@ proc test_debuginfo_pkgs { file_list } {
 proc test_release_pkg {{file_list {}}} {
 	global ERROR
 
-	set product_name "ibm-power-advance-toolchain"
+	set product_name [append_at_internal "advance-toolchain-$::env(AT_NAME)$::env(AT_MAJOR_VERSION)"]
 	if { [llength $file_list] > 0 } {
 		if { [regexp -all -line ".*/${product_name}.prod\$" $file_list] == 1 } {
 			printit "SUCCESS."


### PR DESCRIPTION
Set the product name back to "advance-toolchain-at<VERSION>". 
Mark the product name "ibm-power-advance-toolchain" as obsolete so the SSC solver won't be lost.

Fix #3248 
Fix https://bugzilla.linux.ibm.com/show_bug.cgi?id=200754