### PR TITLE
Update python test in FVTR

### DIFF
--- a/fvtr/python/python.exp
+++ b/fvtr/python/python.exp
@@ -131,6 +131,7 @@ if { [string match 3.* $pyver] } {
                                       test_socket \
                                       test_ssl \
                                       test_subprocess \
+                                      test_sundry \
                                       test_tempfile \
                                       test_threading \
                                       test_time"


### PR DESCRIPTION
Removed test_sundry from python tests. It imports a deprecated library.

Closes #4492 
Closes #4499 
Closes #4500 