### PR TITLE
Fix related with fixincludes in AT <= 16.0

### DIFF
--- a/configs/15.0/packages/gcc/sources
+++ b/configs/15.0/packages/gcc/sources
@@ -74,6 +74,12 @@ atsrc_get_patches ()
 		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/master/GCC%20PowerPC%20Backport/11/0001-powerpc-Remove-forced-runpath-from-with-advance-tool.patch' \
 		2a4d7864672f6227f33687a834e7dca4 || return ${?}
 
+	if [[ "$(uname -m)" == *"ppc64"* ]]; then
+		at_get_patch \
+			'https://raw.githubusercontent.com/powertechpreview/powertechpreview/master/GCC%20PowerPC%20Backport/14/skip-glibc-fix-on-fixincludes.patch' \
+			54ba637650b7386746cd4968cfec9864 || return ${?}
+	fi
+
 	return 0
 }
 
@@ -94,4 +100,10 @@ atsrc_apply_patches ()
 	patch -p1 \
 	      < 0001-powerpc-Remove-forced-runpath-from-with-advance-tool.patch \
 		|| return ${?}
+
+	if [[ "$(uname -m)" == *"ppc64"* ]]; then
+		patch -p1 \
+		      < skip-glibc-fix-on-fixincludes.patch \
+			|| return ${?}
+	fi
 }

--- a/configs/16.0/packages/gcc/sources
+++ b/configs/16.0/packages/gcc/sources
@@ -70,6 +70,12 @@ atsrc_get_patches ()
 		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/master/GCC%20PowerPC%20Backport/11/Revert-Default-to-DWARF5.patch' \
 		0cc724faa8c2db5e686d70900b323365 || return ${?}
 
+	if [[ "$(uname -m)" == *"ppc64"* ]]; then
+		at_get_patch \
+			'https://raw.githubusercontent.com/powertechpreview/powertechpreview/master/GCC%20PowerPC%20Backport/14/skip-glibc-fix-on-fixincludes.patch' \
+			54ba637650b7386746cd4968cfec9864 || return ${?}
+	fi
+
 	return 0
 }
 
@@ -86,4 +92,10 @@ atsrc_apply_patches ()
 	patch -p1 \
 	      < Revert-Default-to-DWARF5.patch \
 		|| return ${?}
+
+	if [[ "$(uname -m)" == *"ppc64"* ]]; then
+		patch -p1 \
+		      < skip-glibc-fix-on-fixincludes.patch \
+			|| return ${?}
+	fi
 }


### PR DESCRIPTION
Add an external patch to skip glibc/pthread fix in GCC fixincludes.