### PR TITLE
Prepare for AT 18.0-1 RC1

### DIFF
--- a/configs/18.0/base.mk
+++ b/configs/18.0/base.mk
@@ -48,8 +48,8 @@
 #
 AT_NAME := at
 AT_MAJOR_VERSION := 18.0
-AT_REVISION_NUMBER := 0
-AT_INTERNAL := none
+AT_REVISION_NUMBER := 1
+AT_INTERNAL := rc1
 AT_PREVIOUS_VERSION := 17.0
 
 # Minimum kernel version distributed on supported distros by this AT version,


### PR DESCRIPTION
Update AT18.0 configuration for RC1 release.

- Bump AT_REVISION_NUMBER from 0 to 1
- Set AT_INTERNAL to rc1