### PR TITLE
Add a patch to disable ldconfig aux-cache file

### DIFF
--- a/configs/16.0/packages/glibc/sources
+++ b/configs/16.0/packages/glibc/sources
@@ -39,3 +39,24 @@ ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=main_toolchain
 ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://sourceware.org/git/?p=glibc.git;a=blob_plain;f=version.h;hb=__REVISION__" | grep -w "VERSION" | sed "s/^.*\"\([0-9\.][0-9\.]*\)\".*$/\1/"'
 
+
+atsrc_get_patches ()
+{
+	if [[ "$DISTRO_ID" == "redhat-9" ]]; then
+		# Disabling ldconfig aux-cache file.
+		at_get_patch \
+			'https://raw.githubusercontent.com/powertechpreview/powertechpreview/2d147b2b9c38c0cb105eb3c5aee02d1b403ab607/GLIBC%20PowerPC%20Backport/2.36/glibc-disabling-aux-cache.patch' \
+			0d753c5c637ed48fba506813007183ac || return ${?}
+	fi
+
+	return 0
+}
+
+atsrc_apply_patches ()
+{
+	if [[ "$DISTRO_ID" == "redhat-9" ]]; then
+		patch -p1 \
+		     < glibc-disabling-aux-cache.patch \
+			|| return ${?}
+	fi
+}

--- a/configs/17.0/packages/glibc/sources
+++ b/configs/17.0/packages/glibc/sources
@@ -45,7 +45,13 @@ atsrc_get_patches ()
 	# Backport the option to influence hwcaps used by PowerPC.
 	at_get_patch \
 		'https://sourceware.org/git/?p=glibc.git;a=patch;h=21841f0d562f0e944c4d267a28cc3ebd19c847e9' \
-		8c54a62656aa74be5cd84d66faf1d235 influence-cpu-hwcap-features.patch || return ${?}
+		c8e2c8d1563499ab6a362d0693e88919 influence-cpu-hwcap-features.patch || return ${?}
+	if [[ "$DISTRO_ID" == "redhat-9" ]]; then
+		# Disabling ldconfig aux-cache file.
+		at_get_patch \
+			'https://raw.githubusercontent.com/powertechpreview/powertechpreview/2d147b2b9c38c0cb105eb3c5aee02d1b403ab607/GLIBC%20PowerPC%20Backport/2.36/glibc-disabling-aux-cache.patch' \
+			0d753c5c637ed48fba506813007183ac || return ${?}
+	fi
 
 	return 0
 }
@@ -55,4 +61,9 @@ atsrc_apply_patches ()
 	patch -p1 \
 	     < influence-cpu-hwcap-features.patch \
 		|| return ${?}
+	if [[ "$DISTRO_ID" == "redhat-9" ]]; then
+		patch -p1 \
+		     < glibc-disabling-aux-cache.patch \
+			|| return ${?}
+	fi
 }

--- a/configs/next/packages/glibc/sources
+++ b/configs/next/packages/glibc/sources
@@ -38,3 +38,24 @@ ATSRC_PACKAGE_DISTRIB=yes
 ATSRC_PACKAGE_BUNDLE=main_toolchain
 ATSRC_PACKAGE_UPSTREAM='wget -qO - "https://sourceware.org/git/?p=glibc.git;a=blob_plain;f=version.h;hb=__REVISION__" | grep -w "VERSION" | sed "s/^.*\"\([0-9\.][0-9\.]*\)\".*$/\1/"'
 
+
+atsrc_get_patches ()
+{
+	if [[ "$DISTRO_ID" == "redhat-9" ]]; then
+		# Disabling ldconfig aux-cache file.
+		at_get_patch \
+			'https://raw.githubusercontent.com/powertechpreview/powertechpreview/2d147b2b9c38c0cb105eb3c5aee02d1b403ab607/GLIBC%20PowerPC%20Backport/2.36/glibc-disabling-aux-cache.patch' \
+			0d753c5c637ed48fba506813007183ac || return ${?}
+	fi
+
+	return 0
+}
+
+atsrc_apply_patches ()
+{
+	if [[ "$DISTRO_ID" == "redhat-9" ]]; then
+		patch -p1 \
+		     < glibc-disabling-aux-cache.patch \
+			|| return ${?}
+	fi
+}


### PR DESCRIPTION
Disable the use of ldconfig aux-cache file on RHEL9. This will avoid ISA level error.

Fix #3844
Fix #3845