### PR TITLE
Add a workaround for SHA-1 issue on RHEL9

### DIFF
--- a/fvtr/ck_provides/ck_provides.exp
+++ b/fvtr/ck_provides/ck_provides.exp
@@ -34,7 +34,7 @@ if { $env(AT_CROSS_BUILD) == "yes" } {
 # expected - string expected in Provides.
 # rc - return code.
 proc process_rpm {package expected rc} {
-	if { [catch {eval exec rpm -q --provides ${package} \
+	if { [catch {eval exec rpm -q --provides ${package} 2>/dev/null \
 			 | grep -E "advance-toolchain" \
 			 | grep -v "$::env(AT_NAME)"} \
 		    res] } {

--- a/fvtr/ck_requires/ck_requires.exp
+++ b/fvtr/ck_requires/ck_requires.exp
@@ -40,11 +40,11 @@ proc process_rpm_packages { packages cross_bld at_dest ldd_path objdump_path } {
 
 		if { ![info exists env(AT_WD)] } {
 			printit "Processing package:  ${package}"
-			set files [exec rpm -ql $package]
+			set files [exec rpm -ql $package 2>/dev/null]
 		} else {
 			printit "Processing package:  ${package}"
 			set rpm_path $env(AT_WD)/rpms/$env(AT_HOST_ARCH)/
-			set files [exec rpm -qlp $rpm_path/$package]
+			set files [exec rpm -qlp $rpm_path/$package 2>/dev/null]
 		}
 
 		set requi $FULLPATH/$package.req.out
@@ -108,10 +108,10 @@ proc process_rpm_packages { packages cross_bld at_dest ldd_path objdump_path } {
 
 		# Compare with the installed rpm packages
 		if { ![info exists ::env(AT_WD)] } {
-			catch {exec rpm -qR $package | grep -E "^lib" | \
+			catch {exec rpm -qR $package 2>/dev/null | grep -E "^lib" | \
 				sort -u > $TMP_FILE}
 		} else {
-			catch {exec rpm -qRp $rpm_path/$package | \
+			catch {exec rpm -qRp $rpm_path/$package 2>/dev/null | \
 				grep -E "^lib" | sort -u > $TMP_FILE}
 		}
 		if {[catch {exec diff -wB $TMP_FILE $requi > $diff}]} {

--- a/fvtr/package-check/package-check.exp
+++ b/fvtr/package-check/package-check.exp
@@ -66,7 +66,7 @@ proc get_rpm_files { package_name } {
 
 	# Collect the RPM package file content
 	set rpm_path $::env(AT_WD)/rpms/$::env(AT_HOST_ARCH)
-	set error [catch {exec rpm -qpl ${rpm_path}/${package_name}} file_list]
+	set error [catch {exec rpm -qpl ${rpm_path}/${package_name} 2>/dev/null} file_list]
 
 	if { ${error} != 0 } {
 		printit "Problem found when looking for ${package_name} content..."

--- a/fvtr/shared.exp
+++ b/fvtr/shared.exp
@@ -512,7 +512,7 @@ ${pkg_name}."
 				# When there is an internal version then the package
 				# name string is sufficient to uniquely identify it
 				if { [catch {exec rpm -qa \
-					--qf "%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n" | \
+					--qf "%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n" 2>/dev/null | \
 					grep "${pkg_name}" | \
 					grep -- "-${at_ver_rev}\."} \
 				packages] } {
@@ -524,7 +524,7 @@ ${pkg_name}."
 				# package names that contain internal version strings like
 				# rc, alpha, beta when grepping.
 				if { [catch {exec rpm -qa \
-					--qf "%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n" | \
+					--qf "%{NAME}-%{VERSION}-%{RELEASE}.%{ARCH}\n" 2>/dev/null | \
 					grep "${pkg_name}" | \
 					grep -- "-${at_ver_rev}\." | \
 					grep -vE "(-rc|-alpha|-beta)"} \


### PR DESCRIPTION
The SHA-1 algorithm has deprecated for a while on RHEL9 [1]. The SHA-256 (or better) algorithm should be use to sign AT rpm packages.

Meanwhile a proper fix is provided, this patch ignores warning messages about the SHA-1 algorithm.

[1] https://www.redhat.com/en/blog/rhel-security-sha-1-package-signatures-distrusted-rhel-9