### PR TITLE
Update python on AT

### DIFF
--- a/configs/14.0/packages/python/sources
+++ b/configs/14.0/packages/python/sources
@@ -63,8 +63,8 @@ atsrc_get_patches ()
 
 	# Disable zlib version check (test_zlib).
 	at_get_patch \
-		https://raw.githubusercontent.com/powertechpreview/powertechpreview/1fa3a5896a6ce15e8b85fcf24109db5c1ea5548a/Python%20Fixes/python-3.7-disable-zlib-version-check.patch \
-		f52555a37aec6cb7f43eb052990e051b || return ${?}
+		https://raw.githubusercontent.com/powertechpreview/powertechpreview/3539865c7bd2654724909f56407664e9937398e4/Python%20Fixes/python-3.7-disable-zlib-version-check.patch \
+		4042518c0f3d97f1850aec26ef8f7acd || return ${?}
 
 	return 0
 }

--- a/configs/15.0/packages/python/sources
+++ b/configs/15.0/packages/python/sources
@@ -52,8 +52,8 @@ atsrc_get_patches ()
 
 	# Disable zlib version check (test_zlib).
 	at_get_patch \
-		https://raw.githubusercontent.com/powertechpreview/powertechpreview/1fa3a5896a6ce15e8b85fcf24109db5c1ea5548a/Python%20Fixes/python-3.7-disable-zlib-version-check.patch \
-		f52555a37aec6cb7f43eb052990e051b || return ${?}
+		https://raw.githubusercontent.com/powertechpreview/powertechpreview/3539865c7bd2654724909f56407664e9937398e4/Python%20Fixes/python-3.7-disable-zlib-version-check.patch \
+		4042518c0f3d97f1850aec26ef8f7acd || return ${?}
 
 	return 0
 }

--- a/configs/16.0/packages/python/sources
+++ b/configs/16.0/packages/python/sources
@@ -50,18 +50,12 @@ atsrc_get_patches ()
 	        https://raw.githubusercontent.com/powertechpreview/powertechpreview/b9f88b42e734110e69873ea810272facc85b97c0/Python%20Fixes/python-3.9-timeout-test_subprocess.patch \
 	        92cfc34136fafb9420655b4bd3ef39d1 || return ${?}
 
-	# Disable zlib version check (test_zlib).
-	at_get_patch \
-		https://raw.githubusercontent.com/powertechpreview/powertechpreview/1fa3a5896a6ce15e8b85fcf24109db5c1ea5548a/Python%20Fixes/python-3.7-disable-zlib-version-check.patch \
-		f52555a37aec6cb7f43eb052990e051b || return ${?}
-
 	return 0
 }
 
 atsrc_apply_patches ()
 {
 	patch -p1 < python-3.9-timeout-test_subprocess.patch || return ${?}
-	patch -p1 < python-3.7-disable-zlib-version-check.patch || return ${?}
 }
 
 atsrc_package_verify_make_log ()

--- a/configs/17.0/packages/python/sources
+++ b/configs/17.0/packages/python/sources
@@ -20,8 +20,8 @@
 #
 
 ATSRC_PACKAGE_NAME="Python"
-ATSRC_PACKAGE_VER=3.11.6
-ATSRC_PACKAGE_REV=720f5bf1ac24
+ATSRC_PACKAGE_VER=3.11.7
+ATSRC_PACKAGE_REV=23234e92236d
 ATSRC_PACKAGE_BRANCH=3.11
 ATSRC_PACKAGE_LICENSE="Python Software Foundation License 2"
 ATSRC_PACKAGE_DOCLINK="https://docs.python.org/${ATSRC_PACKAGE_VER%\.*}/"
@@ -50,11 +50,6 @@ atsrc_get_patches ()
 	        https://raw.githubusercontent.com/powertechpreview/powertechpreview/b9f88b42e734110e69873ea810272facc85b97c0/Python%20Fixes/python-3.9-timeout-test_subprocess.patch \
 	        92cfc34136fafb9420655b4bd3ef39d1 || return ${?}
 
-	# Disable zlib version check (test_zlib).
-	at_get_patch \
-		https://raw.githubusercontent.com/powertechpreview/powertechpreview/1fa3a5896a6ce15e8b85fcf24109db5c1ea5548a/Python%20Fixes/python-3.7-disable-zlib-version-check.patch \
-		f52555a37aec6cb7f43eb052990e051b || return ${?}
-
 	# Allow cross compiling based on cpu flavor.
 	at_get_patch \
 		https://raw.githubusercontent.com/powertechpreview/powertechpreview/97ddb34a7499fc6b7de03ceeabe1cba3a937eb0c/Python%20Fixes/python-3.11-cpuflavor.patch \
@@ -66,7 +61,6 @@ atsrc_get_patches ()
 atsrc_apply_patches ()
 {
 	patch -p1 < python-3.9-timeout-test_subprocess.patch || return ${?}
-	patch -p1 < python-3.7-disable-zlib-version-check.patch || return ${?}
 	patch -p1 < python-3.11-cpuflavor.patch || return ${?}
 }
 

--- a/configs/next/packages/python/sources
+++ b/configs/next/packages/python/sources
@@ -20,8 +20,8 @@
 #
 
 ATSRC_PACKAGE_NAME="Python"
-ATSRC_PACKAGE_VER=3.12.0
-ATSRC_PACKAGE_REV=acc62db8af4e
+ATSRC_PACKAGE_VER=3.12.1
+ATSRC_PACKAGE_REV=259a4af3d269
 ATSRC_PACKAGE_BRANCH=3.12
 ATSRC_PACKAGE_LICENSE="Python Software Foundation License 2"
 ATSRC_PACKAGE_DOCLINK="https://docs.python.org/${ATSRC_PACKAGE_VER%\.*}/"
@@ -52,8 +52,8 @@ atsrc_get_patches ()
 
 	# Disable zlib version check (test_zlib).
 	at_get_patch \
-		https://raw.githubusercontent.com/powertechpreview/powertechpreview/1fa3a5896a6ce15e8b85fcf24109db5c1ea5548a/Python%20Fixes/python-3.7-disable-zlib-version-check.patch \
-		f52555a37aec6cb7f43eb052990e051b || return ${?}
+		https://raw.githubusercontent.com/powertechpreview/powertechpreview/3539865c7bd2654724909f56407664e9937398e4/Python%20Fixes/python-3.12-disable-zlib-version-check.patch \
+		e151af8f433e0fb81a16f7384b49490b || return ${?}
 
 	# Allow cross compiling based on cpu flavor.
 	at_get_patch \
@@ -66,7 +66,7 @@ atsrc_get_patches ()
 atsrc_apply_patches ()
 {
 	patch -p1 < python-3.9-timeout-test_subprocess.patch || return ${?}
-	patch -p1 < python-3.7-disable-zlib-version-check.patch || return ${?}
+	patch -p1 < python-3.12-disable-zlib-version-check.patch || return ${?}
 	patch -p1 < python-3.12-cpuflavor.patch || return ${?}
 }
 


### PR DESCRIPTION
On AT < 16.0 and AT next, update the patch about `zlib` version check.
On AT 16.0 and AT 17.0, remove the patch about `zlib` version check.