### PR TITLE
Add delay when fetching sources

### DIFF
--- a/scripts/helpers/utilities.mk
+++ b/scripts/helpers/utilities.mk
@@ -614,8 +614,8 @@ define fetch_sources
                 retries=$${ATSRC_PACKAGE_RETRIES:-$(BUILD_DEFAULT_RETRIES)}; \
                 num_mirrors=$$(( $$(eval echo \$${#ATSRC_PACKAGE_CO[@]}) - 1 )); \
                 echo "Fetching $1 sources:"; \
-                while [[ $${retries} -ge 0 ]]; do \
-                    echo -en "- Retry cycle: $${retries}.\n"; \
+                for count in $$(seq 0 $${retries}); do \
+                    echo -en "- Retry cycle: $${count}.\n"; \
                     for index in $$(seq 0 $${num_mirrors}); do \
                         fetch=$$(eval echo \$${ATSRC_PACKAGE_CO[$${index}]}); \
                         echo -en "\t* Trying mirror: $${fetch}."; \
@@ -625,10 +625,12 @@ define fetch_sources
                         else \
                             echo " - [SUCCESS]"; \
                             fetch_success='true'; \
-                            retries=0 && break; \
+                            break 2; \
                         fi; \
                     done; \
-                    retries=$$(( retries - 1 )); \
+                    if [[ $${count} -lt $${retries} ]]; then \
+                        sleep $$(( 3 ** (count + 1) )); \
+                    fi; \
                 done; \
                 if [[ "$${fetch_success}" == "false" ]]; then \
                     echo "Couldn't get $1 from any of its mirrors!"; \


### PR DESCRIPTION
In the case many builds are launched at the same time (using a CI for example), upstream repositories could be overloaded by too many connections (from an unique IP address) when fetching sources. Fetch will fail and will be try again.

Added a delay before retrying to fetch source code, to allow upstream repository to calm down. The delay grows as the number of try.