### PR TITLE
Match default processor support from distro

### DIFF
--- a/configs/16.0/distros/redhat-9.mk
+++ b/configs/16.0/distros/redhat-9.mk
@@ -51,6 +51,11 @@ AT_GPG_REPO_KEYIDL := 6976A827
 # Options required by the command to update the repository metadata
 AT_REPOCMD_OPTS := -p -s sha256 --simple-md-filenames --no-database
 
+# Override generic values from build.mk (RHEL 9 requires a power9)
+BUILD_LOAD_ARCH := power9
+BUILD_BASE_ARCH := power9
+BUILD_ACTIVE_MULTILIBS := power10
+
 # Moved here from build.mk since the value for this variable
 # depends on the distro.
 # For a cross build the executables in the toolchain (gcc, ld, etc.)

--- a/configs/16.0/distros/ubuntu-22.mk
+++ b/configs/16.0/distros/ubuntu-22.mk
@@ -50,6 +50,11 @@ AT_GPG_REPO_KEYIDC := 3052930D
 # Options required by the command to update the repository metadata
 AT_REPOCMD_OPTS := -p -s sha256 --simple-md-filenames --no-database
 
+# Override generic values from build.mk (Ubuntu 22.04 requires a power9)
+BUILD_LOAD_ARCH := power9
+BUILD_BASE_ARCH := power9
+BUILD_ACTIVE_MULTILIBS := power10
+
 # As some distros have special requirements for configuration upon final
 # AT installation, put in this macro, the final configurations required
 # after the main build and prior to the rpm build

--- a/configs/16.0/release_notes/relfixes.html
+++ b/configs/16.0/release_notes/relfixes.html
@@ -8,7 +8,8 @@
 <li>Power8 Crypto Operations enablement.</li>
 <li>Power8, Power9, and Power10 optimized system libraries.</li>
 <li>_Float128 enablement as specified by ISO/IEC TS 18661-3, for Power9 and Power10.</li>
-<li>GCC creates binaries using -mcpu=power8 -mtune=power10 by default.</li>
+<li>GCC creates binaries using -mcpu=power9 -mtune=power10 on RHEL 9 and Ubuntu 22.04.</li>
+<li>GCC creates binaries using -mcpu=power8 -mtune=power10 on SLES 15 and Debian 11.</li>
 </ul>
 
 <h3>New features in 16.0-3</h3>

--- a/configs/17.0/release_notes/relfixes.html
+++ b/configs/17.0/release_notes/relfixes.html
@@ -8,7 +8,8 @@
 <li>Power8 Crypto Operations enablement.</li>
 <li>Power8, Power9, and Power10 optimized system libraries.</li>
 <li>_Float128 enablement as specified by ISO/IEC TS 18661-3, for Power9 and Power10.</li>
-<li>GCC creates binaries using -mcpu=power8 -mtune=power10 by default.</li>
+<li>GCC creates binaries using -mcpu=power9 -mtune=power10 on RHEL 9 and Ubuntu 22.04.</li>
+<li>GCC creates binaries using -mcpu=power8 -mtune=power10 on SLES 15 and Debian 12.</li>
 </ul>
 
 <h3>New features in 17.0-1</h3>


### PR DESCRIPTION
Set default processor to match with some distros requirement (RHEL9, and Ubuntu 22.04).
For these distros, the default build will be done using -mcpu=power9 instead of power8.

Fix #3152
Fix #3153