### PR TITLE
Fix python fvtr issue

### DIFF
--- a/fvtr/python/python.exp
+++ b/fvtr/python/python.exp
@@ -140,7 +140,7 @@ if { [string match 3.* $pyver] } {
 	set spawn_cmd "spawn $env(AT_DEST)/bin/python $test_script"
 }
 
-set env(TMPDIR) "$FULLPATH/tmp[pid]"
+set env(TMPDIR) "/tmp/python-tests-[pid]"
 exec mkdir $env(TMPDIR)
 printit "TMPDIR=\"$env(TMPDIR)\""
 global ERROR


### PR DESCRIPTION
Some python tests open an AF_UNIX socket. The AF_UNIX path is limited to 108 bytes[1].
In order to avoid error about a too long AF_UNIX path, the AT fvtr will be run in the /tmp directory.

[1] https://man7.org/linux/man-pages/man7/unix.7.html#BUGS