### PR TITLE
Update glibc on AT 17.0

### DIFF
--- a/configs/17.0/packages/gcc/sources
+++ b/configs/17.0/packages/gcc/sources
@@ -61,6 +61,12 @@ atsrc_get_patches ()
 		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/master/GCC%20libstdc%2B%2B%20PowerPC%20Patches/9/0001-libstdc-Prevent-LD_LIBRARY_PATH-from-leaking-to-msgf.patch' \
 		9cba9a9b94ca9c1b8958c0d722a9c06b || return ${?}
 
+	if [[ "$(uname -m)" == *"ppc64"* ]]; then
+		at_get_patch \
+			'https://raw.githubusercontent.com/powertechpreview/powertechpreview/master/GCC%20PowerPC%20Backport/14/skip-glibc-fix-on-fixincludes.patch' \
+			54ba637650b7386746cd4968cfec9864 || return ${?}
+	fi
+
 	return 0
 }
 
@@ -73,4 +79,10 @@ atsrc_apply_patches ()
 	patch -p1 \
 	      < 0001-libstdc-Prevent-LD_LIBRARY_PATH-from-leaking-to-msgf.patch \
 		|| return ${?}
+
+	if [[ "$(uname -m)" == *"ppc64"* ]]; then
+		patch -p1 \
+		      < skip-glibc-fix-on-fixincludes.patch \
+			|| return ${?}
+fi
 }

--- a/configs/17.0/packages/glibc/sources
+++ b/configs/17.0/packages/glibc/sources
@@ -21,7 +21,7 @@
 
 ATSRC_PACKAGE_NAME="GNU C Library"
 ATSRC_PACKAGE_VER=2.38
-ATSRC_PACKAGE_REV=5a6276d97aa6
+ATSRC_PACKAGE_REV=a921ae4701f3
 ATSRC_PACKAGE_BRANCH=release/2.38/master
 ATSRC_PACKAGE_LICENSE="LGPL 2.1"
 ATSRC_PACKAGE_DOCLINK="http://www.gnu.org/software/libc/manual/html_node/index.html"
@@ -45,7 +45,7 @@ atsrc_get_patches ()
 	# Backport the option to influence hwcaps used by PowerPC.
 	at_get_patch \
 		'https://sourceware.org/git/?p=glibc.git;a=patch;h=21841f0d562f0e944c4d267a28cc3ebd19c847e9' \
-		 e0080d7d2acce3bba761376658f6a064 influence-cpu-hwcap-features.patch || return ${?}
+		 3e7da6d6026bf6e23184622f852524a1 influence-cpu-hwcap-features.patch || return ${?}
 	if [[ "$DISTRO_ID" == "redhat-9" ]]; then
 		# Disabling ldconfig aux-cache file.
 		at_get_patch \


### PR DESCRIPTION
Bump to revision a921ae4701f3
Add an external patch to skip glibc/pthread fix in GCC fixincludes.

Close #4456 