### PR TITLE
Enable an option on glibc on AT 17.0

### DIFF
--- a/configs/17.0/packages/glibc/sources
+++ b/configs/17.0/packages/glibc/sources
@@ -39,3 +39,20 @@ ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=main_toolchain
 ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://sourceware.org/git/?p=glibc.git;a=blob_plain;f=version.h;hb=__REVISION__" | grep -w "VERSION" | sed "s/^.*\"\([0-9\.][0-9\.]*\)\".*$/\1/"'
 
+
+atsrc_get_patches ()
+{
+	# Backport the option to influence hwcaps used by PowerPC.
+	at_get_patch \
+		'https://sourceware.org/git/?p=glibc.git;a=patch;h=21841f0d562f0e944c4d267a28cc3ebd19c847e9' \
+		8c54a62656aa74be5cd84d66faf1d235 influence-cpu-hwcap-features.patch || return ${?}
+
+	return 0
+}
+
+atsrc_apply_patches ()
+{
+	patch -p1 \
+	     < influence-cpu-hwcap-features.patch \
+		|| return ${?}
+}


### PR DESCRIPTION
Backport a patch from the glibc main branch to the 2.38 branch. The patch enables the option to influence hwcaps used by PowerPC.